### PR TITLE
Prefer adapting existing packages before writing code

### DIFF
--- a/src/gpd/agents/gpd-executor.md
+++ b/src/gpd/agents/gpd-executor.md
@@ -32,7 +32,7 @@ You operate across all areas of physics --- theoretical, computational, mathemat
 
 **Reproducibility:** Before computational work, record random seeds, library versions, and hardware details in the derivation file for reproducibility.
 
-**Tool selection:** For computational tasks, consult `{GPD_INSTALL_DIR}/references/tooling/tool-integration.md` for guidance on Python vs Julia vs Mathematica vs Fortran selection, and correct library API usage.
+**Tool selection:** For computational tasks, consult `{GPD_INSTALL_DIR}/references/tooling/tool-integration.md` for guidance on Python vs Julia vs Mathematica vs Fortran selection, correct library API usage, and **the package preference policy** (prefer existing packages over custom code). Check the plan's `package_strategy` frontmatter and search for established libraries before writing implementations from scratch.
 
 **Reference index:** When starting execution in a new domain or needing guidance on which reference to load, consult `{GPD_INSTALL_DIR}/references/execution/executor-index.md` — it maps execution scenarios (QFT, condensed matter, debugging, paper writing, etc.) to the correct reference files.
 
@@ -655,7 +655,11 @@ Each step in the plan must be a self-contained, verifiable unit of research work
 
 **Implementation step:** Write a single module, function, or script that performs one well-defined computational task. Verify by running against test cases with known answers.
 
+> **Package-first rule:** Before writing implementation code, check whether an existing package already provides the needed functionality. Search the plan's `package_strategy` frontmatter, RESEARCH.md computational tools section, and PyPI/conda for established solutions. Prefer `import` over reimplementation. If an existing package covers 70%+ of the task, adapt it (subclass, extend, wrap) rather than writing from scratch. Only write custom implementations when no suitable package exists or when the plan explicitly justifies custom code. Document which packages were considered and why they were used or rejected.
+
 **Simulation step:** Execute one simulation run with defined parameters. Follow numerical_computation_protocol. Verify by checking conservation laws, boundary conditions, or convergence.
+
+> **Package-first rule (simulations):** Use established simulation frameworks (LAMMPS, OpenMM, ASE, QuTiP, FEniCS, Dedalus, etc.) when they support the required physics. Configure and extend existing frameworks rather than writing simulation engines from scratch. A custom simulation loop is justified only when the physics is genuinely novel and no framework supports it, or when the plan's `package_strategy` documents why existing frameworks are unsuitable.
 
 **Analysis step:** Process one dataset or set of results. Verify by checking statistical consistency, error bars, or expected scaling behavior.
 

--- a/src/gpd/agents/gpd-experiment-designer.md
+++ b/src/gpd/agents/gpd-experiment-designer.md
@@ -84,6 +84,36 @@ Also read:
 If prior phases have numerical results, read their SUMMARY.md for baseline values, achieved tolerances, and lessons learned.
 </step>
 
+<step name="identify_simulation_framework">
+## Identify Existing Simulation Frameworks
+
+**Before designing a custom simulation pipeline, search for existing frameworks that can run the required experiment.**
+
+Check in this order:
+
+1. **Plan's `package_strategy` frontmatter:** The planner should have already identified candidate packages. Respect that decision.
+2. **RESEARCH.md Computational Tools section:** The phase researcher documents standard tools for this domain.
+3. **Domain-standard frameworks:** Consult the table below for well-established simulation packages.
+
+| Domain | Standard Frameworks | Strengths |
+|--------|-------------------|-----------|
+| Molecular dynamics | LAMMPS, OpenMM, GROMACS, ASE | Force fields, integrators, analysis built-in |
+| Quantum systems | QuTiP, Qiskit, Cirq | Master equations, circuits, noise models |
+| Fluid dynamics | FEniCS, Dedalus, OpenFOAM | PDE solvers, spectral methods, mesh handling |
+| Condensed matter | kwant, PySCF, DFTB+ | Transport, electronic structure, tight-binding |
+| Statistical mechanics | emcee, PyMC, Stan | MCMC sampling, Bayesian inference |
+| Lattice field theory | Grid, Chroma, openQCD | Gauge field simulation, fermion solvers |
+| N-body / gravitational | REBOUND, Gadget, AREPO | Orbital mechanics, cosmological simulation |
+| General ODE/PDE | SciPy, DifferentialEquations.jl | Adaptive solvers, stiff systems |
+
+**Design principle:** Design the experiment protocol around the framework's capabilities. For example:
+- If using LAMMPS: design in terms of LAMMPS commands (`fix`, `compute`, `dump`), not raw algorithms
+- If using QuTiP: design in terms of `mesolve`, `mcsolve`, Qobj, not manual Lindblad integration
+- If using emcee: design in terms of walkers, burn-in, autocorrelation, not custom MCMC moves
+
+**When NO existing framework fits:** Document why (novel physics, unsupported boundary conditions, performance requirements) in the experiment design. The justification should be specific enough that a reviewer can verify the claim.
+</step>
+
 <step name="identify_quantities">
 ## Identify Target Quantities
 

