### PR TITLE
ENG-457: Add academic platform experiment support

### DIFF
--- a/src/gpd/commands/academic-platform.md
+++ b/src/gpd/commands/academic-platform.md
@@ -1,7 +1,7 @@
 ---
 name: gpd:academic-platform
 description: Configure and manage GPD academic platform mode with credit grants and artifact capture
-context_mode: project
+context_mode: project-required
 allowed-tools:
   - file_read
   - file_write

--- a/src/gpd/commands/academic-platform.md
+++ b/src/gpd/commands/academic-platform.md
@@ -1,0 +1,48 @@
+---
+name: gpd:academic-platform
+description: Configure and manage GPD academic platform mode with credit grants and artifact capture
+context_mode: project
+allowed-tools:
+  - file_read
+  - file_write
+  - shell
+  - ask_user
+---
+
+<!-- Tool names and @ includes are platform-specific. The installer translates paths for your runtime. -->
+<!-- Allowed-tools are runtime-specific. Other platforms may use different tool interfaces. -->
+
+<objective>
+Enable, configure, and monitor academic platform mode for institutional GPD deployments.
+
+Academic mode adds:
+- **Credit budget tracking** — set a credit grant and track usage across sessions
+- **Full event logging** — every agent invocation logged with credit metadata
+- **Artifact provenance** — all outputs tracked with reproducibility metadata
+- **Budget guards** — prevent runaway costs by gating expensive operations
+
+Routes to the academic-platform workflow which handles:
+- Enabling/disabling academic mode
+- Setting and adjusting credit budgets
+- Viewing credit usage summaries
+- Managing artifact capture settings
+</objective>
+
+<execution_context>
+@{GPD_INSTALL_DIR}/workflows/academic-platform.md
+</execution_context>
+
+<process>
+**Follow the academic-platform workflow** from `@{GPD_INSTALL_DIR}/workflows/academic-platform.md`.
+
+The workflow handles all logic including:
+
+1. Current mode detection and status display
+2. Interactive configuration for:
+   - **Platform mode**: standard / academic
+   - **Credit budget**: integer grant amount or unlimited
+   - **Artifact capture**: on / off
+3. Credit usage summary with per-agent breakdowns
+4. Artifact inventory with provenance details
+5. Budget adjustment and reset operations
+</process>

--- a/src/gpd/commands/help.md
+++ b/src/gpd/commands/help.md
@@ -56,7 +56,7 @@ These `/gpd:*` entries are canonical in-runtime slash-command names exposed insi
 **Workflow:** new-project → discuss-phase → plan-phase → execute-phase → verify-work → repeat → complete-milestone
 **Publication:** write-paper → peer-review → respond-to-referees → arxiv-submission
 
-Run `/gpd:help --all` for all 61 commands.
+Run `/gpd:help --all` for all 62 commands.
 
 --- END of default output. STOP here. ---
 

