### PR TITLE
Update GitHub Actions for Node 24 and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,24 +37,24 @@ jobs:
           fi
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install development dependencies
         run: |
@@ -109,7 +109,7 @@ jobs:
           uv run --with twine python -m twine check dist/*
 
       - name: Upload Python distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-dists
           path: dist/*
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Download Python distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: python-dists
           path: dist
@@ -148,14 +148,14 @@ jobs:
 
     steps:
       - name: Check out release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.build-release.outputs.release_sha }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -164,7 +164,7 @@ jobs:
           python scripts/release_workflow.py stamp-publish-date --repo . --release-date "${{ needs.build-release.outputs.release_date }}" > /tmp/publish-date.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,24 @@ jobs:
           fi
 
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install development dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -32,7 +32,7 @@ jobs:
         run: python scripts/sync_repo_graph_contract.py
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --dev
@@ -46,15 +46,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Install dependencies
         run: uv sync --dev

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ The final section of this README keeps the full checked-in repository interdepen
 ## Repository Interdependency Graph
 
 <!-- repo-graph-generated-on:start -->
-Generated on `2026-03-25` from the current worktree.
+Generated on `2026-03-26` from the current worktree.
 <!-- repo-graph-generated-on:end -->
 
 ## Status
@@ -26,7 +26,7 @@ This graph therefore includes:
 
 <!-- repo-graph-scope:start -->
 
-- Live repo files analyzed in the current tree: `680`
+- Live repo files analyzed in the current tree: `681`
 - Python files under `src/` and `tests/`: `241`
 - `src/gpd/commands/*.md`: `61`
 - `src/gpd/agents/*.md`: `23`
@@ -216,13 +216,13 @@ flowchart TD
   `authority`
   Locked dependency resolution surface for CI.
 
-- `.github/workflows/test.yml -> actions/checkout@v4`
+- `.github/workflows/test.yml -> actions/checkout@v5`
   `external-service`
 
-- `.github/workflows/test.yml -> actions/setup-python@v5`
+- `.github/workflows/test.yml -> actions/setup-python@v6`
   `external-service`
 
-- `.github/workflows/test.yml -> astral-sh/setup-uv@v4`
+- `.github/workflows/test.yml -> astral-sh/setup-uv@v7`
   `external-service`
 
 - `.github/pull_request_template.md -> src/**`

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_on": "2026-03-25",
+  "generated_on": "2026-03-26",
   "excluded_graph_dirs": [
     ".git",
     ".mcp.json",
@@ -18,7 +18,7 @@
     "dist"
   ],
   "scope_counts": {
-    "Live repo files analyzed in the current tree": 680,
+    "Live repo files analyzed in the current tree": 681,
     "Python files under `src/` and `tests/`": 241,
     "`src/gpd/commands/*.md`": 61,
     "`src/gpd/agents/*.md`": 23,

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -449,10 +449,10 @@ def test_merge_gate_workflow_uses_main_branch_pytest_on_python_311() -> None:
     assert "branches: [main]" in workflow
     assert "workflow_dispatch:" in workflow
     assert "name: pytest (3.11)" in workflow
-    assert "actions/checkout@v4" in workflow
-    assert "actions/setup-python@v5" in workflow
+    assert "actions/checkout@v5" in workflow
+    assert "actions/setup-python@v6" in workflow
     assert 'python-version: "3.11"' in workflow
-    assert "astral-sh/setup-uv@v4" in workflow
+    assert "astral-sh/setup-uv@v7" in workflow
     assert "uv sync --dev" in workflow
     assert "uv run pytest tests/ -v" in workflow
 
@@ -468,7 +468,10 @@ def test_prepare_release_workflow_creates_release_pr_without_publishing() -> Non
     assert "workflow_dispatch:" in workflow
     assert 'description: "Dry run — validate and preview without opening a release PR"' in workflow
     assert "pull-requests: write" in workflow
-    assert "astral-sh/setup-uv@v4" in workflow
+    assert "actions/checkout@v5" in workflow
+    assert "actions/setup-python@v6" in workflow
+    assert "actions/setup-node@v6" in workflow
+    assert "astral-sh/setup-uv@v7" in workflow
     assert "uv sync --dev --frozen" in workflow
     assert "scripts/release_workflow.py prepare" in workflow
     assert "uv run pytest tests/test_release_consistency.py -v" in workflow
@@ -496,6 +499,11 @@ def test_publish_release_workflow_uses_trusted_publishing_from_merged_release_co
     assert "environment:" in workflow
     assert "name: PyPI" in workflow
     assert "id-token: write" in workflow
+    assert "actions/checkout@v5" in workflow
+    assert "actions/setup-python@v6" in workflow
+    assert "actions/setup-node@v6" in workflow
+    assert "actions/upload-artifact@v6" in workflow
+    assert "actions/download-artifact@v8" in workflow
     assert "pypa/gh-action-pypi-publish@release/v1" in workflow
     assert "npm publish" in workflow
     assert "gh release create" in workflow


### PR DESCRIPTION
## Summary
- bump GitHub Actions workflow dependencies to Node-24-capable action majors across test and release workflows
- add weekly Dependabot updates for GitHub Actions, `uv`, and `npm`
- refresh release-consistency expectations and repo-graph artifacts to match the new CI surfaces

## Why
GitHub is deprecating Node.js 20 for JavaScript actions and plans to default runners to Node.js 24 starting June 2, 2026. This change removes the current deprecation warnings and adds ongoing dependency maintenance so workflow pins do not drift again.

## Validation
- `./.venv/bin/ruff check src tests`
- `./.venv/bin/pytest -q tests/test_release_consistency.py tests/core/test_repo_interdependency_graph.py`
- `./.venv/bin/pytest -q`
