### PR TITLE
feat(review): add peer review reliability guidance and stage recovery

### DIFF
--- a/src/gpd/specs/references/publication/peer-review-reliability.md
+++ b/src/gpd/specs/references/publication/peer-review-reliability.md
@@ -1,0 +1,143 @@
+---
+load_when:
+  - "peer review"
+  - "review reliability"
+  - "review recovery"
+  - "stage failure"
+  - "review phase entry"
+tier: 2
+context_cost: low
+---
+
+# Peer Review Phase Reliability
+
+Guidance for reliable execution of the staged peer-review pipeline, covering when the phase triggers, how stages recover from failure, how to distinguish internal from external review, and how review findings feed back into manuscript revisions.
+
+## When Peer Review Triggers
+
+The peer review phase activates **after a complete manuscript draft exists** and **before final PDF packaging and submission**. Specifically:
+
+1. **After draft completion.** The `/gpd:write-paper` workflow produces a manuscript with all sections, equations, figures, and bibliography in place. Peer review does not run on incomplete drafts or outlines.
+2. **Before final PDF.** Peer review must complete and its findings must be addressed before the manuscript is packaged for submission (e.g., via `/gpd:arxiv-submission`).
+3. **Explicit invocation.** Peer review runs when the user invokes `/gpd:peer-review` or when the write-paper workflow reaches its internal review gate. It is not triggered automatically by file saves or partial edits.
+
+### Precondition Checklist
+
+- Manuscript main file exists under `paper/`, `manuscript/`, or `draft/`
+- `.gpd/STATE.md` and `.gpd/ROADMAP.md` are present
+- Phase summaries and verification reports are available under `.gpd/phases/`
+- `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and reproducibility manifest are present (strict mode)
+
+If any precondition fails, the review preflight blocks entry and reports the missing items.
+
+## Internal Review vs. External Review
+
+The staged peer-review panel is an **automated internal review**. It is not a substitute for external peer review by human referees at a journal.
+
+| Dimension | Internal (automated panel) | External (journal referees) |
+|-----------|---------------------------|----------------------------|
+| Trigger | Author invokes before submission | Editor assigns after submission |
+| Agents | Six staged subagents with fresh context | Human domain experts |
+| Scope | Claim extraction, math, physics, literature, significance, adjudication | Full scientific judgment including community context |
+| Authority | Advisory; author decides how to respond | Binding; editor decides publication |
+| Artifacts | `.gpd/review/` JSON stage reports, referee report | Journal referee reports |
+| Rounds | Up to 3 automated rounds | Journal-determined |
+
+Use internal review to catch overclaiming, missing evidence, mathematical errors, and weak physical interpretation **before** submitting to external review. Internal review findings should be treated as a quality gate, not as a publication decision.
+
+## Entry and Exit Criteria
+
+### Entry Criteria
+
+All of the following must hold before the review phase begins:
+
+1. **Manuscript completeness.** All sections referenced in the paper structure are drafted. No placeholder or stub sections remain.
+2. **Artifact readiness.** `ARTIFACT-MANIFEST.json` and `BIBLIOGRAPHY-AUDIT.json` exist and pass validation.
+3. **Verification coverage.** At least one verification report exists under `.gpd/phases/`.
+4. **Preflight pass.** `gpd validate review-preflight peer-review --strict` exits zero.
+
+### Exit Criteria
+
+The review phase is complete when:
+
+1. **All six stages have run.** Stage artifacts exist for reader, literature, math, physics, interestingness, and the final referee decision.
+2. **Referee decision is valid.** `REFEREE-DECISION.json` passes schema validation.
+3. **Review ledger is valid.** `REVIEW-LEDGER.json` passes schema validation.
+4. **Findings are dispositioned.** Every blocking finding has either been addressed in a revision or explicitly acknowledged in an author response.
+
+If the recommendation is `accept` or `minor_revision` with no unresolved blockers, the manuscript may proceed to submission packaging. If the recommendation is `major_revision` or `reject`, the manuscript must return to revision before re-entering peer review.
+
+## Stage Failure Modes and Recovery
+
+Each of the six review stages can fail. The pipeline is **fail-closed**: a failed stage blocks all downstream stages that depend on it.
+
+### Common Failure Modes
+
+| Failure mode | Affected stages | Symptom | Recovery |
+|-------------|----------------|---------|----------|
+| Subagent spawn failure | Any | Stage artifact not written | Retry the stage once; if it fails again, stop and report |
+| Malformed stage output | Any | JSON does not match `StageReviewReport` schema | Validate output, retry stage with explicit schema reminder |
+| Missing upstream artifact | Stages 2-6 | Stage cannot read required input | Re-run the failed upstream stage first |
+| Manuscript file not found | Stage 1 | Reader cannot locate `.tex` files | Verify manuscript path before retrying |
+| Timeout or resource limit | Any | Stage does not complete | Retry once; if persistent, reduce manuscript scope or run stages sequentially |
+| Claim index missing | Stages 2-6 | `CLAIMS.json` absent after Stage 1 | Re-run Stage 1 before proceeding |
+
+### Recovery Protocol
+
+1. **Detect.** After each stage completes, validate that the expected output artifact exists and conforms to the `StageReviewReport` JSON schema.
+2. **Retry.** Each stage is allowed at most **one retry**. On retry, pass the same inputs and explicit schema guidance.
+3. **Escalate.** If a stage fails after one retry, halt the pipeline and report the failure with the stage name, failure mode, and any partial output.
+4. **No silent skipping.** Never skip a failed stage and continue to the next. The staged design depends on each stage producing a valid handoff artifact.
+
+### Stage Output Validation
+
+After each stage writes its artifact, confirm:
+
+- The file exists at the expected path
+- The file parses as valid JSON
+- Required top-level keys are present: `version`, `round`, `stage_id`, `stage_kind`, `summary`, `findings`, `confidence`, `recommendation_ceiling`
+- The `stage_id` matches the expected stage
+- `findings` is an array (may be empty)
+- Each finding has `issue_id`, `severity`, `summary`, and `blocking` fields
+
+If validation fails, treat it as a stage failure and apply the retry protocol above.
+
+## How Review Findings Feed Into Revisions
+
+### Artifact Outputs
+
+The review pipeline produces these actionable artifacts:
+
+1. **Review summary** (`.gpd/REFEREE-REPORT.md` / `.gpd/REFEREE-REPORT.tex`): Human-readable narrative of the panel findings, recommendation, and rationale.
+2. **Review ledger** (`.gpd/review/REVIEW-LEDGER.json`): Machine-readable list of all issues with severity, blocking status, affected claims, and required actions.
+3. **Referee decision** (`.gpd/review/REFEREE-DECISION.json`): Final recommendation, confidence, blocking issue IDs, and stage artifact references.
+
+### Severity and Prioritization
+
+Findings are classified by severity:
+
+| Severity | Meaning | Blocks acceptance | Typical action |
+|----------|---------|-------------------|----------------|
+| `critical` | Fundamental flaw in claims, math, or physics | Yes | Must fix before any resubmission |
+| `major` | Significant gap in evidence, literature, or interpretation | Yes | Must fix or honestly scope down claims |
+| `minor` | Local clarification, missing citation, wording issue | No | Should fix but does not block |
+| `suggestion` | Optional improvement for clarity or presentation | No | Author discretion |
+
+### Revision Workflow
+
+1. **Read the review ledger.** Sort findings by severity (critical first, then major, then minor).
+2. **Address blocking issues.** Every finding with `"blocking": true` must be resolved or the claims must be narrowed to match the available evidence.
+3. **Write author response.** Document how each finding was addressed in `.gpd/AUTHOR-RESPONSE.md` (or `-R2.md` / `-R3.md` for subsequent rounds).
+4. **Re-enter review.** After revisions, re-run `/gpd:peer-review` for the next round. The pipeline detects prior reports and author responses to increment the round number automatically.
+5. **Converge.** The pipeline supports up to 3 review rounds. If the manuscript has not converged to `accept` or `minor_revision` after 3 rounds, consider restructuring the central contribution.
+
+### Mapping Findings to Manuscript Changes
+
+Each finding in the review ledger includes:
+
+- `claim_ids`: Which claims are affected
+- `manuscript_locations`: Where in the manuscript the issue appears
+- `required_action`: What must change
+- `evidence_refs`: Supporting evidence for the finding
+
+Use these fields to make targeted, traceable revisions rather than broad rewrites. The author response should reference the `issue_id` for each finding and state whether it was fixed, partially addressed, or disputed with justification.

--- a/src/gpd/specs/workflows/peer-review.md
+++ b/src/gpd/specs/workflows/peer-review.md
@@ -201,6 +201,19 @@ Return STAGE 1 COMPLETE with assessment, blocker count, and major concern count.
 If Stage 1 fails, STOP. Later stages depend on its claim map.
 </step>
 
+<step name="stage_recovery_1">
+**Stage 1 recovery -- Validate the reader output before proceeding.**
+
+Check that both `.gpd/review/CLAIMS{round_suffix}.json` and `.gpd/review/STAGE-reader{round_suffix}.json` exist, parse as valid JSON, and contain the required top-level keys (`version`, `round`, `stage_id`, `stage_kind`, `summary`, `findings`, `confidence`, `recommendation_ceiling` for the stage report; `claims` for the claim index).
+
+If validation fails:
+
+1. **Retry once.** Re-run the Stage 1 subagent with the same inputs and an explicit reminder to match the `StageReviewReport` and `ClaimIndex` JSON schemas from `peer-review-panel.md`.
+2. **If the retry also fails,** STOP the pipeline and report the failure: stage name, missing or malformed fields, and any partial output. Do not proceed to Stages 2-6.
+
+Max retries per stage: **1**.
+</step>
+
 <step name="stage_2_and_3">
 **Stages 2 and 3 — Run literature and mathematics in parallel when possible.**
 
@@ -281,6 +294,19 @@ If the runtime supports parallel subagent execution, run Stage 2 and Stage 3 in 
 If either stage fails, STOP and report the failure.
 </step>
 
+<step name="stage_recovery_2_3">
+**Stages 2-3 recovery -- Validate literature and math outputs before proceeding.**
+
+For each of `.gpd/review/STAGE-literature{round_suffix}.json` and `.gpd/review/STAGE-math{round_suffix}.json`, check that the file exists, parses as valid JSON, and contains the required top-level keys: `version`, `round`, `stage_id`, `stage_kind`, `summary`, `findings`, `confidence`, `recommendation_ceiling`.
+
+If validation fails for either stage:
+
+1. **Retry once.** Re-run only the failed stage subagent with the same inputs and an explicit reminder to match the `StageReviewReport` JSON schema from `peer-review-panel.md`.
+2. **If the retry also fails,** STOP the pipeline and report the failure: stage name, missing or malformed fields, and any partial output. Do not proceed to Stage 4.
+
+Max retries per stage: **1**.
+</step>
+
 <step name="stage_4_physics">
 **Stage 4 — Check physical soundness after the mathematical pass.**
 
@@ -334,6 +360,19 @@ Return STAGE 4 COMPLETE with assessment, blocker count, and major concern count.
 If Stage 4 fails, STOP and report the failure.
 </step>
 
+<step name="stage_recovery_4">
+**Stage 4 recovery -- Validate the physics output before proceeding.**
+
+Check that `.gpd/review/STAGE-physics{round_suffix}.json` exists, parses as valid JSON, and contains the required top-level keys: `version`, `round`, `stage_id`, `stage_kind`, `summary`, `findings`, `confidence`, `recommendation_ceiling`.
+
+If validation fails:
+
+1. **Retry once.** Re-run the Stage 4 subagent with the same inputs and an explicit reminder to match the `StageReviewReport` JSON schema from `peer-review-panel.md`.
+2. **If the retry also fails,** STOP the pipeline and report the failure: stage name, missing or malformed fields, and any partial output. Do not proceed to Stage 5.
+
+Max retries per stage: **1**.
+</step>
+
 <step name="stage_5_significance">
 **Stage 5 — Judge interestingness and venue fit after the technical stages.**
 
@@ -376,6 +415,19 @@ Return STAGE 5 COMPLETE with assessment, blocker count, and major concern count.
 ```
 
 If Stage 5 fails, STOP and report the failure.