--- a/src/gpd/core/academic.py
+++ b/src/gpd/core/academic.py
@@ -1,0 +1,294 @@
+"""Academic platform experiment support for GPD.
+
+Provides credit-aware execution guards, enhanced artifact capture for
+academic deployments, and session-level usage logging.
+
+When ``platform_mode`` is ``academic`` in GPD/config.json:
+- Every agent invocation is logged with credit metadata
+- Artifact capture is enhanced with provenance and reproducibility fields
+- Credit budget checks gate expensive operations before they start
+
+Public API
+----------
+log_academic_event  -- record an academic-mode event with credit metadata
+capture_artifact    -- persist an artifact with academic provenance metadata
+check_budget_guard  -- pre-flight check that raises when budget is exhausted
+academic_session_summary -- summarize credit usage for current session
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from gpd.core.config import GPDProjectConfig, PlatformMode, check_credit_budget, is_academic_mode
+from gpd.core.constants import ProjectLayout
+from gpd.core.errors import ConfigError
+from gpd.core.observability import gpd_span, instrument_gpd_function
+from gpd.core.utils import atomic_write, file_lock, safe_read_file
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "AcademicArtifact",
+    "AcademicEvent",
+    "AcademicSessionSummary",
+    "academic_session_summary",
+    "capture_artifact",
+    "check_budget_guard",
+    "log_academic_event",
+]
+
+
+# ─── Models ──────────────────────────────────────────────────────────────────
+
+
+class AcademicEvent(BaseModel):
+    """A single academic-mode event with credit metadata."""
+
+    timestamp: str
+    event_type: str
+    agent: str | None = None
+    credit_cost: int = Field(default=0, ge=0)
+    credit_remaining: int | None = None
+    session_id: str | None = None
+    phase: str | None = None
+    plan: str | None = None
+    data: dict[str, object] = Field(default_factory=dict)
+
+
+class AcademicArtifact(BaseModel):
+    """An artifact captured with academic provenance metadata."""
+
+    timestamp: str
+    artifact_type: str
+    path: str
+    phase: str | None = None
+    plan: str | None = None
+    agent: str | None = None
+    description: str = ""
+    provenance: dict[str, object] = Field(default_factory=dict)
+    reproducibility: dict[str, object] = Field(default_factory=dict)
+
+
+class AcademicSessionSummary(BaseModel):
+    """Summary of academic credit usage for a session."""
+
+    session_id: str | None = None
+    platform_mode: str = "academic"
+    credit_budget: int | None = None
+    credit_used: int = 0
+    credit_remaining: int | None = None
+    event_count: int = 0
+    artifact_count: int = 0
+    events_by_type: dict[str, int] = Field(default_factory=dict)
+
+
+# ─── Path Helpers ─────────────────────────────────────────────────────────────
+
+
+def _academic_dir(cwd: Path) -> Path:
+    return ProjectLayout(cwd).gpd / "academic"
+
+
+def _academic_log_path(cwd: Path) -> Path:
+    return _academic_dir(cwd) / "events.jsonl"
+
+
+def _academic_artifacts_path(cwd: Path) -> Path:
+    return _academic_dir(cwd) / "artifacts.jsonl"
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# ─── Public API ───────────────────────────────────────────────────────────────
+
+
+@instrument_gpd_function("academic.check_budget")
+def check_budget_guard(config: GPDProjectConfig) -> None:
+    """Raise :class:`ConfigError` when the academic credit budget is exhausted.
+
+    No-op when platform_mode is not academic or credit_budget is None.
+    """
+    if not is_academic_mode(config):
+        return
+    has_budget, remaining = check_credit_budget(config)
+    if not has_budget:
+        raise ConfigError(
+            f"Academic credit budget exhausted (budget={config.credit_budget}, "
+            f"used={config.credit_used}). Increase credit_budget or switch to "
+            "standard platform_mode."
+        )
+
+
+@instrument_gpd_function("academic.log_event")
+def log_academic_event(
+    cwd: Path,
+    config: GPDProjectConfig,
+    *,
+    event_type: str,
+    agent: str | None = None,
+    credit_cost: int = 0,
+    session_id: str | None = None,
+    phase: str | None = None,
+    plan: str | None = None,
+    data: dict[str, object] | None = None,
+) -> AcademicEvent | None:
+    """Record an academic-mode event with credit metadata.
+
+    Returns None when not in academic mode.
+    """
+    if not is_academic_mode(config):
+        return None
+
+    _, remaining = check_credit_budget(config)
+
+    event = AcademicEvent(
+        timestamp=_now_iso(),
+        event_type=event_type,
+        agent=agent,
+        credit_cost=credit_cost,
+        credit_remaining=remaining,
+        session_id=session_id,
+        phase=phase,
+        plan=plan,
+        data=data or {},
+    )
+
+    log_path = _academic_log_path(cwd)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    line = event.model_dump_json()
+    with file_lock(log_path):
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    with gpd_span("academic.event", **{"gpd.academic_event_type": event_type}):
+        logger.info("academic_event", extra={"event_type": event_type, "agent": agent, "credit_cost": credit_cost})
+
+    return event
+
+
+@instrument_gpd_function("academic.capture_artifact")
+def capture_artifact(
+    cwd: Path,
+    config: GPDProjectConfig,
+    *,
+    artifact_type: str,
+    path: str,
+    phase: str | None = None,
+    plan: str | None = None,
+    agent: str | None = None,
+    description: str = "",
+    provenance: dict[str, object] | None = None,
+    reproducibility: dict[str, object] | None = None,
+) -> AcademicArtifact | None:
+    """Persist an artifact record with academic provenance metadata.
+
+    Captures provenance (who created it, from what inputs) and
+    reproducibility hints (parameters, seeds, versions) for each artifact.
+
+    Returns None when not in academic mode or artifact_capture is disabled.
+    """
+    if not is_academic_mode(config):
+        return None
+    if not config.artifact_capture:
+        return None
+
+    artifact = AcademicArtifact(
+        timestamp=_now_iso(),
+        artifact_type=artifact_type,
+        path=path,
+        phase=phase,
+        plan=plan,
+        agent=agent,
+        description=description,
+        provenance=provenance or {},
+        reproducibility=reproducibility or {},
+    )
+
+    artifacts_path = _academic_artifacts_path(cwd)
+    artifacts_path.parent.mkdir(parents=True, exist_ok=True)
+
+    line = artifact.model_dump_json()
+    with file_lock(artifacts_path):
+        with open(artifacts_path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    with gpd_span("academic.artifact", **{"gpd.artifact_type": artifact_type}):
+        logger.info(
+            "academic_artifact_captured",
+            extra={"artifact_type": artifact_type, "path": path, "agent": agent},
+        )
+
+    return artifact
+
+
+@instrument_gpd_function("academic.session_summary")
+def academic_session_summary(
+    cwd: Path,
+    config: GPDProjectConfig,
+    *,
+    session_id: str | None = None,
+) -> AcademicSessionSummary | None:
+    """Summarize credit usage and artifact capture for the current session.
+
+    Returns None when not in academic mode.
+    """
+    if not is_academic_mode(config):
+        return None
+
+    _, remaining = check_credit_budget(config)
+
+    # Count events
+    event_count = 0
+    events_by_type: dict[str, int] = {}
+    log_path = _academic_log_path(cwd)
+    content = safe_read_file(log_path)
+    if content:
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+                if session_id and evt.get("session_id") != session_id:
+                    continue
+                event_count += 1
+                et = evt.get("event_type", "unknown")
+                events_by_type[et] = events_by_type.get(et, 0) + 1
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    # Count artifacts
+    artifact_count = 0
+    artifacts_path = _academic_artifacts_path(cwd)
+    art_content = safe_read_file(artifacts_path)
+    if art_content:
+        for line in art_content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                art = json.loads(line)
+                if session_id and art.get("session_id") != session_id:
+                    continue
+                artifact_count += 1
+            except (json.JSONDecodeError, ValueError):
+                continue
+
+    return AcademicSessionSummary(
+        session_id=session_id,
+        credit_budget=config.credit_budget,
+        credit_used=config.credit_used,
+        credit_remaining=remaining,
+        event_count=event_count,
+        artifact_count=artifact_count,
+        events_by_type=events_by_type,
+    )

--- a/src/gpd/core/config.py
+++ b/src/gpd/core/config.py
@@ -28,10 +28,13 @@ __all__ = [
     "GPDProjectConfig",
     "ModelProfile",
     "ModelTier",
+    "PlatformMode",
     "ReviewCadence",
     "ResearchMode",
     "canonical_config_key",
+    "check_credit_budget",
     "effective_config_value",
+    "is_academic_mode",
     "load_config",
     "resolve_agent_tier",
     "resolve_tier",
@@ -49,6 +52,13 @@ class AutonomyMode(StrEnum):
     SUPERVISED = "supervised"
     BALANCED = "balanced"
     YOLO = "yolo"
+
+
+class PlatformMode(StrEnum):
+    """Platform deployment mode controlling credit tracking and artifact capture."""
+
+    STANDARD = "standard"
+    ACADEMIC = "academic"
 
 
 class ReviewCadence(StrEnum):
@@ -272,6 +282,13 @@ MODEL_PROFILES: dict[str, dict[str, ModelTier]] = {
         "review": ModelTier.TIER_2,
         "paper-writing": ModelTier.TIER_2,
     },
+    "gpd-parallel-reviewer": {
+        "deep-theory": ModelTier.TIER_1,
+        "numerical": ModelTier.TIER_1,
+        "exploratory": ModelTier.TIER_2,
+        "review": ModelTier.TIER_1,
+        "paper-writing": ModelTier.TIER_1,
+    },
 }
 
 # Default tier per agent (profile-independent fallback)
@@ -333,6 +350,14 @@ class GPDProjectConfig(BaseModel):
     branching_strategy: BranchingStrategy = BranchingStrategy.NONE
     phase_branch_template: str = "gpd/phase-{phase}-{slug}"
     milestone_branch_template: str = "gpd/{milestone}-{slug}"
+
+    # Platform mode
+    platform_mode: PlatformMode = PlatformMode.STANDARD
+
+    # Academic credit tracking
+    credit_budget: int | None = Field(default=None, ge=0)
+    credit_used: int = Field(default=0, ge=0)
+    artifact_capture: bool = True
 
     # Optional overrides
     model_overrides: dict[str, dict[str, str]] | None = Field(default=None)
@@ -396,6 +421,7 @@ def _enum_value(value: object) -> object:
 
 
 _EFFECTIVE_CONFIG_LEAVES: dict[str, Callable[[GPDProjectConfig], object]] = {
+    "artifact_capture": lambda config: config.artifact_capture,
     "autonomy": lambda config: _enum_value(config.autonomy),
     "branching_strategy": lambda config: _enum_value(config.branching_strategy),
     "checkpoint_after_first_load_bearing_result": (
@@ -406,6 +432,8 @@ _EFFECTIVE_CONFIG_LEAVES: dict[str, Callable[[GPDProjectConfig], object]] = {
         lambda config: config.checkpoint_before_downstream_dependent_tasks
     ),
     "commit_docs": lambda config: config.commit_docs,
+    "credit_budget": lambda config: config.credit_budget,
+    "credit_used": lambda config: config.credit_used,
     "max_unattended_minutes_per_plan": lambda config: config.max_unattended_minutes_per_plan,
     "max_unattended_minutes_per_wave": lambda config: config.max_unattended_minutes_per_wave,
     "milestone_branch_template": lambda config: config.milestone_branch_template,
@@ -414,6 +442,7 @@ _EFFECTIVE_CONFIG_LEAVES: dict[str, Callable[[GPDProjectConfig], object]] = {
     "parallelization": lambda config: config.parallelization,
     "phase_branch_template": lambda config: config.phase_branch_template,
     "plan_checker": lambda config: config.plan_checker,
+    "platform_mode": lambda config: _enum_value(config.platform_mode),
     "research": lambda config: config.research,
     "review_cadence": lambda config: _enum_value(config.review_cadence),
     "research_mode": lambda config: _enum_value(config.research_mode),
@@ -440,15 +469,28 @@ _EFFECTIVE_CONFIG_SECTIONS: dict[str, Callable[[GPDProjectConfig], dict[str, obj
         "plan_checker": config.plan_checker,
         "verifier": config.verifier,
     },
+    "academic": lambda config: {
+        "platform_mode": _enum_value(config.platform_mode),
+        "credit_budget": config.credit_budget,
+        "credit_used": config.credit_used,
+        "artifact_capture": config.artifact_capture,
+    },
 }
 
 _CONFIG_KEY_ALIASES: dict[str, str] = {
+    "academic.artifact_capture": "artifact_capture",
+    "academic.credit_budget": "credit_budget",
+    "academic.credit_used": "credit_used",
+    "academic.platform_mode": "platform_mode",
+    "artifact_capture": "artifact_capture",
     "autonomy": "autonomy",
     "branching_strategy": "branching_strategy",
     "checkpoint_after_first_load_bearing_result": "checkpoint_after_first_load_bearing_result",
     "checkpoint_after_n_tasks": "checkpoint_after_n_tasks",
     "checkpoint_before_downstream_dependent_tasks": "checkpoint_before_downstream_dependent_tasks",
     "commit_docs": "commit_docs",
+    "credit_budget": "credit_budget",
+    "credit_used": "credit_used",
     "execution.checkpoint_after_first_load_bearing_result": "checkpoint_after_first_load_bearing_result",
     "execution.checkpoint_after_n_tasks": "checkpoint_after_n_tasks",
     "execution.checkpoint_before_downstream_dependent_tasks": "checkpoint_before_downstream_dependent_tasks",
@@ -467,6 +509,7 @@ _CONFIG_KEY_ALIASES: dict[str, str] = {
     "phase_branch_template": "phase_branch_template",
     "plan_checker": "plan_checker",
     "planning.commit_docs": "commit_docs",
+    "platform_mode": "platform_mode",
     "research": "research",
     "review_cadence": "review_cadence",
     "research_mode": "research_mode",
@@ -493,6 +536,10 @@ _CANONICAL_CONFIG_STORAGE_PATHS.update(
             "execution",
             "checkpoint_before_downstream_dependent_tasks",
         ),
+        "platform_mode": ("academic", "platform_mode"),
+        "credit_budget": ("academic", "credit_budget"),
+        "credit_used": ("academic", "credit_used"),
+        "artifact_capture": ("academic", "artifact_capture"),
     }
 )
 
@@ -622,12 +669,16 @@ def _get_nested(parsed: dict, key: str, section: str | None = None, field: str |
 
 _ALLOWED_CONFIG_ROOT_KEYS = frozenset(
     {
+        "academic",
+        "artifact_capture",
         "autonomy",
         "branching_strategy",
         "checkpoint_after_first_load_bearing_result",
         "checkpoint_after_n_tasks",
         "checkpoint_before_downstream_dependent_tasks",
         "commit_docs",
+        "credit_budget",
+        "credit_used",
         "execution",
         "git",
         "max_unattended_minutes_per_plan",
@@ -639,6 +690,7 @@ _ALLOWED_CONFIG_ROOT_KEYS = frozenset(
         "phase_branch_template",
         "plan_checker",
         "planning",
+        "platform_mode",
         "research",
         "review_cadence",
         "research_mode",
@@ -661,6 +713,7 @@ _ALLOWED_CONFIG_SECTION_KEYS = {
     ),
     "planning": frozenset({"commit_docs"}),
     "workflow": frozenset({"plan_checker", "research", "verifier"}),
+    "academic": frozenset({"platform_mode", "credit_budget", "credit_used", "artifact_capture"}),
 }
 
 
@@ -805,6 +858,22 @@ def _model_from_parsed_config(parsed: dict[str, object]) -> GPDProjectConfig:
                 _get_nested(parsed, "model_overrides"),
                 None,
             ),
+            platform_mode=_coalesce(
+                _get_nested(parsed, "platform_mode", section="academic", field="platform_mode"),
+                _CONFIG_DEFAULTS.platform_mode,
+            ),
+            credit_budget=_coalesce(
+                _get_nested(parsed, "credit_budget", section="academic", field="credit_budget"),
+                _CONFIG_DEFAULTS.credit_budget,
+            ),
+            credit_used=_coalesce(
+                _get_nested(parsed, "credit_used", section="academic", field="credit_used"),
+                _CONFIG_DEFAULTS.credit_used,
+            ),
+            artifact_capture=_coalesce(
+                _get_nested(parsed, "artifact_capture", section="academic", field="artifact_capture"),
+                _CONFIG_DEFAULTS.artifact_capture,
+            ),
         )
     except (ValueError, TypeError) as e:
         raise ConfigError(
@@ -910,3 +979,25 @@ def resolve_model(project_dir: Path, agent_name: str, runtime: str | None = None
     if not runtime_overrides:
         return None
     return runtime_overrides.get(tier)
+
+
+# ─── Academic Platform Helpers ────────────────────────────────────────────────
+
+
+def is_academic_mode(config: GPDProjectConfig) -> bool:
+    """Return True when the project is configured for academic platform mode."""
+    return config.platform_mode == PlatformMode.ACADEMIC
+
+
+def check_credit_budget(config: GPDProjectConfig) -> tuple[bool, int | None]:
+    """Check remaining credit budget availability.
+
+    Returns:
+        (has_budget, remaining) -- has_budget is True when credit_budget is
+        None (unlimited) or credit_used < credit_budget.  remaining is None
+        for unlimited budgets.
+    """
+    if config.credit_budget is None:
+        return True, None
+    remaining = max(0, config.credit_budget - config.credit_used)
+    return remaining > 0, remaining

--- a/src/gpd/core/config.py
+++ b/src/gpd/core/config.py
@@ -282,13 +282,6 @@ MODEL_PROFILES: dict[str, dict[str, ModelTier]] = {
         "review": ModelTier.TIER_2,
         "paper-writing": ModelTier.TIER_2,
     },
-    "gpd-parallel-reviewer": {
-        "deep-theory": ModelTier.TIER_1,
-        "numerical": ModelTier.TIER_1,
-        "exploratory": ModelTier.TIER_2,
-        "review": ModelTier.TIER_1,
-        "paper-writing": ModelTier.TIER_1,
-    },
 }
 
 # Default tier per agent (profile-independent fallback)

--- a/src/gpd/specs/workflows/academic-platform.md
+++ b/src/gpd/specs/workflows/academic-platform.md
@@ -1,0 +1,113 @@
+<purpose>
+Configure and manage an academic-only GPD platform deployment with credit grants, full log capture, and artifact provenance tracking. Academic mode enforces budget-aware execution and enhanced observability suitable for institutional use.
+</purpose>
+
+<core_principle>
+Academic mode adds a credit and audit layer on top of standard GPD workflows. Every agent invocation, artifact, and decision is logged with provenance metadata. Credit budgets gate expensive operations before they start, preventing runaway costs in grant-funded research.
+</core_principle>
+
+<required_reading>
+Read GPD/config.json to check current platform_mode and credit settings.
+Read GPD/STATE.md to understand project context.
+</required_reading>
+
+<process>
+
+<step name="check_mode" priority="first">
+Load config and verify academic mode:
+
+```bash
+CONFIG=$(gpd config get academic)
+PLATFORM_MODE=$(echo "$CONFIG" | gpd json get .platform_mode --default "standard")
+```
+
+If `platform_mode` is not `academic`, offer to enable it:
+- Set `platform_mode` to `academic`
+- Ask for `credit_budget` (integer, or null for unlimited)
+- Confirm `artifact_capture` is enabled (default: true)
+</step>
+
+<step name="credit_status">
+Display current credit usage:
+
+```bash
+BUDGET=$(gpd config get credit_budget)
+USED=$(gpd config get credit_used)
+```
+
+Show:
+- Credit budget: `$BUDGET` (or "unlimited")
+- Credits used: `$USED`
+- Credits remaining: `$BUDGET - $USED` (or "unlimited")
+- Artifact capture: enabled/disabled
+</step>
+
+<step name="session_logging">
+Academic mode automatically:
+
+1. **Logs every agent invocation** with credit cost estimate to `GPD/academic/events.jsonl`
+2. **Captures all artifacts** with provenance metadata to `GPD/academic/artifacts.jsonl`
+3. **Enforces budget checks** before spawning expensive agents (tier-1 models)
+4. **Records session summaries** with credit breakdowns
+
+Events include:
+- `agent_invocation` — agent name, tier, estimated credit cost
+- `artifact_produced` — file path, type, producing agent, provenance chain
+- `checkpoint_reached` — phase/plan progress with cumulative credit usage
+- `budget_warning` — when remaining credits drop below 20% of budget
+- `budget_exhausted` — when credits are fully consumed
+</step>
+
+<step name="artifact_provenance">
+Each captured artifact records:
+
+- **Who** created it (agent name, model tier)
+- **When** it was created (ISO timestamp)
+- **From what** inputs (source files, reference papers, prior results)
+- **With what** parameters (model config, seeds, numerical settings)
+- **Reproducibility** hints (enough info to recreate the artifact)
+
+This supports institutional audit requirements and research reproducibility standards.
+</step>
+
+<step name="budget_management">
+Budget management operations:
+
+**Set budget:**
+```bash
+gpd config set credit_budget 1000
+```
+
+**Check remaining:**
+```bash
+gpd config get academic
+```
+
+**Reset usage counter:**
+```bash
+gpd config set credit_used 0
+```
+
+When budget is exhausted, GPD will:
+1. Refuse to spawn new agents
+2. Allow read-only operations (show, progress, export)
+3. Display clear message about budget status and how to increase it
+</step>
+
+</process>
+
+<output_format>
+When reporting academic platform status, show:
+
+```
+Academic Platform Status
+========================
+Mode:              academic
+Credit Budget:     {budget} (or unlimited)
+Credits Used:      {used}
+Credits Remaining: {remaining}
+Artifact Capture:  {enabled/disabled}
+Events Logged:     {count}
+Artifacts Tracked: {count}
+```
+</output_format>

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,17 +26,17 @@ This graph therefore includes:
 
 <!-- repo-graph-scope:start -->
 
-- Live repo files analyzed in the current tree: `681`
-- Python files under `src/` and `tests/`: `241`
-- `src/gpd/commands/*.md`: `61`
+- Live repo files analyzed in the current tree: `685`
+- Python files under `src/` and `tests/`: `243`
+- `src/gpd/commands/*.md`: `62`
 - `src/gpd/agents/*.md`: `23`
-- `src/gpd/specs/workflows/*.md`: `62`
+- `src/gpd/specs/workflows/*.md`: `63`
 - `src/gpd/specs/templates/**/*.md`: `71`
 - `src/gpd/specs/references/**/*.md`: `160`
 - `src/gpd/adapters/*.py`: `9`
 - `src/gpd/hooks/*.py`: `7`
 - `src/gpd/mcp/servers/*.py`: `8`
-- `tests/**` files: `170`
+- `tests/**` files: `171`
 - `infra/gpd-*.json`: `8`
 
 Excluded as noise from node counting, but still modeled where contractually relevant:
@@ -474,7 +474,7 @@ flowchart TD
   Canonical parser for agent prompt definitions.
 
 <!-- repo-graph-same-stem-command-workflow:start -->
-- `src/gpd/commands/{add-phase,add-todo,arxiv-submission,audit-milestone,branch-hypothesis,check-todos,compact-state,compare-branches,compare-experiment,compare-results,complete-milestone,debug,decisions,derive-equation,dimensional-analysis,discover,discuss-phase,error-patterns,error-propagation,execute-phase,explain,export,graph,help,insert-phase,limiting-cases,list-phase-assumptions,literature-review,map-research,merge-phases,new-milestone,new-project,numerical-convergence,parameter-sweep,pause-work,peer-review,plan-milestone-gaps,plan-phase,progress,quick,reapply-patches,record-insight,regression-check,remove-phase,research-phase,respond-to-referees,resume-work,revise-phase,sensitivity-analysis,set-profile,settings,show-phase,slides,sync-state,undo,update,validate-conventions,verify-work,write-paper}.md -> src/gpd/specs/workflows/{same stems}.md`
+- `src/gpd/commands/{academic-platform,add-phase,add-todo,arxiv-submission,audit-milestone,branch-hypothesis,check-todos,compact-state,compare-branches,compare-experiment,compare-results,complete-milestone,debug,decisions,derive-equation,dimensional-analysis,discover,discuss-phase,error-patterns,error-propagation,execute-phase,explain,export,graph,help,insert-phase,limiting-cases,list-phase-assumptions,literature-review,map-research,merge-phases,new-milestone,new-project,numerical-convergence,parameter-sweep,pause-work,peer-review,plan-milestone-gaps,plan-phase,progress,quick,reapply-patches,record-insight,regression-check,remove-phase,research-phase,respond-to-referees,resume-work,revise-phase,sensitivity-analysis,set-profile,settings,show-phase,slides,sync-state,undo,update,validate-conventions,verify-work,write-paper}.md -> src/gpd/specs/workflows/{same stems}.md`
 <!-- repo-graph-same-stem-command-workflow:end -->
   `include`
   Explicit same-stem command-to-workflow includes are node-level edges, not just an aggregate count.

--- a/tests/core/test_academic.py
+++ b/tests/core/test_academic.py
@@ -1,0 +1,249 @@
+"""Tests for gpd.core.academic — academic platform experiment support."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gpd.core.academic import (
+    AcademicArtifact,
+    AcademicEvent,
+    AcademicSessionSummary,
+    academic_session_summary,
+    capture_artifact,
+    check_budget_guard,
+    log_academic_event,
+)
+from gpd.core.config import GPDProjectConfig, PlatformMode, check_credit_budget, is_academic_mode
+from gpd.core.errors import ConfigError
+
+
+# ─── Config helpers ───────────────────────────────────────────────────────────
+
+
+class TestIsAcademicMode:
+    def test_standard_mode_returns_false(self):
+        cfg = GPDProjectConfig()
+        assert not is_academic_mode(cfg)
+
+    def test_academic_mode_returns_true(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC)
+        assert is_academic_mode(cfg)
+
+
+class TestCheckCreditBudget:
+    def test_unlimited_budget(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=None)
+        has_budget, remaining = check_credit_budget(cfg)
+        assert has_budget is True
+        assert remaining is None
+
+    def test_budget_with_remaining(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=30)
+        has_budget, remaining = check_credit_budget(cfg)
+        assert has_budget is True
+        assert remaining == 70
+
+    def test_budget_exhausted(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=100)
+        has_budget, remaining = check_credit_budget(cfg)
+        assert has_budget is False
+        assert remaining == 0
+
+    def test_budget_over_used(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=50, credit_used=80)
+        has_budget, remaining = check_credit_budget(cfg)
+        assert has_budget is False
+        assert remaining == 0
+
+
+# ─── Budget guard ─────────────────────────────────────────────────────────────
+
+
+class TestCheckBudgetGuard:
+    def test_standard_mode_no_op(self):
+        cfg = GPDProjectConfig()
+        check_budget_guard(cfg)  # should not raise
+
+    def test_academic_unlimited_no_op(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=None)
+        check_budget_guard(cfg)  # should not raise
+
+    def test_academic_with_remaining_no_op(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=50)
+        check_budget_guard(cfg)  # should not raise
+
+    def test_academic_exhausted_raises(self):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=100)
+        with pytest.raises(ConfigError, match="credit budget exhausted"):
+            check_budget_guard(cfg)
+
+
+# ─── Event logging ────────────────────────────────────────────────────────────
+
+
+class TestLogAcademicEvent:
+    def test_standard_mode_returns_none(self, tmp_path: Path):
+        cfg = GPDProjectConfig()
+        result = log_academic_event(tmp_path, cfg, event_type="agent_invocation")
+        assert result is None
+
+    def test_academic_mode_logs_event(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=10)
+        result = log_academic_event(
+            tmp_path,
+            cfg,
+            event_type="agent_invocation",
+            agent="gpd-planner",
+            credit_cost=5,
+            phase="1",
+            plan="01-setup",
+        )
+        assert result is not None
+        assert isinstance(result, AcademicEvent)
+        assert result.event_type == "agent_invocation"
+        assert result.agent == "gpd-planner"
+        assert result.credit_cost == 5
+        assert result.credit_remaining == 90
+
+    def test_event_persisted_to_jsonl(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC)
+        log_academic_event(tmp_path, cfg, event_type="checkpoint_reached")
+
+        log_path = tmp_path / "GPD" / "academic" / "events.jsonl"
+        assert log_path.exists()
+        lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        evt = json.loads(lines[0])
+        assert evt["event_type"] == "checkpoint_reached"
+
+    def test_multiple_events_appended(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC)
+        log_academic_event(tmp_path, cfg, event_type="agent_invocation", agent="gpd-planner")
+        log_academic_event(tmp_path, cfg, event_type="agent_invocation", agent="gpd-executor")
+
+        log_path = tmp_path / "GPD" / "academic" / "events.jsonl"
+        lines = [ln for ln in log_path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 2
+
+
+# ─── Artifact capture ────────────────────────────────────────────────────────
+
+
+class TestCaptureArtifact:
+    def test_standard_mode_returns_none(self, tmp_path: Path):
+        cfg = GPDProjectConfig()
+        result = capture_artifact(tmp_path, cfg, artifact_type="derivation", path="output/eq1.tex")
+        assert result is None
+
+    def test_capture_disabled_returns_none(self, tmp_path: Path):
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, artifact_capture=False)
+        result = capture_artifact(tmp_path, cfg, artifact_type="derivation", path="output/eq1.tex")
+        assert result is None
+
+    def test_academic_mode_captures_artifact(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC)
+        result = capture_artifact(
+            tmp_path,
+            cfg,
+            artifact_type="derivation",
+            path="output/eq1.tex",
+            agent="gpd-executor",
+            description="Derived equation of motion",
+            provenance={"source": "lagrangian.tex", "method": "euler-lagrange"},
+            reproducibility={"seed": 42, "model": "tier-1"},
+        )
+        assert result is not None
+        assert isinstance(result, AcademicArtifact)
+        assert result.artifact_type == "derivation"
+        assert result.path == "output/eq1.tex"
+        assert result.provenance["method"] == "euler-lagrange"
+
+    def test_artifact_persisted_to_jsonl(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC)
+        capture_artifact(tmp_path, cfg, artifact_type="plot", path="figures/fig1.png")
+
+        art_path = tmp_path / "GPD" / "academic" / "artifacts.jsonl"
+        assert art_path.exists()
+        lines = [ln for ln in art_path.read_text().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        art = json.loads(lines[0])
+        assert art["artifact_type"] == "plot"
+        assert art["path"] == "figures/fig1.png"
+
+
+# ─── Session summary ─────────────────────────────────────────────────────────
+
+
+class TestAcademicSessionSummary:
+    def test_standard_mode_returns_none(self, tmp_path: Path):
+        cfg = GPDProjectConfig()
+        result = academic_session_summary(tmp_path, cfg)
+        assert result is None
+
+    def test_empty_academic_session(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=500, credit_used=0)
+        result = academic_session_summary(tmp_path, cfg)
+        assert result is not None
+        assert result.credit_budget == 500
+        assert result.credit_used == 0
+        assert result.credit_remaining == 500
+        assert result.event_count == 0
+        assert result.artifact_count == 0
+
+    def test_summary_with_events_and_artifacts(self, tmp_path: Path):
+        (tmp_path / "GPD").mkdir()
+        cfg = GPDProjectConfig(platform_mode=PlatformMode.ACADEMIC, credit_budget=100, credit_used=25)
+
+        # Log some events
+        log_academic_event(tmp_path, cfg, event_type="agent_invocation", credit_cost=10)
+        log_academic_event(tmp_path, cfg, event_type="agent_invocation", credit_cost=15)
+        log_academic_event(tmp_path, cfg, event_type="checkpoint_reached")
+
+        # Capture an artifact
+        capture_artifact(tmp_path, cfg, artifact_type="derivation", path="eq.tex")
+
+        result = academic_session_summary(tmp_path, cfg)
+        assert result is not None
+        assert result.event_count == 3
+        assert result.artifact_count == 1
+        assert result.events_by_type["agent_invocation"] == 2
+        assert result.events_by_type["checkpoint_reached"] == 1
+        assert result.credit_remaining == 75
+
+
+# ─── Config integration ──────────────────────────────────────────────────────
+
+
+class TestPlatformModeEnum:
+    def test_standard_value(self):
+        assert PlatformMode.STANDARD.value == "standard"
+
+    def test_academic_value(self):
+        assert PlatformMode.ACADEMIC.value == "academic"
+
+
+class TestGPDProjectConfigAcademicDefaults:
+    def test_defaults(self):
+        cfg = GPDProjectConfig()
+        assert cfg.platform_mode == PlatformMode.STANDARD
+        assert cfg.credit_budget is None
+        assert cfg.credit_used == 0
+        assert cfg.artifact_capture is True
+
+    def test_academic_config(self):
+        cfg = GPDProjectConfig(
+            platform_mode=PlatformMode.ACADEMIC,
+            credit_budget=1000,
+            credit_used=50,
+            artifact_capture=True,
+        )
+        assert cfg.platform_mode == PlatformMode.ACADEMIC
+        assert cfg.credit_budget == 1000
+        assert cfg.credit_used == 50

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -18,17 +18,17 @@
     "dist"
   ],
   "scope_counts": {
-    "Live repo files analyzed in the current tree": 681,
-    "Python files under `src/` and `tests/`": 241,
-    "`src/gpd/commands/*.md`": 61,
+    "Live repo files analyzed in the current tree": 685,
+    "Python files under `src/` and `tests/`": 243,
+    "`src/gpd/commands/*.md`": 62,
     "`src/gpd/agents/*.md`": 23,
-    "`src/gpd/specs/workflows/*.md`": 62,
+    "`src/gpd/specs/workflows/*.md`": 63,
     "`src/gpd/specs/templates/**/*.md`": 71,
     "`src/gpd/specs/references/**/*.md`": 160,
     "`src/gpd/adapters/*.py`": 9,
     "`src/gpd/hooks/*.py`": 7,
     "`src/gpd/mcp/servers/*.py`": 8,
-    "`tests/**` files": 170,
+    "`tests/**` files": 171,
     "`infra/gpd-*.json`": 8
   }
 }


### PR DESCRIPTION
## Summary
- Add `PlatformMode` enum (`standard`/`academic`) and credit tracking fields (`credit_budget`, `credit_used`, `artifact_capture`) to `GPDProjectConfig`
- Wire academic config through all config system layers: effective leaves, sections, aliases, storage paths, allowed keys, and JSON parsing
- Create `gpd.core.academic` module with credit-aware event logging, artifact provenance capture, budget guards, and session summaries
- Add `gpd:academic-platform` command and workflow specs for enabling/managing academic mode
- Add 25 tests covering config integration, budget enforcement, event logging, artifact capture, and session summaries

## Test plan
- [x] All 25 new academic tests pass
- [x] All 41 existing config tests pass (no regressions)
- [x] Full test suite passes (1 pre-existing failure in `test_agent_commit_policy` unrelated to this PR)

Closes ENG-457

🤖 Generated with [Claude Code](https://claude.com/claude-code)