--- a/src/gpd/agents/gpd-phase-researcher.md
+++ b/src/gpd/agents/gpd-phase-researcher.md
@@ -253,15 +253,25 @@ Convention loading: see agent-infrastructure.md Convention Loading Protocol.
 
 ### Core Tools
 
-| Tool          | Version/Module | Purpose        | Why Standard         |
-| ------------- | -------------- | -------------- | -------------------- |
-| [e.g., SymPy] | [ver/module]   | [what it does] | [why experts use it] |
+| Tool          | Version/Module | Purpose        | Why Standard         | Use Directly or Adapt? |
+| ------------- | -------------- | -------------- | -------------------- | ---------------------- |
+| [e.g., SymPy] | [ver/module]   | [what it does] | [why experts use it] | [direct / adapt / reference only] |
 
 ### Supporting Tools
 
 | Tool               | Purpose         | When to Use         |
 | ------------------ | --------------- | ------------------- |
 | [e.g., matplotlib] | [visualization] | [specific use case] |
+
+### Package Recommendation
+
+**Recommended approach:** [use_existing / adapt_existing / combine_existing / custom]
+
+| Package | Covers | Does NOT Cover | Adaptation Needed | License |
+| ------- | ------ | -------------- | ----------------- | ------- |
+| [name]  | [what it handles] | [gaps] | [subclass X / configure Y / none] | [MIT/BSD/etc.] |
+
+**If custom code is recommended, justify:** [Why no existing package is suitable — be specific about the gap]
 
 ### Alternatives Considered
 
@@ -469,13 +479,26 @@ For each domain, follow this search strategy:
 4. Search for the specific problem or closely related problems: `site:arxiv.org "[specific method]" "[specific system]"`
 5. Check for known exact solutions, no-go theorems, or impossibility results
 
-### 3b: Computational Tools
+### 3b: Computational Tools and Existing Packages
+
+**CRITICAL: Package discovery is a primary research output.** The planner and executor depend on this section to decide whether to use, adapt, or build computational tools. Thorough package research here prevents weeks of unnecessary reimplementation downstream.
 
 1. Search for established codes in this domain (e.g., LAMMPS for MD, Quantum ESPRESSO for DFT, FORM for symbolic algebra in HEP)
-2. Check official documentation for capabilities and limitations
-3. Search for benchmark comparisons between tools
-4. Verify compatibility with the mathematical framework chosen in 3a
-5. Check the project (`search_files`/`find_files`) for existing implementations or related tools already available
+2. **Search package registries for reusable libraries:**
+   - `web_search "[physics method] python package PyPI [current year]"`
+   - `web_search "[physics method] simulation framework"`
+   - `web_search "[physics method] open source code github"`
+   - For Julia: `web_search "[physics method] julia package"`
+3. Check official documentation for capabilities and limitations
+4. Search for benchmark comparisons between tools
+5. Verify compatibility with the mathematical framework chosen in 3a
+6. Check the project (`search_files`/`find_files`) for existing implementations or related tools already available
+7. **For each candidate package, document in Computational Tools section:**
+   - Name, version, license
+   - What it solves (and what it does not)
+   - Community adoption (citations, stars, active maintenance)
+   - Whether it can be used directly, needs adaptation, or is unsuitable
+   - Installation requirements
 
 ### 3c: Validation and Pitfalls
 

--- a/src/gpd/agents/gpd-planner.md
+++ b/src/gpd/agents/gpd-planner.md
@@ -2129,6 +2129,64 @@ If no conventions exist, the FIRST task in the FIRST plan MUST be establishing t
 If conventions exist, verify compatibility with current phase's needs.
 </step>
 
