### PR TITLE
fix: prevent catastrophic state reset on empty state.json (FULL-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Get Physics Done are documented here.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.
+- Fix catastrophic state reset: `_normalize_state_schema({})` now emits the integrity sentinel that triggers backup recovery, preventing silent data loss when `state.json` contains an empty object.
 
 ## v1.1.0
 

--- a/src/gpd/core/state.py
+++ b/src/gpd/core/state.py
@@ -1803,8 +1803,12 @@ def _normalize_state_schema(
     project_root: Path | None = None,
 ) -> tuple[dict, list[str]]:
     """Normalize a raw state dict and capture integrity-affecting coercions."""
-    if not raw:
+    if raw is None:
         return default_state_dict(), []
+    if not raw:  # {} case — emit sentinel to trigger backup recovery
+        return default_state_dict(), [
+            "schema normalization: irrecoverable validation failure; reset to defaults"
+        ]
     if not isinstance(raw, dict):
         return default_state_dict(), [f"state root must be an object, got {type(raw).__name__}"]
 

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -527,6 +527,80 @@ def test_normalize_state_schema_irrecoverable_reset_drops_unknown_top_level_keys
     assert any("schema normalization: irrecoverable validation failure; reset to defaults" in issue for issue in issues)
 
 
+def test_normalize_state_schema_empty_dict_emits_reset_sentinel() -> None:
+    """An empty dict {} must emit the irrecoverable-reset sentinel so backup recovery triggers."""
+    normalized, issues = _normalize_state_schema({})
+
+    assert normalized["position"]["progress_percent"] == 0  # got defaults
+    assert any(
+        "schema normalization: irrecoverable validation failure; reset to defaults" in issue
+        for issue in issues
+    )
+
+
+def test_normalize_state_schema_none_returns_defaults_without_issues() -> None:
+    """None input (fresh project) must return clean defaults with no integrity issues."""
+    normalized, issues = _normalize_state_schema(None)
+
+    assert normalized["position"]["progress_percent"] == 0
+    assert issues == []
+
+
+def test_state_validate_recovers_backup_when_primary_is_empty_dict(tmp_path: Path) -> None:
+    """When state.json contains {}, backup recovery must restore the valid backup."""
+    baseline = default_state_dict()
+    # NOTE: current_phase is intentionally left as None (the default).
+    # Setting it to a phase like "07" would trigger state_validate's
+    # filesystem cross-check (state.py lines 4753-4776), which verifies
+    # that a matching phase directory exists under phases_dir.  In a
+    # bare tmp_path that directory does not exist, so the check would
+    # add an issue and make valid=False.  This test targets backup
+    # recovery, not filesystem consistency, so we avoid that path.
+    baseline["open_questions"] = ["Important question"]
+    save_state_json(tmp_path, baseline)
+    save_state_markdown(tmp_path, generate_state_markdown(baseline))
+    layout = ProjectLayout(tmp_path)
+
+    # Corrupt primary to {}, keep backup valid
+    layout.state_json.write_text("{}\n", encoding="utf-8")
+    layout.state_json_backup.write_text(
+        json.dumps(baseline, indent=2) + "\n", encoding="utf-8"
+    )
+
+    validation = state_validate(tmp_path)
+
+    assert validation.valid is True
+    assert validation.integrity_status == "warning"
+    assert any(
+        "state.json root was recovered from state.json.bak" in warning
+        for warning in validation.warnings
+    )
+
+
+def test_mutation_snapshot_graceful_fallback_when_primary_and_backup_are_empty_dict(
+    tmp_path: Path,
+) -> None:
+    """When both state.json and state.json.bak are {}, load must not crash and must return defaults."""
+    recovered_state = default_state_dict()
+    recovered_state["position"]["current_phase"] = "05"
+    recovered_state["position"]["status"] = "Executing"
+    save_state_json(tmp_path, recovered_state)
+    save_state_markdown(tmp_path, generate_state_markdown(recovered_state))
+    layout = ProjectLayout(tmp_path)
+
+    # Corrupt both primary and backup to {}
+    layout.state_json.write_text("{}\n", encoding="utf-8")
+    layout.state_json_backup.write_text("{}\n", encoding="utf-8")
+
+    loaded = _load_state_snapshot_for_mutation(tmp_path)
+
+    # Must not crash; both {} normalize to defaults with sentinel, but
+    # backup recovery does not fire (backup also has sentinel), so the
+    # primary's normalized defaults are returned as-is.
+    assert isinstance(loaded, dict)
+    assert "position" in loaded
+
+
 def test_ensure_state_schema_strips_claim_extra_keys_without_dropping_claim():
     contract = json.loads((FIXTURES_DIR / "project_contract.json").read_text(encoding="utf-8"))
     contract["claims"][0]["notes"] = "harmless"


### PR DESCRIPTION
## Summary

- **Root cause**: `_normalize_state_schema({})` used `if not raw:` which treats `{}` identically to `None`, silently returning defaults with zero integrity issues and bypassing backup recovery.
- **Fix**: Separate `None` and `{}` cases. `None` (fresh project) returns clean defaults. `{}` (corrupted state) emits the irrecoverable-reset sentinel that triggers backup recovery via `_state_reset_issue_present()`.
- **3-line change** in `src/gpd/core/state.py`, 4 new tests in `tests/core/test_state.py`.

## Root Cause

`src/gpd/core/state.py` line 1806 uses `if not raw:` which evaluates True for both `None` and `{}`. When `state.json` contains `{}`, the function returns `default_state_dict(), []` — no integrity issues. The backup recovery mechanism in `_normalize_state_schema_with_backup_project_contract` requires the sentinel issue to trigger, so it never fires. The next mutation overwrites both `state.json` and `state.json.bak` with near-empty defaults, permanently destroying all accumulated state.

## Changes

- `src/gpd/core/state.py`: Changed `if not raw:` to `if raw is None:`, added new `if not raw:` block that emits the sentinel integrity issue for the `{}` case.
- `tests/core/test_state.py`: Added 4 tests — unit tests for `{}` and `None` normalization, integration tests for backup recovery and graceful fallback.
- `CHANGELOG.md`: Added entry under vNEXT.

## Cross-platform Safety

Pure Python logic change. No file I/O, no path handling, no platform-specific behavior. The fix is beneficial on all platforms and neutral for all inputs except `{}`, which was previously a silent data loss path.

## Test Plan

- [x] `test_normalize_state_schema_empty_dict_emits_reset_sentinel` — verifies `{}` emits sentinel
- [x] `test_normalize_state_schema_none_returns_defaults_without_issues` — verifies `None` regression
- [x] `test_state_validate_recovers_backup_when_primary_is_empty_dict` — integration: `{}` + valid backup
- [x] `test_mutation_snapshot_graceful_fallback_when_primary_and_backup_are_empty_dict` — integration: both `{}`
- [x] `test_empty_dict_returns_defaults` (existing) — no regression in `ensure_state_schema({})`
- [x] Full `uv run pytest` passes (7248 passed, 43 skipped, 0 failed)