### PR TITLE
feat: surface key project artifacts with structured review summaries

### DIFF
--- a/src/gpd/specs/references/orchestration/artifact-surfacing.md
+++ b/src/gpd/specs/references/orchestration/artifact-surfacing.md
@@ -1,0 +1,173 @@
+---
+load_when:
+  - "artifact surfacing"
+  - "review artifacts"
+  - "artifact summary"
+  - "wave completion"
+  - "phase deliverables"
+tier: 2
+context_cost: low
+---
+
+# Artifact Surfacing and Review UX
+
+How artifacts are classified, surfaced at wave boundaries, and presented for review. This document covers artifact visibility during execution, not manifest generation (for build-time manifests, see `src/gpd/mcp/paper/artifact_manifest.py`).
+
+**Related files:**
+- `references/orchestration/checkpoints.md` -- checkpoint interaction points
+- `workflows/execute-phase.md` -- wave-based execution with artifact_summary step
+- `workflows/verify-phase.md` -- phase verification against contract targets
+
+---
+
+## 1. Artifact Classes
+
+Every artifact produced during a research project falls into one of the following classes. The class determines its review priority and surfacing behavior.
+
+| Class | Description | Typical extensions | Example paths |
+|---|---|---|---|
+| **planning-doc** | Phase plans, roadmaps, requirements | `.md` | `.gpd/phases/01-*/01-01-PLAN.md` |
+| **literature-review** | Survey notes, citation databases, reading summaries | `.md`, `.bib` | `notes/literature-survey.md` |
+| **experiment-config** | Simulation parameters, grid definitions, model setups | `.json`, `.yaml`, `.py` | `simulations/config.json` |
+| **result-table** | Numerical outputs, data frames, benchmark comparisons | `.csv`, `.json`, `.md` | `data/eigenvalues.csv` |
+| **generated-figure** | Plots, diagrams, phase diagrams, convergence curves | `.pdf`, `.png`, `.eps`, `.svg` | `figures/dispersion.pdf` |
+| **draft-section** | Manuscript sections, appendix drafts | `.tex`, `.md` | `paper/sections/results.tex` |
+| **final-latex** | Complete compiled manuscript source | `.tex`, `.bib`, `.bst` | `paper/main.tex` |
+| **final-pdf** | Compiled PDF output | `.pdf` | `paper/output/main.pdf` |
+| **peer-review-output** | Review panel reports, referee responses | `.md`, `.json` | `.gpd/paper/REVIEW-REPORT.md` |
+
+---
+
+## 2. Review Priority Levels
+
+Each artifact is assigned a review priority that determines how prominently it appears in wave completion summaries and whether it blocks downstream work.
+
+### Required Review
+
+Artifacts that must be inspected before downstream waves proceed. These represent load-bearing results where errors propagate.
+
+- Key derivations that downstream calculations depend on
+- Numerical results that serve as inputs to later phases
+- Convention-setting documents (notation, unit systems)
+- Contract deliverables tagged as acceptance tests
+
+### Optional Review
+
+Artifacts worth inspecting but that do not block progress. Errors here are contained and correctable later.
+
+- Supporting plots and figures
+- Intermediate calculation notebooks
+- Literature survey notes
+- Auxiliary data files
+
+### Final Deliverable
+
+Artifacts that represent completed research outputs. These are surfaced at phase completion, not at wave boundaries.
+
+- Final manuscript LaTeX source and compiled PDF
+- Peer review panel reports
+- Experiment configuration archives
+- Publication-ready figures with captions
+
+---
+
+## 3. Surfacing at Phase and Wave Completion
+
+### Wave Completion Summary
+
+After each wave completes (see `execute_waves` in `workflows/execute-phase.md`), the orchestrator emits an `artifact_summary` block listing key artifacts produced. The summary follows this format:
+
+```
+## Artifacts: Wave {N}
+
+| Path | Class | Review |
+|------|-------|--------|
+| derivations/dispersion.py | result-table | required |
+| figures/dispersion_plot.pdf | generated-figure | optional |
+| notes/01-02-SUMMARY.md | planning-doc | optional |
+
+Required review: 1 artifact(s) -- inspect before Wave {N+1}
+```
+
+**Rules for the artifact summary:**
+
+1. List only artifacts created or modified in the completed wave (from SUMMARY.md `key-files.created` and `key-files.modified`)
+2. Assign the artifact class from the table in section 1 based on file extension and path
+3. Mark review priority using the rules in section 2
+4. Show paths relative to the project root
+5. Keep the summary compact -- one row per artifact, no inline content
+
+### Phase Completion Summary
+
+At phase completion (after all waves and verification), emit a full artifact inventory:
+
+```
+## Phase {X} Artifact Inventory
+
+### Required Review (inspect before next phase)
+- derivations/hamiltonian.py -- result-table
+- data/eigenvalues.csv -- result-table
+
+### Final Deliverables
+- paper/sections/methods.tex -- draft-section
+- figures/phase_diagram.pdf -- generated-figure
+
+### Optional Review
+- notes/01-01-SUMMARY.md -- planning-doc
+- notes/literature-notes.md -- literature-review
+```
+
+---
+
+## 4. Recommended Review Order
+
+When multiple artifacts require review, present them in this order to maximize review efficiency:
+
+1. **Convention-setting artifacts** -- notation definitions, unit system locks, coordinate conventions. These affect interpretation of everything else.
+2. **Load-bearing derivations** -- analytical results that downstream calculations consume. Errors here have the highest propagation cost.
+3. **Numerical results and benchmarks** -- computed values, convergence data, comparison tables. Check these against known limits and dimensional expectations.
+4. **Generated figures** -- visual outputs that summarize results. Review after the underlying data is confirmed.
+5. **Draft manuscript sections** -- prose and LaTeX. Review last since they depend on all prior artifacts being correct.
+6. **Peer review outputs** -- panel reports and referee responses. These are terminal artifacts with no downstream dependents.
+
+This order follows the dependency chain: upstream artifacts first, downstream artifacts after their inputs are validated.
+
+---
+
+## 5. Integration with Progress and Checkpoint Commands
+
+### Progress Command
+
+The `/gpd:progress` command includes artifact counts in its phase status output:
+
+```
+Phase 2: Numerical Simulation -- 3/4 plans complete
+  Artifacts: 12 total (3 required-review, 2 final-deliverable, 7 optional)
+  Pending review: derivations/self_energy.py, data/convergence.csv, figures/spectral.pdf
+```
+
+When artifacts marked as required-review remain uninspected, the progress display flags them so the researcher can prioritize review before proceeding.
+
+### Checkpoint Integration
+
+Checkpoints of type `checkpoint:human-verify` should reference the specific artifacts being verified:
+
+```xml
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-derived>Self-energy in GW approximation</what-derived>
+  <artifacts>
+    derivations/self_energy.py (required review)
+    figures/spectral_function.pdf (optional review)
+  </artifacts>
+  <how-to-verify>
+    1. Im[Sigma] = 0 at Fermi surface
+    2. Spectral weight Z between 0 and 1
+  </how-to-verify>
+</task>
+```
+
+This ties the verification request to concrete file paths, making it actionable.
+
+### Artifact Manifest Linkage
+
+For paper-writing phases, the artifact summary at wave completion feeds into the ARTIFACT-MANIFEST.json generated by the paper build pipeline. The manifest records SHA-256 hashes, provenance chains, and category labels for each artifact. The wave-level summaries provide the upstream traceability that the manifest formalizes.