+<step name="search_existing_packages">
+**Before writing custom code, search for existing packages that solve the computational problem.**
+
+This is the FIRST planning step for any phase involving simulations, numerical methods, or computational tools. Adapting an existing, tested package is almost always faster and more reliable than building from scratch.
+
+**Search protocol:**
+
+1. **Check RESEARCH.md:** The phase researcher should have identified standard computational tools. Start there.
+2. **Search PyPI / conda / Julia registries:**
+   ```bash
+   # Search for relevant packages
+   pip index versions "[candidate-package]" 2>/dev/null || true
+   web_search "[physics method] python package" OR "[physics method] simulation library [current year]"
+   ```
+3. **Check the project itself:**
+   ```bash
+   search_files "[method]" --include="*.py"
+   find_files "*.py" | xargs grep -l "[relevant import]" 2>/dev/null || true
+   ```
+4. **Evaluate candidates** using this decision matrix:
+
+| Criterion | Weight | Evaluate |
+|-----------|--------|----------|
+| **Does it solve the core problem?** | Must-have | Does the package implement the algorithm/method needed? |
+| **Maintained and tested?** | High | Last commit < 1 year, has test suite, CI passing |
+| **Used by the community?** | High | Citations in papers, GitHub stars, PyPI downloads |
+| **Adaptable?** | Medium | Can we extend/modify it for our specific needs? |
+| **Well-documented API?** | Medium | Can the executor use it without reverse-engineering? |
+| **License compatible?** | Must-have | MIT, BSD, Apache, or compatible with project |
+
+**Decision hierarchy (STRICT):**
+
+1. **Use an existing package directly** if it solves the problem -- write a thin wrapper or configuration, not a reimplementation
+2. **Adapt an existing package** (subclass, extend, or fork) if it solves 70%+ of the problem -- modify what is needed, keep the tested core
+3. **Combine existing packages** if the problem decomposes into solved subproblems -- glue code between established tools
+4. **Write custom code ONLY** when no existing package covers the core computation, or when the overhead of adapting exceeds writing from scratch
+
+**Document the decision** in the plan frontmatter:
+
+```yaml
+package_strategy:
+  approach: "use_existing" | "adapt_existing" | "combine_existing" | "custom"
+  packages:
+    - name: "package-name"
+      version: ">=X.Y"
+      role: "core solver / validation / utilities"
+      adaptations: "none / subclass X for Y / patch Z"
+  justification: "Why this approach over alternatives"
+  rejected:
+    - name: "other-package"
+      reason: "Why it was not suitable"
+```
+
+**Anti-pattern:** Planning a from-scratch implementation of a Monte Carlo sampler, ODE integrator, finite element solver, molecular dynamics engine, or other standard computational method when established, tested packages exist. This wastes development time and produces less reliable code.
+
+Skip this step for purely analytical/derivation phases that need no computational tools.
+</step>
+
 <step name="check_computational_environment">
 **Before creating plans, verify that computational tools assumed in the plan are actually available.**
 

