### PR TITLE
[fix] Use Path.replace() for atomic settings overwrite on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Get Physics Done are documented here.
 ## vNEXT
 
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
+- fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.
 
 ## v1.1.0
 

--- a/src/gpd/adapters/install_utils.py
+++ b/src/gpd/adapters/install_utils.py
@@ -902,7 +902,7 @@ def write_settings(settings_path: str | Path, settings: dict[str, object]) -> No
     except PermissionError as exc:
         raise PermissionError(f"Cannot write to settings directory {p.parent} — check permissions") from exc
     try:
-        tmp_path.rename(p)
+        tmp_path.replace(p)
     except OSError:
         tmp_path.unlink(missing_ok=True)
         raise

--- a/tests/test_install_utils_edge.py
+++ b/tests/test_install_utils_edge.py
@@ -1063,9 +1063,9 @@ class TestWriteSettings:
         target = tmp_path / "settings.json"
         target.write_text('{"original": true}', encoding="utf-8")
 
-        # Patch rename to fail
-        with patch.object(Path, "rename", side_effect=OSError("rename failed")):
-            with pytest.raises(OSError, match="rename failed"):
+        # Patch replace to fail (write_settings uses Path.replace for atomic overwrite)
+        with patch.object(Path, "replace", side_effect=OSError("replace failed")):
+            with pytest.raises(OSError, match="replace failed"):
                 write_settings(target, {"new": True})
 
         # Original should be intact (write_text succeeded on .tmp, rename failed)


### PR DESCRIPTION
## Summary

- **Original problem:** `write_settings()` uses the write-to-temp-then-rename pattern for atomic file writes. `Path.rename()` raises `FileExistsError` on Windows when the target already exists (e.g., during reinstall/update), while it atomically overwrites on POSIX.
- **The fix:** Replace `tmp_path.rename(p)` with `tmp_path.replace(p)` at `install_utils.py:905`. `Path.replace()` (`os.replace`) is the documented cross-platform API for atomic file replacement.
- **Why this won't cause additional problems:** `os.replace()` is a strict superset of `os.rename()` — identical behavior on POSIX, plus it handles the existing-target case on Windows. No callers depend on `FileExistsError` from this rename (verified by searching entire codebase). The `except OSError` cleanup handler remains correct.

## Cross-platform safety

- **POSIX/macOS**: `os.replace()` ≡ `os.rename()` — identical atomic overwrite behavior
- **Windows**: Fixes the `FileExistsError` — now atomically overwrites like POSIX

## Test plan

- [x] `uv run ruff check src/gpd/adapters/install_utils.py` — all checks passed
- [x] Targeted adapter tests: 28 previously-failing tests now pass (e.g., `TestUninstall::test_uninstall_cleans_settings`)
- [x] Remaining failures in adapter tests are from unrelated root causes (path separators, shlex.quote, venv paths)