### PR TITLE
[fix] Add health check cross-validation between state.json results and SUMMARY provides (BUG-010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
-- Add result-consistency health check that cross-validates `state.json` intermediate results against SUMMARY.md `provides` frontmatter and warns on mismatches.
+- Add result-consistency health check that cross-validates `state.json` intermediate results against SUMMARY.md `provides` frontmatter and warns on mismatches, with guards against empty-string false matches, short-string over-matching, and malformed state records.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- Add result-consistency health check that cross-validates `state.json` intermediate results against SUMMARY.md `provides` frontmatter and warns on mismatches.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -813,6 +813,13 @@ def check_checkpoint_tags(cwd: Path) -> HealthCheck:
     return HealthCheck(status=status, label="Checkpoint Tags", details=details, warnings=warnings)
 
 
+# Minimum length for a provides/description string to participate in substring
+# matching.  Strings shorter than this are silently skipped to prevent trivial
+# single-character or two-character values (like "E" or "ds") from matching
+# virtually every result description.
+_MIN_PROVIDES_LENGTH = 3
+
+
 def check_result_consistency(cwd: Path) -> HealthCheck:
     """Cross-validate state.json intermediate_results against SUMMARY provides.
 
@@ -822,7 +829,9 @@ def check_result_consistency(cwd: Path) -> HealthCheck:
 
     Conservative matching: an ``IntermediateResult.description`` is considered
     matched if it appears as an exact case-insensitive substring of any SUMMARY
-    ``provides`` value, or vice-versa.
+    ``provides`` value, or vice-versa.  Strings shorter than
+    ``_MIN_PROVIDES_LENGTH`` are excluded from substring matching to avoid
+    trivial false positives.
     """
     from gpd.core.query import collect_summaries, resolve_field
     from gpd.core.results import result_list
@@ -839,7 +848,19 @@ def check_result_consistency(cwd: Path) -> HealthCheck:
             details={"reason": "no_state"},
         )
 
-    results = result_list(state_obj)
+    # Wrap result_list in try/except — malformed state.json records would
+    # raise PydanticValidationError and crash the entire health-check run.
+    try:
+        results = result_list(state_obj)
+    except PydanticValidationError as exc:
+        return HealthCheck(
+            status=CheckStatus.WARN,
+            label="Result Consistency",
+            details={"error": "malformed_state_results"},
+            warnings=[
+                f"Cannot parse intermediate_results from state.json: {exc}"
+            ],
+        )
     details["state_result_count"] = len(results)
 
     # 2. Collect SUMMARY provides across all phases
@@ -849,12 +870,17 @@ def check_result_consistency(cwd: Path) -> HealthCheck:
         provides_values = resolve_field(entry.frontmatter, "provides")
         for pv in provides_values:
             if isinstance(pv, str):
+                # Guard: skip empty / whitespace-only provides strings.
+                # In Python, "" in "any string" is True, which would
+                # silently suppress all mismatch warnings.
+                if not pv.strip():
+                    continue
                 all_provides.append(pv)
             elif isinstance(pv, dict):
                 # Structured provides: extract "name" or "provides" keys
                 for key in ("name", "provides"):
                     val = pv.get(key)
-                    if isinstance(val, str):
+                    if isinstance(val, str) and val.strip():
                         all_provides.append(val)
 
     details["summary_provides_count"] = len(all_provides)
@@ -868,7 +894,9 @@ def check_result_consistency(cwd: Path) -> HealthCheck:
             continue
         desc_lower = desc.lower()
         matched = any(
-            desc_lower in prov or prov in desc_lower
+            (desc_lower in prov or prov in desc_lower)
+            if len(prov) >= _MIN_PROVIDES_LENGTH and len(desc_lower) >= _MIN_PROVIDES_LENGTH
+            else prov == desc_lower
             for prov in provides_lower
         )
         if not matched:
