### PR TITLE
feat: add runtime configuration guide and compatibility guidance

### DIFF
--- a/src/gpd/specs/references/tooling/runtime-config-guide.md
+++ b/src/gpd/specs/references/tooling/runtime-config-guide.md
@@ -1,0 +1,99 @@
+# Runtime Configuration Guide
+
+Guidance for configuring host runtime environments when running GPD. This reference covers recommended settings, extension compatibility, portable configuration patterns, and common environment pitfalls across all supported runtimes.
+
+## Recommended Minimal Configuration
+
+After installation (`npx get-physics-done`), GPD writes managed entries into the host runtime's configuration directory. These managed entries include:
+
+- **Status line or notification hooks** -- GPD status display in the runtime UI
+- **Update check hooks** -- check for GPD updates on session start
+- **MCP servers** -- GPD MCP servers for state and paper tooling (where supported)
+
+GPD does not touch entries it did not create. Existing user hooks, MCP servers, and settings are preserved.
+
+## Permission Mode Alignment
+
+GPD's `runtime_permissions` integration (via `gpd permissions sync`) aligns the runtime's tool-permission mode with GPD's autonomy setting:
+
+| GPD Autonomy | Recommended Runtime Mode | Effect |
+|-------------|-------------------------|--------|
+| `supervised` | Default (prompts for each tool) | Maximum human oversight |
+| `balanced` | Default or plan mode | Normal workflow, prompts for destructive actions |
+| `yolo` | Most permissive available | `gpd permissions sync` applies runtime-native setting |
+
+When `autonomy=yolo`, `gpd permissions sync` writes the appropriate permissive-mode configuration for the active runtime. This takes effect on the next session launch where a restart is required, or immediately where the runtime supports hot reload.
+
+## Extension and Skill Compatibility
+
+GPD installs its commands and agents into the runtime's command/agent directories. Other extensions and skills can coexist as long as they do not:
+
+1. **Override GPD command names** -- GPD uses the `gpd:` prefix (or runtime-equivalent). Any other extension using the same prefix will conflict.
+2. **Modify GPD-managed hooks** -- Status line and update hooks are GPD-managed. Other hooks with different names are fine.
+3. **Remove the `get-physics-done/` directory** -- GPD stores all installed content under the runtime's config directory in `get-physics-done/`. Do not remove this directory while a project is active.
+
+### Known-Safe Combinations
+
+- Built-in runtime tools (file read/write, shell, search, etc.) -- fully compatible
+- User-defined custom slash commands -- compatible if they do not use the `gpd:` prefix
+- Third-party MCP servers -- compatible; GPD's MCP servers use `gpd-state` and `gpd-paper` names
+- Multiple project configuration files -- compatible; GPD does not modify project-level config files it did not create
+
+### Potentially Problematic Combinations
+
+- Extensions that modify runtime settings files without preserving existing entries -- may remove GPD hooks
+- Extensions that clear the command directory -- will remove GPD commands
+- Custom agents named `gpd-*` -- will conflict with GPD agent names
+
+## Portable Configuration Patterns
+
+### Avoid Machine-Specific Paths
+
+GPD generates paths relative to the runtime config directory during install. If you manually reference paths in project configuration:
+
+- Use `~/` prefix instead of `/Users/username/` or `/home/username/`
+- Use `$HOME` in shell hook commands
+- Avoid hardcoding Python interpreter paths; use `python3` or the managed venv at `~/.gpd/venv/bin/python`
+
+### Multi-Machine Setup
+
+When syncing a GPD project across machines (via git, cloud storage, etc.):
+
+1. The `.gpd/` project directory is portable -- it uses relative paths internally
+2. Runtime-specific configuration is machine-local -- re-run `npx get-physics-done` on each machine
+3. The managed venv at `~/.gpd/venv/` is machine-local -- the installer recreates it automatically
+4. MCP server config is machine-local -- re-install regenerates it
+
+### Low-Resource Environments
+
+- GPD requires Python 3.11+ and Node.js for installation
+- The managed venv uses approximately 200MB of disk for dependencies
+- The host runtime requires network access to its provider's API
+- If disk space is limited, use `npx get-physics-done --skip-mcp` to skip MCP server installation (paper tools will be unavailable but core workflow commands work)
+- On ARM devices, ensure the Python interpreter matches the architecture
+
+## Troubleshooting
+
+### GPD Commands Not Appearing
+
+1. Verify the install completed: check for `get-physics-done/` in the runtime config directory
+2. Check the manifest: `cat <config-dir>/gpd-file-manifest.json`
+3. Re-install if needed: `npx get-physics-done`
+
+### Permission Prompts Interrupting Workflow
+
+1. Check current mode: `gpd permissions status`
+2. For fully unattended execution: `gpd config set autonomy yolo` then `gpd permissions sync`
+3. For plan-mode (approve plans, auto-execute): check your runtime's `--permission-mode` or equivalent launch flag
+
+### Hooks Not Running
+
+1. Check the runtime settings file for GPD-managed hook entries
+2. Verify hook scripts exist in the `get-physics-done/hooks/` subdirectory
+3. Re-install to regenerate: `npx get-physics-done`
+
+### MCP Servers Not Connecting
+
+1. Check the runtime's MCP configuration file
+2. Verify the managed Python has dependencies: `~/.gpd/venv/bin/python -c "import gpd"`
+3. Re-install to regenerate MCP config: `npx get-physics-done`