+</step>
+
+<step name="stage_recovery_5">
+**Stage 5 recovery -- Validate the significance output before proceeding.**
+
+Check that `.gpd/review/STAGE-interestingness{round_suffix}.json` exists, parses as valid JSON, and contains the required top-level keys: `version`, `round`, `stage_id`, `stage_kind`, `summary`, `findings`, `confidence`, `recommendation_ceiling`.
+
+If validation fails:
+
+1. **Retry once.** Re-run the Stage 5 subagent with the same inputs and an explicit reminder to match the `StageReviewReport` JSON schema from `peer-review-panel.md`.
+2. **If the retry also fails,** STOP the pipeline and report the failure: stage name, missing or malformed fields, and any partial output. Do not proceed to Stage 6 adjudication.
+
+Max retries per stage: **1**.
 </step>
 
 <step name="final_adjudication">
@@ -447,6 +499,26 @@ Return REVIEW COMPLETE with recommendation, confidence, issue counts, and whethe
 If the referee agent fails to spawn or returns an error, STOP and report the failure. Do not silently skip final adjudication.
 </step>
 
+<step name="stage_recovery_6">
+**Stage 6 recovery -- Validate the adjudication outputs before proceeding.**
+
+Check that both `.gpd/review/REVIEW-LEDGER{round_suffix}.json` and `.gpd/review/REFEREE-DECISION{round_suffix}.json` exist, parse as valid JSON, and contain the required top-level keys (`version`, `round`, `manuscript_path`, `issues` for the ledger; `manuscript_path`, `target_journal`, `final_recommendation`, `final_confidence`, `stage_artifacts`, `blocking_issue_ids` for the decision).
+
+Run the built-in validators:
+
+```bash
+gpd validate review-ledger .gpd/review/REVIEW-LEDGER{round_suffix}.json
+gpd validate referee-decision .gpd/review/REFEREE-DECISION{round_suffix}.json --strict --ledger .gpd/review/REVIEW-LEDGER{round_suffix}.json
+```
+
+If validation fails:
+
+1. **Retry once.** Re-run the Stage 6 referee subagent with the same inputs and an explicit reminder to match the `review-ledger-schema.md` and `referee-decision-schema.md` schemas.
+2. **If the retry also fails,** STOP the pipeline and report the failure: stage name, validation errors, and any partial output. Do not proceed to report summarization.
+
+Max retries per stage: **1**.
+</step>
+
 <step name="optional_pdf_compile">
 **Optional PDF compile of the LaTeX referee report:**
 