--- a/src/gpd/specs/workflows/execute-phase.md
+++ b/src/gpd/specs/workflows/execute-phase.md
@@ -564,9 +564,32 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    - Bad: "Wave 2 complete. Proceeding to Wave 3."
    - Good: "Spin-chain spectrum computed -- Bethe ansatz solution yields N-magnon energies with correct Heisenberg limit. Finite-size scaling exponents match CFT prediction (nu = 1.00 +/- 0.02). Transport coefficient calculation (Wave 3) can now use these eigenstates."
 
-7. **Handle failures** -- see `wave_failure_handling` below.
+7. **Artifact summary** -- surface key artifacts produced in the completed wave.
 
-8. **Execute checkpoint plans between waves** -- see `<checkpoint_handling>`.
+   After verifying wave completion, collect the artifacts from each plan's SUMMARY.md (`key-files.created`, `key-files.modified`) and emit a compact summary with review priorities. See `references/orchestration/artifact-surfacing.md` for artifact class definitions and review priority rules.
+
+   ```
+   ## Artifacts: Wave {N}
+
+   | Path | Class | Review |
+   |------|-------|--------|
+   | {relative_path} | {artifact_class} | {required | optional | final-deliverable} |
+   ...
+
+   Required review: {count} artifact(s) -- inspect before Wave {N+1}
+   ```
+
+   **Classification rules:**
+   - Assign artifact class from file extension and path (see artifact-surfacing.md section 1)
+   - Mark as `required` if the artifact is a load-bearing derivation, numerical result consumed by later waves, or contract deliverable tagged as an acceptance test
+   - Mark as `final-deliverable` for completed manuscript outputs, compiled PDFs, and peer review reports
+   - Mark as `optional` for supporting plots, intermediate notebooks, and literature notes
+
+   **If any artifacts are marked `required`:** Include their paths in the wave completion report so the researcher can prioritize review. Do not block execution for optional artifacts.
+
+8. **Handle failures** -- see `wave_failure_handling` below.
+
+9. **Execute checkpoint plans between waves** -- see `<checkpoint_handling>`.
 
    Before unlocking downstream dependent waves, confirm that risky-wave plans passed the first meaningful review point:
 