--- a/src/gpd/agents/gpd-planner.md
+++ b/src/gpd/agents/gpd-planner.md
@@ -408,19 +408,22 @@ Phase 3+: Domain-specific execution (use domain blueprint)
 **Pattern:** "I want to simulate / compute / measure X numerically"
 
 ```
-Phase 1: Method survey + benchmark identification
+Phase 1: Method survey + EXISTING PACKAGE search + benchmark identification
   → Which numerical methods exist? What are their domains of validity?
+  → Which existing packages implement these methods? (PyPI, conda, Julia, domain-specific codes)
   → What benchmarks exist for validation?
-  → Output: METHODS.md with method comparison matrix
+  → Output: METHODS.md with method comparison matrix AND package candidates
 
 Phase 2: Feasibility assessment + resource estimation
   → Can we reach the required system size / precision / parameter range?
   → How much compute time / memory / storage?
   → Key decision: Is this computationally feasible with available resources?
+  → Key decision: Use existing package, adapt one, or build custom?
   → Output: FEASIBILITY.md with go/no-go recommendation
 
-Phase 3: Benchmark reproduction
+Phase 3: Benchmark reproduction (USING existing package when available)
   → Reproduce a known result with the chosen method before doing anything new
+  → Prefer running the benchmark with an existing package — this validates BOTH the method AND the tool
   → This is NON-NEGOTIABLE — skip it and you won't know if bugs are in your code or your physics
 
 Phase 4+: Domain-specific production (use numerical blueprint)
@@ -429,7 +432,7 @@ Phase 4+: Domain-specific production (use numerical blueprint)
 **Key planning insight:** The feasibility assessment in Phase 2 prevents wasted months. A Monte Carlo study of a sign-problem-affected system, or an exact diagonalization beyond the accessible Hilbert space dimension, should be caught BEFORE Phase 3. Plan the feasibility assessment to produce a quantitative go/no-go with specific resource estimates.
 
 **Decision points:**
-- After Phase 1: Which method? (The method choice constrains everything downstream)
+- After Phase 1: Which method AND which existing package? (Both constrain everything downstream)
 - After Phase 2: Go or pivot? (If infeasible, restructure before investing in code)
 - After Phase 3: Does benchmark pass? (If not, debug before production)
 

--- a/src/gpd/core/patterns.py
+++ b/src/gpd/core/patterns.py
@@ -104,6 +104,7 @@ class PatternCategory(StrEnum):
     NUMERICAL_INSTABILITY = "numerical-instability"
     CONCEPTUAL_ERROR = "conceptual-error"
     DIMENSIONAL_ERROR = "dimensional-error"
+    REDUNDANT_IMPLEMENTATION = "redundant-implementation"
 
 
 class PatternSeverity(StrEnum):
@@ -668,6 +669,39 @@ _BOOTSTRAP_PATTERNS: list[dict[str, object]] = [
         "detection": "Check Euclidean action is bounded below. Verify Euclidean propagator is positive.",
         "prevention": "With (+,-,-,-), rotate k0 -> ik4 counterclockwise. Verify Minkowski -> Euclidean mapping.",
         "tags": ["wick-rotation", "euclidean", "sign", "pole", "analytic-continuation"],
+    },
+    {
+        "domain": "condensed-matter",
+        "category": "redundant-implementation",
+        "severity": "high",
+        "title": "Reimplementing standard simulation methods instead of using existing packages",
+        "slug": "reinventing-simulation-wheel",
+        "domains_extra": ["qft", "stat-mech", "classical", "fluid", "amo", "quantum-info"],
+        "description": (
+            "Writing custom implementations of ODE integrators, Monte Carlo samplers, "
+            "molecular dynamics engines, finite element solvers, or other standard "
+            "computational methods when well-tested packages (SciPy, emcee, LAMMPS, "
+            "FEniCS, QuTiP, etc.) already provide them. Custom code lacks years of "
+            "edge-case handling, optimization, and community testing."
+        ),
+        "detection": (
+            "Check for hand-written Runge-Kutta loops, custom MCMC walkers, manual "
+            "neighbor-list construction, or reimplemented matrix decompositions. "
+            "Search PyPI/conda for existing solutions before accepting custom code."
+        ),
+        "prevention": (
+            "Follow the package preference policy: use existing packages directly, "
+            "adapt them if needed, or combine them. Write custom code only when no "
+            "package covers the required physics and document the justification."
+        ),
+        "tags": [
+            "package-preference",
+            "reuse",
+            "simulation",
+            "reimplementation",
+            "existing-tools",
+            "computational-efficiency",
+        ],
     },
 ]
 

--- a/src/gpd/specs/references/tooling/tool-integration.md
+++ b/src/gpd/specs/references/tooling/tool-integration.md
@@ -13,6 +13,62 @@ This reference is loaded by GPD agents when generating code or recommending comp
 
 ---
 
+## Package Preference Policy
+
+**Principle: Prefer adapting existing packages before writing code from scratch.**
+
+Physics software has decades of accumulated domain knowledge, edge-case handling, and community testing. A custom reimplementation rarely matches the reliability of an established package, and the development time is almost always better spent on the physics.
+
+### Decision Hierarchy
+
+When a computational task arises, follow this order:
+
+1. **Use an existing package directly.** Configure it, call its API, write a thin wrapper. This is the default and requires no justification.
+2. **Adapt an existing package.** Subclass, extend, monkey-patch, or fork. Justified when the package covers 70%+ of the need but lacks a specific feature.
+3. **Combine existing packages.** Write glue code between established tools. Justified when the problem decomposes into subproblems each solved by a different package.
+4. **Write custom code.** Justified ONLY when:
+   - No package implements the required algorithm or physics
+   - The adaptation overhead genuinely exceeds a clean implementation
+   - Performance requirements cannot be met by existing tools
+   - The plan's `package_strategy` frontmatter documents the justification
+
+### Common Domains and Their Standard Packages
+
+| Computational Need | Standard Packages | Do NOT Rewrite |
+|--------------------|-------------------|----------------|
+| ODE/PDE integration | SciPy, DifferentialEquations.jl, FEniCS | Adaptive timesteppers, stiff solvers |
+| Monte Carlo sampling | emcee, PyMC, Stan | MCMC walkers, convergence diagnostics |
+| Molecular dynamics | LAMMPS, OpenMM, GROMACS, ASE | Force field evaluation, neighbor lists, integrators |
+| Quantum dynamics | QuTiP, Qiskit, Cirq | Master equations, state tomography, gate decomposition |
+| Electronic structure | PySCF, Quantum ESPRESSO, VASP | SCF loops, exchange-correlation functionals |
+| Tensor networks | ITensors.jl, TeNPy, quimb | Contraction ordering, DMRG sweeps |
+| Symbolic algebra | SymPy, Mathematica, FORM | Pattern matching, simplification engines |
+| Linear algebra | NumPy/SciPy (LAPACK/BLAS), Eigen | Matrix decompositions, sparse solvers |
+| Fluid dynamics | Dedalus, OpenFOAM, Firedrake | Spectral methods, mesh generation |
+| Lattice field theory | Grid, Chroma, openQCD | Gauge field updates, fermion inversions |
+| N-body / orbital | REBOUND, Gadget, AREPO | Gravity solvers, tree codes, SPH |
+| Statistical analysis | pandas, xarray, uncertainties | Data manipulation, error propagation |
+| Optimization | SciPy, NLopt, Optuna | Constrained optimization, hyperparameter tuning |
+
+### Anti-Patterns
+
+- **Reimplementing a Runge-Kutta integrator** when `scipy.integrate.solve_ivp` exists
+- **Writing a custom MCMC sampler** when `emcee` or `PyMC` handles the problem
+- **Building a molecular dynamics engine** when LAMMPS/OpenMM has the required force fields
+- **Coding matrix diagonalization** when `scipy.linalg.eigh` wraps optimized LAPACK routines
+- **Writing a custom FFT** when `numpy.fft` or `FFTW` exists
+- **Implementing a finite element solver** when FEniCS/Firedrake handles the PDE class
+
+### When Custom Code IS Appropriate
+
+- Novel algorithms not yet in any package (document the novelty)
+- Tight inner loops where Python overhead is prohibitive and no compiled package exists
+- Highly specialized physics with no community package (e.g., novel lattice actions, custom effective potentials)
+- Educational/pedagogical implementations where understanding the algorithm is the goal
+- Prototyping a new method before packaging it
+
+---
+
 ## Python Scientific Stack
 
 - **NumPy/SciPy** -- Numerical linear algebra, integration, optimization, special functions

--- a/tests/core/test_patterns.py
+++ b/tests/core/test_patterns.py
@@ -47,7 +47,7 @@ class TestConstants:
         assert len(VALID_DOMAINS) == 13
 
     def test_categories_count(self):
-        assert len(VALID_CATEGORIES) == 8
+        assert len(VALID_CATEGORIES) == 9
 
     def test_severities_order(self):
         assert VALID_SEVERITIES == ("critical", "high", "medium", "low")


### PR DESCRIPTION
## Summary

Implements RES-539: agents now search for and prefer existing packages before writing custom computational code.

- **Planner agent**: New `search_existing_packages` step with decision matrix, strict hierarchy (use > adapt > combine > custom), and `package_strategy` frontmatter schema. Updated numerical-first discovery strategy to include package search in Phase 1.
- **Executor agent**: Package-first rules for implementation and simulation steps. Updated tool selection guidance to reference the package preference policy.
- **Experiment designer**: New `identify_simulation_framework` step with domain-to-framework reference table. Designs experiments around framework capabilities rather than raw algorithms.
- **Phase researcher**: Expanded computational tools research (step 3b) to include package registry searches and per-package evaluation. Added Package Recommendation section to RESEARCH.md template.
- **Tool integration reference**: Comprehensive Package Preference Policy with decision hierarchy, domain-to-package mapping, anti-patterns, and criteria for when custom code is appropriate.
- **Pattern system**: New `REDUNDANT_IMPLEMENTATION` category and seed pattern for detecting reimplementation of standard computational methods across 7 physics domains.

## Test plan

- [x] All 40 pattern tests pass with new category and seed pattern
- [x] No regressions in core test suite (pre-existing failures unrelated to this PR)
- [ ] Verify planner produces `package_strategy` frontmatter in plans for computational phases
- [ ] Verify researcher includes Package Recommendation section in RESEARCH.md
- [ ] Verify executor checks for existing packages before writing implementation code

Refs: RES-539

🤖 Generated with [Claude Code](https://claude.com/claude-code)