### PR TITLE
Fix Windows install crash: bad escape \U in Gemini adapter

### DIFF
--- a/src/gpd/adapters/gemini.py
+++ b/src/gpd/adapters/gemini.py
@@ -202,7 +202,7 @@ def _gemini_policy_command_prefixes(bridge_command: str) -> tuple[str, ...]:
 
 def _rewrite_gpd_cli_invocations(content: str, bridge_command: str) -> str:
     """Rewrite bare ``gpd`` CLI calls to the shared runtime CLI bridge."""
-    return _GPD_CLI_INVOCATION_RE.sub(bridge_command, content)
+    return _GPD_CLI_INVOCATION_RE.sub(lambda m: bridge_command, content)
 
 
 def _inject_gemini_command_runtime_note(content: str, bridge_command: str) -> str:
@@ -396,7 +396,7 @@ def _render_gemini_policy_toml(bridge_command: str) -> str:
     """Render the Gemini policy file GPD installs for headless auto-edit flows."""
     rendered_prefixes: list[str] = []
     for prefix in _gemini_policy_command_prefixes(bridge_command):
-        rendered_prefixes.append("'" + prefix.replace("'", "''") + "'")
+        rendered_prefixes.append(json.dumps(prefix))
     prefixes = ",\n  ".join(rendered_prefixes)
     return (
         "# Managed by Get Physics Done (GPD).\n"

--- a/src/gpd/adapters/opencode.py
+++ b/src/gpd/adapters/opencode.py
@@ -142,7 +142,7 @@ def convert_claude_to_opencode_frontmatter(content: str, path_prefix: str | None
     converted = content
     converted = convert_tool_references_in_body(converted, _TOOL_REFERENCE_MAP)
     converted = converted.replace("/gpd:", "/gpd-")
-    converted = re.sub(r"~/\.claude\b", resolved_config_dir, converted)
+    converted = re.sub(r"~/\.claude\b", lambda m: resolved_config_dir, converted)
 
     preamble, frontmatter, separator, body = split_markdown_frontmatter(converted)
     if not frontmatter:

--- a/tests/adapters/test_gemini.py
+++ b/tests/adapters/test_gemini.py
@@ -15,6 +15,8 @@ from gpd.adapters.gemini import (
     _convert_frontmatter_to_gemini,
     _convert_gemini_tool_name,
     _convert_to_gemini_toml,
+    _render_gemini_policy_toml,
+    _rewrite_gpd_cli_invocations,
 )
 from gpd.adapters.install_utils import build_runtime_cli_bridge_command
 
@@ -571,7 +573,7 @@ class TestInstall:
         assert 'modes = ["autoEdit"]' in policy
         assert "allow_redirection = true" in policy
         assert expected_gemini_bridge(target) in policy
-        assert "'git init'" in policy
+        assert '"git init"' in policy
 
     def test_install_preserves_existing_policy_paths_and_mcp_trust_choice(
         self,
@@ -1019,3 +1021,36 @@ class TestUninstall:
         target.mkdir()
         result = adapter.uninstall(target)
         assert result["removed"] == []
+
+
+class TestRewriteWindowsPathEscape:
+    """Regression: Windows paths with backslashes must not be interpreted as
+    escape sequences by ``re.sub``.  See discussion #12."""
+
+    @pytest.mark.parametrize(
+        "bridge_command",
+        [
+            r"'C:\Users\OuterSpaceOrg\.gpd\venv\Scripts\python.exe' -m gpd.runtime_cli",
+            r"'C:\Users\me\.gpd\venv\Scripts\python.exe' -m gpd.runtime_cli",
+        ],
+    )
+    def test_rewrite_gpd_cli_invocations_windows_path(self, bridge_command: str) -> None:
+        content = "Run `gpd status` to check progress."
+        result = _rewrite_gpd_cli_invocations(content, bridge_command)
+        assert bridge_command in result
+        assert "gpd status" not in result
+
+
+class TestPolicyTomlWindowsPath:
+    """Regression: policy TOML must be valid even when bridge_command contains
+    Windows backslash paths.  See discussion #12."""
+
+    def test_render_policy_toml_with_windows_path(self) -> None:
+        import tomllib
+
+        bridge = r"'C:\Users\OuterSpaceOrg\.gpd\venv\Scripts\python.exe' -m gpd.runtime_cli --runtime gemini"
+        toml_text = _render_gemini_policy_toml(bridge)
+        parsed = tomllib.loads(toml_text)
+        prefixes = parsed["rule"][0]["commandPrefix"]
+        assert any("python" in p for p in prefixes)
+        assert any("git init" in p for p in prefixes)


### PR DESCRIPTION
## Summary

- **Root cause:** `re.sub(bridge_command, content)` in `_rewrite_gpd_cli_invocations` interprets backslashes in the replacement string as backreference escapes. On Windows, `bridge_command` contains paths like `C:\Users\...` where `\U` is treated as an invalid escape sequence.
- **Fix:** Use `lambda m: bridge_command` as the replacement, which bypasses `re.sub()`'s backreference processing. Also hardened the same pattern in the OpenCode adapter.
- Adds regression tests with Windows-style paths.

Closes #12

## Test plan
- [x] 2 new parametrized regression tests with `C:\Users\...` paths
- [x] All 65 Gemini adapter tests pass
- [x] All 51 OpenCode adapter tests pass
- [x] Full suite: 2887+ tests pass (2 pre-existing failures unrelated to this change)
