### PR TITLE
fix: correct approximation/uncertainty add syntax in agent docs (FULL-002a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Get Physics Done are documented here.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.
+- Fix agent docs: `approximation add` and `uncertainty add` use positional arguments, not `--name`/`--quantity` flags (agent-infrastructure.md, sensitivity-analysis.md, error-propagation.md).
 
 ## v1.1.0
 

--- a/src/gpd/specs/references/orchestration/agent-infrastructure.md
+++ b/src/gpd/specs/references/orchestration/agent-infrastructure.md
@@ -480,12 +480,12 @@ Track approximations, uncertainties, open questions, and active calculations:
 
 ```bash
 # Approximation tracking
-gpd approximation add --name "<name>" [--validity-range "<range>"] [--controlling-param "<param>"] [--current-value "<val>"] [--status "<status>"]
+gpd approximation add "<name>" [--validity-range "<range>"] [--controlling-param "<param>"] [--current-value "<val>"] [--status "<status>"]
 gpd approximation list
 gpd approximation check
 
 # Uncertainty tracking
-gpd uncertainty add --quantity "<quantity>" [--value "<value>"] [--uncertainty "<uncertainty>"] [--phase "<N>"] [--method "<method>"]
+gpd uncertainty add "<quantity>" [--value "<value>"] [--uncertainty "<uncertainty>"] [--phase "<N>"] [--method "<method>"]
 gpd uncertainty list
 
 # Open question tracking (positional text args)

--- a/src/gpd/specs/workflows/error-propagation.md
+++ b/src/gpd/specs/workflows/error-propagation.md
@@ -311,8 +311,8 @@ Save to: `${target_phase_dir}/ERROR-BUDGET.md`.
 Add the final result with error bars to `propagated_uncertainties` in state.json:
 
 ```bash
-gpd uncertainty add \
-  --quantity "{symbol}" --value "{central_value}" \
+gpd uncertainty add "{symbol}" \
+  --value "{central_value}" \
   --uncertainty "{delta}" --phase "{phase}" --method "error-propagation"
 ```
 

--- a/src/gpd/specs/workflows/sensitivity-analysis.md
+++ b/src/gpd/specs/workflows/sensitivity-analysis.md
@@ -524,8 +524,8 @@ Save to:
 Update `propagated_uncertainties` via the CLI (which properly syncs STATE.md and state.json):
 
 ```bash
-gpd uncertainty add \
-  --quantity "{target quantity}" --value "{nominal_value}" \
+gpd uncertainty add "{target quantity}" \
+  --value "{nominal_value}" \
   --uncertainty "{total_uncertainty}" --phase "{phase}" --method "sensitivity-analysis"
 ```
 
@@ -533,13 +533,13 @@ Run this for the target quantity and for each parameter whose sensitivity-derive
 
 ```bash
 # Target quantity
-gpd uncertainty add \
-  --quantity "{symbol}" --value "{f_nominal}" \
+gpd uncertainty add "{symbol}" \
+  --value "{f_nominal}" \
   --uncertainty "{delta_f}" --phase "${phase_number}" --method "sensitivity-analysis"
 
 # Dominant parameter contribution (if separately tracked)
-gpd uncertainty add \
-  --quantity "{symbol}_from_{dominant_param}" --value "{delta_f_dominant}" \
+gpd uncertainty add "{symbol}_from_{dominant_param}" \
+  --value "{delta_f_dominant}" \
   --uncertainty "{delta_f_dominant}" --phase "${phase_number}" --method "sensitivity-analysis"
 ```
 

--- a/tests/core/test_research_phase_stage_manifest.py
+++ b/tests/core/test_research_phase_stage_manifest.py
@@ -65,7 +65,7 @@ def test_research_phase_prompt_budget_keeps_the_vertical_reasonably_tight() -> N
 
     assert agent_metrics.raw_include_count == 0
     assert agent_metrics.expanded_line_count == 2028
-    assert agent_metrics.expanded_char_count == 101134
+    assert agent_metrics.expanded_char_count == 101116
     assert agent_metrics.expanded_char_count < 130000
     assert command_metrics.raw_include_count == 2
     assert command_metrics.expanded_line_count == 421


### PR DESCRIPTION
## Summary

- Agent docs incorrectly show `--name` and `--quantity` as flags for `gpd approximation add` and `gpd uncertainty add`, but the CLI declares them as positional arguments (`typer.Argument`).
- Agents following these docs silently lose data: `--name "Large-N"` is not a recognized option, so Typer ignores it and `name` defaults to `None`.
- Fixed 6 instances across 3 spec files. Updated prompt budget snapshot test.

## Changes

- `src/gpd/specs/references/orchestration/agent-infrastructure.md`: Fixed `approximation add` (line 483) and `uncertainty add` (line 488) syntax
- `src/gpd/specs/workflows/sensitivity-analysis.md`: Fixed 3 `uncertainty add` invocations (lines 527, 536, 541)
- `src/gpd/specs/workflows/error-propagation.md`: Fixed 1 `uncertainty add` invocation (line 314)
- `tests/core/test_research_phase_stage_manifest.py`: Updated `expanded_char_count` snapshot (101134 -> 101116, 18-char reduction from removing `--name`/`--quantity` flags in agent-infrastructure.md which is included in the phase-researcher prompt)
- `CHANGELOG.md`: Added entry under vNEXT

## Verification

- Confirmed CLI declarations: `cli.py:4650` (`name: str | None = typer.Argument(None, ...)`) and `cli.py:4705` (`quantity: str | None = typer.Argument(None, ...)`)
- Exhaustive search: `grep -rn 'gpd (approximation|uncertainty) add --(name|quantity)' src/gpd/specs/` returns zero matches after fix

## Test Plan

- [x] Full `uv run pytest`: 7234 passed, 43 skipped, 0 failed