@@ -511,11 +583,16 @@ If this was a revision round, state the round number and whether the referee con
 - [ ] Supporting artifacts loaded when present
 - [ ] Claim index written
 - [ ] Stage 1 reader artifact written
+- [ ] Stage 1 output validated (JSON schema check passed or retry succeeded)
 - [ ] Stage 2 literature-context artifact written
 - [ ] Stage 3 mathematical-soundness artifact written
+- [ ] Stages 2-3 outputs validated (JSON schema check passed or retry succeeded)
 - [ ] Stage 4 physical-soundness artifact written
+- [ ] Stage 4 output validated (JSON schema check passed or retry succeeded)
 - [ ] Stage 5 interestingness artifact written
+- [ ] Stage 5 output validated (JSON schema check passed or retry succeeded)
 - [ ] Review ledger and referee decision JSON written
+- [ ] Stage 6 outputs validated (ledger and decision schema checks passed or retry succeeded)
 - [ ] Final adjudicating gpd-referee executed successfully
 - [ ] Latest referee report located and summarized
 - [ ] Outcome routed to the correct next action

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The final section of this README keeps the full checked-in repository interdepen
 ## Repository Interdependency Graph
 
 <!-- repo-graph-generated-on:start -->
-Generated on `2026-03-18` from the current worktree.
+Generated on `2026-03-23` from the current worktree.
 <!-- repo-graph-generated-on:end -->
 
 ## Status
