### PR TITLE
Fix release consistency test: add Codex skills vs agents note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ GPD currently installs into four AI runtimes. To preselect one during install, u
 Each runtime uses its own command prefix, but the workflow is the same across all four. After installing GPD, open your chosen runtime normally from your system terminal and use the commands shown above.
 
 Notes:
-- Codex: GPD writes `.codex/config.toml` during install, enables `features.multi_agent = true`, configures the required notify hook and built-in MCP servers, registers GPD agent roles in `[agents.*]`, and installs local skills into repo-scoped `.agents/skills/` for local installs.
+- Codex-specific note: GPD writes `.codex/config.toml` during install, enables `features.multi_agent = true`, configures the required notify hook and built-in MCP servers, registers GPD agent roles in `[agents.*]`, and exposes only public `gpd-*` agents there as discoverable skills in `.agents/skills/`; the full agent catalog still installs under `.codex/agents/` for direct invocation.
 - Gemini: GPD writes `.gemini/settings.json` during install, enables `experimental.enableAgents`, and configures the required hooks and built-in MCP servers as part of a complete Gemini setup.
 
 ## What GPD Does


### PR DESCRIPTION
## Summary
- Adds documentation distinguishing Codex public discoverable skills (`~/.agents/skills/`) from the full agent catalog (`~/.codex/agents/`)
- Fixes `test_codex_runtime_docs_distinguish_public_skills_from_full_agent_install`

## Test plan
- [x] `tests/test_release_consistency.py` — 31 passed
- [x] `tests/core/test_repo_interdependency_graph.py` — 15 passed