@@ -593,7 +616,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    For `pre_fanout`, the matching gate-clear and `fanout unlock` are separate transitions: the clear records the review outcome, the unlock releases downstream work. Keep the segment live on status, notify, and resume surfaces until both have been observed. Do not silently continue on "looks fine" prose alone.
 
-9. **Inter-wave verification gate (if more waves remain):**
+10. **Inter-wave verification gate (if more waves remain):**
 
    Before spawning the next wave, run lightweight verification on the just-completed wave's outputs. This catches errors cheaply before they propagate to downstream waves.
 
@@ -724,11 +747,11 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    Present options and wait for user response (or auto-continue in YOLO mode if both are warnings, not errors — unless `YOLO_RESTRICTIONS` includes `no_skip_inter_wave`, in which case always present).
 
-   **If disabled:** Skip verification gate, proceed directly to step 10. Exception: if `YOLO_RESTRICTIONS` includes `no_skip_inter_wave`, the gate runs even when disabled by config.
+   **If disabled:** Skip verification gate, proceed directly to step 11. Exception: if `YOLO_RESTRICTIONS` includes `no_skip_inter_wave`, the gate runs even when disabled by config.
 
    **Cost:** ~2-5k tokens per inter-wave gate. For a 4-wave phase with deep-theory profile, this is ~10-15k tokens overhead — negligible compared to the cost of a sign error propagating through 3 subsequent waves.
 
-10. **Inter-wave transition display:**
+11. **Inter-wave transition display:**
 
    Before spawning the next wave, display a physics-meaningful progress update that connects what was just computed to what comes next:
 
@@ -744,7 +767,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    Extract the "Completed" summary from the wave N completion report (step 6 above). Extract "Enables" and "Starting" from the wave N+1 plan objectives. Keep each line to one sentence.
 
-11. **Proceed to next wave.**
+12. **Proceed to next wave.**
    </step>
 
 <step name="wave_failure_handling">

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The final section of this README keeps the full checked-in repository interdepen
 ## Repository Interdependency Graph
 
 <!-- repo-graph-generated-on:start -->
-Generated on `2026-03-18` from the current worktree.
+Generated on `2026-03-23` from the current worktree.
 <!-- repo-graph-generated-on:end -->
 
 ## Status
@@ -26,13 +26,13 @@ This graph therefore includes:
 
 <!-- repo-graph-scope:start -->
 
-- Live repo files analyzed in the current tree: `641`
+- Live repo files analyzed in the current tree: `642`
 - Python files under `src/` and `tests/`: `206`
 - `src/gpd/commands/*.md`: `61`
 - `src/gpd/agents/*.md`: `23`
 - `src/gpd/specs/workflows/*.md`: `62`
 - `src/gpd/specs/templates/**/*.md`: `71`
-- `src/gpd/specs/references/**/*.md`: `156`
+- `src/gpd/specs/references/**/*.md`: `157`
 - `src/gpd/adapters/*.py`: `9`
 - `src/gpd/hooks/*.py`: `6`
 - `src/gpd/mcp/servers/*.py`: `8`

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_on": "2026-03-18",
+  "generated_on": "2026-03-23",
   "excluded_graph_dirs": [
     ".git",
     ".mcp.json",
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scope_counts": {
-    "Live repo files analyzed in the current tree": 641,
+    "Live repo files analyzed in the current tree": 642,
     "Python files under `src/` and `tests/`": 206,
     "`src/gpd/commands/*.md`": 61,
     "`src/gpd/agents/*.md`": 23,
     "`src/gpd/specs/workflows/*.md`": 62,
     "`src/gpd/specs/templates/**/*.md`": 71,
-    "`src/gpd/specs/references/**/*.md`": 156,
+    "`src/gpd/specs/references/**/*.md`": 157,
     "`src/gpd/adapters/*.py`": 9,
     "`src/gpd/hooks/*.py`": 6,
     "`src/gpd/mcp/servers/*.py`": 8,


### PR DESCRIPTION
Adds artifact-surfacing.md and wires artifact summaries into the execute-phase workflow.

## Summary
- Add `src/gpd/specs/references/orchestration/artifact-surfacing.md` covering artifact classes, review priority levels, surfacing format, recommended review order, and integration with progress/checkpoint commands
- Update `src/gpd/specs/workflows/execute-phase.md` with artifact_summary step after wave completion
- Update repo graph contract to reflect the new reference file

## Test plan
- [x] prompt wiring + repo graph tests pass
- [x] No runtime name violations