@@ -26,13 +26,13 @@ This graph therefore includes:
 
 <!-- repo-graph-scope:start -->
 
-- Live repo files analyzed in the current tree: `641`
+- Live repo files analyzed in the current tree: `642`
 - Python files under `src/` and `tests/`: `206`
 - `src/gpd/commands/*.md`: `61`
 - `src/gpd/agents/*.md`: `23`
 - `src/gpd/specs/workflows/*.md`: `62`
 - `src/gpd/specs/templates/**/*.md`: `71`
-- `src/gpd/specs/references/**/*.md`: `156`
+- `src/gpd/specs/references/**/*.md`: `157`
 - `src/gpd/adapters/*.py`: `9`
 - `src/gpd/hooks/*.py`: `6`
 - `src/gpd/mcp/servers/*.py`: `8`

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_on": "2026-03-18",
+  "generated_on": "2026-03-23",
   "excluded_graph_dirs": [
     ".git",
     ".mcp.json",
@@ -18,13 +18,13 @@
     "dist"
   ],
   "scope_counts": {
-    "Live repo files analyzed in the current tree": 641,
+    "Live repo files analyzed in the current tree": 642,
     "Python files under `src/` and `tests/`": 206,
     "`src/gpd/commands/*.md`": 61,
     "`src/gpd/agents/*.md`": 23,
     "`src/gpd/specs/workflows/*.md`": 62,
     "`src/gpd/specs/templates/**/*.md`": 71,
-    "`src/gpd/specs/references/**/*.md`": 156,
+    "`src/gpd/specs/references/**/*.md`": 157,
     "`src/gpd/adapters/*.py`": 9,
     "`src/gpd/hooks/*.py`": 6,
     "`src/gpd/mcp/servers/*.py`": 8,


### PR DESCRIPTION
## Summary

- Add new reference doc `src/gpd/specs/references/publication/peer-review-reliability.md` covering stage failure modes, recovery protocol, entry/exit criteria, internal vs external review distinction, and how review findings feed into revisions
- Update `src/gpd/specs/workflows/peer-review.md` with `stage_recovery` steps after each of the 6 review stages, each validating JSON schema conformance of stage output with max 1 retry
- Update repo graph contract to reflect the new reference file

## Test plan

- [x] `test_repo_interdependency_graph.py` -- 76 tests pass (scope counts match, graph contract valid)
- [x] `test_prompt_wiring.py` -- all tests pass including `test_non_adapter_sources_do_not_hardcode_runtime_names`
- [x] No forbidden runtime names (claude/gemini/codex/opencode) in new files
- [ ] Manual review: verify stage_recovery steps are correctly positioned after each stage

🤖 Generated with [Claude Code](https://claude.com/claude-code)