@@ -884,7 +912,9 @@ def check_result_consistency(cwd: Path) -> HealthCheck:
     for provides_text in all_provides:
         prov_lower = provides_text.lower()
         matched = any(
-            prov_lower in desc or desc in prov_lower
+            (prov_lower in desc or desc in prov_lower)
+            if len(prov_lower) >= _MIN_PROVIDES_LENGTH and len(desc) >= _MIN_PROVIDES_LENGTH
+            else prov_lower == desc
             for desc in result_descriptions_lower
         )
         if not matched:
@@ -2309,6 +2339,7 @@ __all__ = [
     "check_orphans",
     "check_plan_frontmatter",
     "check_project_structure",
+    "check_result_consistency",
     "check_roadmap_consistency",
     "check_state_validity",
     "check_storage_paths",

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -813,6 +813,108 @@ def check_checkpoint_tags(cwd: Path) -> HealthCheck:
     return HealthCheck(status=status, label="Checkpoint Tags", details=details, warnings=warnings)
 
 
+def check_result_consistency(cwd: Path) -> HealthCheck:
+    """Cross-validate state.json intermediate_results against SUMMARY provides.
+
+    Compares the two parallel result registries — ``intermediate_results`` in
+    ``state.json`` (written by ``gpd result add``) and ``provides`` frontmatter
+    in SUMMARY files (written by executor agents) — and warns on mismatches.
+
+    Conservative matching: an ``IntermediateResult.description`` is considered
+    matched if it appears as an exact case-insensitive substring of any SUMMARY
+    ``provides`` value, or vice-versa.
+    """
+    from gpd.core.query import collect_summaries, resolve_field
+    from gpd.core.results import result_list
+
+    warnings: list[str] = []
+    details: dict[str, object] = {}
+
+    # 1. Load state.json intermediate_results
+    state_obj, _state_source = _peek_normalized_state_for_health(cwd)
+    if state_obj is None:
+        return HealthCheck(
+            status=CheckStatus.OK,
+            label="Result Consistency",
+            details={"reason": "no_state"},
+        )
+
+    results = result_list(state_obj)
+    details["state_result_count"] = len(results)
+
+    # 2. Collect SUMMARY provides across all phases
+    summaries = collect_summaries(cwd)
+    all_provides: list[str] = []
+    for entry in summaries:
+        provides_values = resolve_field(entry.frontmatter, "provides")
+        for pv in provides_values:
+            if isinstance(pv, str):
+                all_provides.append(pv)
+            elif isinstance(pv, dict):
+                # Structured provides: extract "name" or "provides" keys
+                for key in ("name", "provides"):
+                    val = pv.get(key)
+                    if isinstance(val, str):
+                        all_provides.append(val)
+
+    details["summary_provides_count"] = len(all_provides)
+    provides_lower = [p.lower() for p in all_provides]
+
+    # 3. Compare: state results with no corresponding SUMMARY provides
+    state_only: list[str] = []
+    for result in results:
+        desc = result.description
+        if not desc:
+            continue
+        desc_lower = desc.lower()
+        matched = any(
+            desc_lower in prov or prov in desc_lower
+            for prov in provides_lower
+        )
+        if not matched:
+            state_only.append(f"{result.id}: {desc}")
+
+    # 4. Compare: SUMMARY provides with no corresponding state result
+    result_descriptions_lower = [
+        (r.description or "").lower()
+        for r in results
+        if r.description
+    ]
+    summary_only: list[str] = []
+    for provides_text in all_provides:
+        prov_lower = provides_text.lower()
+        matched = any(
+            prov_lower in desc or desc in prov_lower
+            for desc in result_descriptions_lower
+        )
+        if not matched:
+            summary_only.append(provides_text)
+
+    details["state_only_count"] = len(state_only)
+    details["summary_only_count"] = len(summary_only)
+
+    if state_only:
+        warnings.append(
+            f"{len(state_only)} state.json result(s) with no matching SUMMARY provides: "
+            + "; ".join(state_only[:5])
+            + (" ..." if len(state_only) > 5 else "")
+        )
+    if summary_only:
+        warnings.append(
+            f"{len(summary_only)} SUMMARY provides with no matching state.json result: "
+            + "; ".join(summary_only[:5])
+            + (" ..." if len(summary_only) > 5 else "")
+        )
+
+    status = CheckStatus.WARN if warnings else CheckStatus.OK
+    return HealthCheck(
+        status=status,
+        label="Result Consistency",
+        details=details,
+        warnings=warnings,
+    )
+
+
 # ─── Auto-Fix ────────────────────────────────────────────────────────────────
 
 
@@ -942,6 +1044,7 @@ _ALL_CHECKS: list[tuple[str, object]] = [
     ("config", check_config),
     ("checkpoint_tags", check_checkpoint_tags),
     ("git_status", check_git_status),
+    ("result_consistency", check_result_consistency),
 ]
 
 
@@ -982,6 +1085,7 @@ def run_health(cwd: Path, *, fix: bool = False) -> HealthReport:
                     "config": "Config",
                     "checkpoint_tags": "Checkpoint Tags",
                     "git_status": "Git Status",
+                    "result_consistency": "Result Consistency",
                 }
                 for name, check_fn in _ALL_CHECKS:
                     label = check_labels[name]

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -2725,3 +2725,203 @@ class TestCheckResultConsistency:
         assert result.details["state_only_count"] == 1
         assert result.details["summary_only_count"] == 1
         assert len(result.warnings) == 2