--- a/src/gpd/specs/workflows/settings.md
+++ b/src/gpd/specs/workflows/settings.md
@@ -273,6 +273,15 @@ Quick commands:
 
 </step>
 
+<step name="runtime_guidance">
+Refer to `{GPD_INSTALL_DIR}/references/tooling/runtime-config-guide.md` for:
+- recommended minimal runtime configuration
+- extension and skill compatibility guidance
+- portable configuration patterns for multi-machine setups
+- permission mode alignment with GPD autonomy settings
+- troubleshooting common environment issues
+</step>
+
 </process>
 
 <downstream_consumption>

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The final section of this README keeps the full checked-in repository interdepen
 ## Repository Interdependency Graph
 
 <!-- repo-graph-generated-on:start -->
-Generated on `2026-03-18` from the current worktree.
+Generated on `2026-03-23` from the current worktree.
 <!-- repo-graph-generated-on:end -->
 
 ## Status
@@ -26,13 +26,13 @@ This graph therefore includes:
 
 <!-- repo-graph-scope:start -->
 
-- Live repo files analyzed in the current tree: `641`
+- Live repo files analyzed in the current tree: `642`
 - Python files under `src/` and `tests/`: `206`
 - `src/gpd/commands/*.md`: `61`
 - `src/gpd/agents/*.md`: `23`
 - `src/gpd/specs/workflows/*.md`: `62`
 - `src/gpd/specs/templates/**/*.md`: `71`
-- `src/gpd/specs/references/**/*.md`: `156`
+- `src/gpd/specs/references/**/*.md`: `157`
 - `src/gpd/adapters/*.py`: `9`
 - `src/gpd/hooks/*.py`: `6`
 - `src/gpd/mcp/servers/*.py`: `8`

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_on": "2026-03-18",
+  "generated_on": "2026-03-23",
   "excluded_graph_dirs": [
     ".git",
     ".mcp.json",
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scope_counts": {
-    "Live repo files analyzed in the current tree": 641,
+    "Live repo files analyzed in the current tree": 642,
     "Python files under `src/` and `tests/`": 206,
     "`src/gpd/commands/*.md`": 61,
     "`src/gpd/agents/*.md`": 23,
     "`src/gpd/specs/workflows/*.md`": 62,
     "`src/gpd/specs/templates/**/*.md`": 71,
-    "`src/gpd/specs/references/**/*.md`": 156,
+    "`src/gpd/specs/references/**/*.md`": 157,
     "`src/gpd/adapters/*.py`": 9,
     "`src/gpd/hooks/*.py`": 6,
     "`src/gpd/mcp/servers/*.py`": 8,


### PR DESCRIPTION
## Problem

Users are unsure how to configure their runtime environment for GPD, whether extensions/skills can coexist, how to make configuration portable across machines, and how to align runtime permission modes with GPD autonomy settings.

## Solution

Add a runtime-agnostic configuration guide at `src/gpd/specs/references/tooling/runtime-config-guide.md` covering:
- Recommended minimal configuration
- Permission mode alignment with GPD autonomy settings (supervised/balanced/yolo)
- Extension and skill compatibility (known-safe and potentially problematic combinations)
- Portable configuration patterns (avoiding machine-specific paths)
- Multi-machine setup guidance (what is portable vs machine-local)
- Low-resource environment considerations
- Troubleshooting for common issues (commands not appearing, permission prompts, hooks, MCP)

Wire the guide into the settings workflow so users are directed to it after configuring their project.

## What happens for each runtime

The guide is runtime-agnostic and applies to all supported runtimes. Runtime-specific details (permission mode names, config file paths) are referenced generically — the adapters and `gpd permissions sync` handle the runtime-specific translation.

## Test plan

- [x] 76 prompt wiring + repo graph tests pass
- [x] Runtime name hardcoding test passes (guide uses runtime-neutral language)
- [x] Repo graph contract updated

## Changes

| File | Change |
|------|--------|
| `src/gpd/specs/references/tooling/runtime-config-guide.md` | New reference doc |
| `src/gpd/specs/workflows/settings.md` | Added runtime guidance step |
| `tests/repo_graph_contract.json` | Updated counts |
| `tests/README.md` | Updated scope block |