+
+    # ── SERIOUS #1: Empty-string provides must not match everything ────────
+
+    def test_empty_provides_string_does_not_match_everything(
+        self, tmp_path: Path
+    ) -> None:
+        """An empty provides value must NOT suppress all state-only warnings.
+
+        In Python, ``"" in "any string"`` is ``True``. Without a guard, a
+        single ``""`` in provides would silently match every result description.
+        """
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "critical measurement of g-factor", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        phase_dir = planning / "phases" / "01-setup"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "SUMMARY.md").write_text(
+            '---\nprovides:\n  - ""\n---\n# Summary\n', encoding="utf-8"
+        )
+        result = check_result_consistency(tmp_path)
+        # The empty provides must be ignored, so R-01 should be state-only.
+        assert result.status == CheckStatus.WARN
+        assert result.details["state_only_count"] == 1
+        # The empty provides itself must be excluded from all_provides.
+        assert result.details["summary_provides_count"] == 0
+
+    def test_whitespace_only_provides_string_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        """Whitespace-only provides like ``"   "`` must be treated like empty."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "mass renormalization", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        phase_dir = planning / "phases" / "01-setup"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "SUMMARY.md").write_text(
+            '---\nprovides:\n  - "   "\n---\n# Summary\n', encoding="utf-8"
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["summary_provides_count"] == 0
+
+    # ── SERIOUS #2: Malformed state.json records ──────────────────────────
+
+    def test_malformed_state_results_returns_warn_not_crash(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If result_list raises PydanticValidationError (e.g., from a
+        malformed intermediate_results record that somehow bypassed state
+        normalization), the health check must return WARN, not crash.
+
+        In practice, _peek_normalized_state_for_health already strips
+        malformed records, so we monkeypatch result_list to simulate the
+        failure path.
+        """
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        (planning / "state.json").write_text(
+            json.dumps({"intermediate_results": [{"id": "R-01", "description": "valid"}]}),
+            encoding="utf-8",
+        )
+
+        def _boom(state, **kw):  # type: ignore[override]
+            from gpd.core.results import IntermediateResult
+            # Force a real PydanticValidationError
+            IntermediateResult(**{"description": "no id"})
+
+        monkeypatch.setattr("gpd.core.results.result_list", _boom)
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details.get("error") == "malformed_state_results"
+        assert any("Cannot parse" in w for w in result.warnings)
+
+    def test_normalization_already_strips_malformed_records(
+        self, tmp_path: Path
+    ) -> None:
+        """Verify that state-loading normalization strips malformed records
+        (missing ``id``), so result_list sees only valid records and returns OK."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        (planning / "state.json").write_text(
+            json.dumps({"intermediate_results": [{"description": "no id field here"}]}),
+            encoding="utf-8",
+        )
+        result = check_result_consistency(tmp_path)
+        # Normalization drops the bad record; no crash, no warning.
+        assert result.status == CheckStatus.OK
+        assert result.details["state_result_count"] == 0
+
+    # ── WARNING #3: Short-string over-matching ────────────────────────────
+
+    def test_short_provides_do_not_match_via_substring(
+        self, tmp_path: Path
+    ) -> None:
+        """Provides shorter than _MIN_PROVIDES_LENGTH must not substring-match;
+        they should only exact-match (case-insensitive)."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "energy spectrum", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        phase_dir = planning / "phases" / "01-setup"
+        phase_dir.mkdir(parents=True)
+        # "E" is too short to match "energy spectrum" via substring.
+        (phase_dir / "SUMMARY.md").write_text(
+            "---\nprovides:\n  - E\n---\n# Summary\n", encoding="utf-8"
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["state_only_count"] == 1
+
+    def test_short_provides_exact_match_still_works(
+        self, tmp_path: Path
+    ) -> None:
+        """A short provides string should still match if it is an exact
+        case-insensitive match for a result description."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "ds", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        phase_dir = planning / "phases" / "01-setup"
+        phase_dir.mkdir(parents=True)
+        (phase_dir / "SUMMARY.md").write_text(
+            "---\nprovides:\n  - ds\n---\n# Summary\n", encoding="utf-8"
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_only_count"] == 0
+
+    # ── MINOR #6: Structured provides with "provides" key ────────────────
+
+    def test_structured_provides_with_provides_key(
+        self, tmp_path: Path
+    ) -> None:
+        """Structured provides dicts with a ``provides`` key (not ``name``)
+        should have their value extracted and matched."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "holographic entanglement entropy", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        (phase_dir / "SUMMARY.md").write_text(
+            "---\nprovides:\n  - provides: holographic entanglement entropy\n---\n# Summary\n",
+            encoding="utf-8",
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_only_count"] == 0
+
+    def test_structured_provides_with_empty_name_is_ignored(
+        self, tmp_path: Path
+    ) -> None:
+        """Structured provides dict with empty ``name`` must be skipped."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+        state = {
+            "intermediate_results": [
+                {"id": "R-01", "description": "Witten diagram", "phase": "01"},
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+        (phase_dir / "SUMMARY.md").write_text(
+            '---\nprovides:\n  - name: ""\n---\n# Summary\n',
+            encoding="utf-8",
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["summary_provides_count"] == 0

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -38,6 +38,7 @@ from gpd.core.health import (
     check_orphans,
     check_plan_frontmatter,
     check_project_structure,
+    check_result_consistency,
     check_roadmap_consistency,
     check_state_validity,
     check_storage_paths,
@@ -2465,3 +2466,262 @@ class TestCheckLatestReturn:
         assert result.status == CheckStatus.FAIL
         assert "tasks_completed not a number" in result.issues[0] or "tasks_completed not a number" in " ".join(result.issues)
         assert "tasks_total not a number" in " ".join(result.issues)
+
+
+class TestCheckResultConsistency:
+    """Tests for the result-consistency health check."""
+
+    def test_no_state_returns_ok(self, tmp_path: Path) -> None:
+        """When state.json is absent, the check should gracefully return OK."""
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details.get("reason") == "no_state"
+
+    def test_empty_results_and_no_summaries_returns_ok(self, tmp_path: Path) -> None:
+        """When both registries are empty, there is nothing to mismatch."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "state.json").write_text(
+            json.dumps({"intermediate_results": []}),
+            encoding="utf-8",
+        )
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_result_count"] == 0
+        assert result.details["summary_provides_count"] == 0
+
+    def test_matching_results_returns_ok(self, tmp_path: Path) -> None:
+        """When descriptions and provides match, check should return OK."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "Hamiltonian eigenvalues",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - Hamiltonian eigenvalues\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_result_count"] == 1
+        assert result.details["summary_provides_count"] == 1
+        assert result.details["state_only_count"] == 0
+        assert result.details["summary_only_count"] == 0
+
+    def test_state_only_result_warns(self, tmp_path: Path) -> None:
+        """A result in state.json with no SUMMARY provides should warn."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "partition function",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["state_only_count"] == 1
+        assert any("state.json result" in w for w in result.warnings)
+
+    def test_summary_only_provides_warns(self, tmp_path: Path) -> None:
+        """A SUMMARY provides with no state.json result should warn."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {"intermediate_results": []}
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - correlation function\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["summary_only_count"] == 1
+        assert any("SUMMARY provides" in w for w in result.warnings)
+
+    def test_substring_match_is_accepted(self, tmp_path: Path) -> None:
+        """Substring matching should link related descriptions and provides."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "energy spectrum",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        # provides is a superset string containing the description
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - full energy spectrum for ground state\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_only_count"] == 0
+        assert result.details["summary_only_count"] == 0
+
+    def test_case_insensitive_matching(self, tmp_path: Path) -> None:
+        """Matching should be case-insensitive."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "Green Function",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - green function\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+
+    def test_structured_provides_with_name_key(self, tmp_path: Path) -> None:
+        """Structured provides entries with 'name' key should be extracted."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "dispersion relation",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - name: dispersion relation\n"
+            "    format: equation\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_only_count"] == 0
+        assert result.details["summary_only_count"] == 0
+
+    def test_results_without_description_are_skipped(self, tmp_path: Path) -> None:
+        """Results without descriptions should not cause false warnings."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        (planning / "phases").mkdir()
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "equation": "E = mc^2",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.OK
+        assert result.details["state_only_count"] == 0
+
+    def test_both_directions_mismatch(self, tmp_path: Path) -> None:
+        """Both state-only and summary-only mismatches should appear."""
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        phases = planning / "phases"
+        phase_dir = phases / "01-setup"
+        phase_dir.mkdir(parents=True)
+
+        state = {
+            "intermediate_results": [
+                {
+                    "id": "R-01-01",
+                    "description": "free energy",
+                    "phase": "01",
+                },
+            ],
+        }
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        summary_content = (
+            "---\n"
+            "provides:\n"
+            "  - scattering amplitude\n"
+            "---\n"
+            "# Summary\n"
+        )
+        (phase_dir / "SUMMARY.md").write_text(summary_content, encoding="utf-8")
+
+        result = check_result_consistency(tmp_path)
+        assert result.status == CheckStatus.WARN
+        assert result.details["state_only_count"] == 1
+        assert result.details["summary_only_count"] == 1
+        assert len(result.warnings) == 2


### PR DESCRIPTION
## Summary

- **Original problem:** GPD has two parallel result registries — `state.json intermediate_results` (written by `gpd result add`) and SUMMARY.md `provides` frontmatter (written by executor agents). There is zero cross-validation between them. Users running `gpd result list` and `gpd query search` get completely different answers for the same project.

- **The fix:** Adds a new health check `check_result_consistency()` (~100 lines) that compares the two systems and warns on mismatches. Reports results in state.json with no corresponding SUMMARY provides, and vice versa. Uses conservative matching (case-insensitive substring with minimum length threshold) to avoid false positives.

- **Why this won't cause additional problems:** Read-only analysis — queries both systems, never writes or modifies either. Plugs into the existing `HealthCheck` model and `_ALL_CHECKS` registration pattern. Reports at WARN level (not FAIL). Projects where the two systems agree pass silently. Empty/whitespace provides are excluded. Short strings (< 3 chars) require exact match to prevent over-matching. Malformed state.json records are caught gracefully.

## Changes

- `src/gpd/core/health.py`: New `check_result_consistency()` function + registration
- `tests/core/test_health.py`: 18 new tests covering matching logic, edge cases (empty strings, short strings, malformed records, structured provides)
- `CHANGELOG.md`: vNEXT entry

## Test plan

- [x] `uv run ruff check src/gpd/core/health.py` — all checks passed
- [x] `uv run pytest tests/core/test_health.py` — 106 passed
- [x] Full suite: 7242 passed, 43 skipped, 0 failed
- [x] Adversarial audit: 0 FATAL / 0 SERIOUS / 0 WARNING / 0 MINOR (2 rounds)