### PR TITLE
fix: accept integer/float values in depends_on frontmatter (FULL-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Get Physics Done are documented here.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.
 - Fix catastrophic state reset: `_normalize_state_schema({})` now emits the integrity sentinel that triggers backup recovery, preventing silent data loss when `state.json` contains an empty object.
+- Accept integer and float values in `depends_on` and `files_modified` frontmatter lists by coercing them to strings during validation.
 
 ## v1.1.0
 

--- a/src/gpd/core/frontmatter.py
+++ b/src/gpd/core/frontmatter.py
@@ -1187,7 +1187,11 @@ def _unsupported_frontmatter_errors(schema_name: str, meta: dict[str, object]) -
 
 
 def _validate_non_empty_string_list_field(meta: dict[str, object], field_name: str, errors: list[str]) -> None:
-    """Append validation errors when a field is not a list of non-empty strings."""
+    """Append validation errors when a field is not a list of non-empty strings.
+
+    Integer and float values are coerced to strings in-place so that
+    YAML ``depends_on: [5]`` (parsed as ``[5]``) is accepted.
+    """
     if field_name not in meta:
         return
     value = meta.get(field_name)
@@ -1195,6 +1199,9 @@ def _validate_non_empty_string_list_field(meta: dict[str, object], field_name: s
         errors.append(f"{field_name}: expected a list")
         return
     for index, item in enumerate(value):
+        if isinstance(item, (int, float)) and not isinstance(item, bool):
+            value[index] = str(item)
+            item = value[index]
         if not isinstance(item, str) or not item.strip():
             errors.append(f"{field_name}: entry {index} must be a non-empty string")
 

--- a/tests/core/test_frontmatter.py
+++ b/tests/core/test_frontmatter.py
@@ -1281,7 +1281,8 @@ class TestValidateFrontmatter:
         assert result.valid is False
         assert any(error.startswith("must_haves:") for error in result.errors)
 
-    def test_summary_rejects_non_string_provides_entries(self):
+    def test_summary_coerces_integer_provides_entries(self):
+        """Integer provides entries are coerced to strings (FULL-019)."""
         content = (
             "---\n"
             "phase: 01\n"
@@ -1290,6 +1291,23 @@ class TestValidateFrontmatter:
             "provides:\n"
             "  - solver\n"
             "  - 12\n"
+            "completed: 2025-01-01\n"
+            "---\n\nBody."
+        )
+        result = validate_frontmatter(content, "summary")
+
+        assert "provides: entry 1 must be a non-empty string" not in result.errors
+
+    def test_summary_rejects_non_coercible_provides_entries(self):
+        """Boolean provides entries are still rejected (not coerced)."""
+        content = (
+            "---\n"
+            "phase: 01\n"
+            "plan: 01\n"
+            "depth: standard\n"
+            "provides:\n"
+            "  - solver\n"
+            "  - true\n"
             "completed: 2025-01-01\n"
             "---\n\nBody."
         )
@@ -2844,3 +2862,38 @@ class TestSelfCheckRegexBoundaries:
         from gpd.core.frontmatter import _SELF_CHECK_PASS
 
         assert _SELF_CHECK_PASS.search("compass") is None
+
+
+# ─── FULL-019: depends_on integer coercion ───────────────────────────────────
+
+
+def test_validate_non_empty_string_list_field_coerces_integers():
+    """FULL-019: depends_on: [5] should be accepted after int-to-str coercion."""
+    from gpd.core.frontmatter import _validate_non_empty_string_list_field
+
+    meta: dict[str, object] = {"depends_on": [5, "PLAN-02"]}
+    errors: list[str] = []
+    _validate_non_empty_string_list_field(meta, "depends_on", errors)
+    assert errors == []
+    assert meta["depends_on"] == ["5", "PLAN-02"]
+
+
+def test_validate_non_empty_string_list_field_rejects_bool():
+    """Booleans must not be coerced (isinstance(True, int) is True in Python)."""
+    from gpd.core.frontmatter import _validate_non_empty_string_list_field
+
+    meta: dict[str, object] = {"depends_on": [True]}
+    errors: list[str] = []
+    _validate_non_empty_string_list_field(meta, "depends_on", errors)
+    assert len(errors) == 1
+
+
+def test_validate_non_empty_string_list_field_coerces_float():
+    """Float phase numbers like 72.1 (decimal phases) should be coerced."""
+    from gpd.core.frontmatter import _validate_non_empty_string_list_field
+
+    meta: dict[str, object] = {"depends_on": [72.1]}
+    errors: list[str] = []
+    _validate_non_empty_string_list_field(meta, "depends_on", errors)
+    assert errors == []
+    assert meta["depends_on"] == ["72.1"]


### PR DESCRIPTION
## Summary

- `depends_on: [5]` in PLAN.md frontmatter fails validation because YAML parses bare numbers as integers, but the validator requires strings.
- Now `_validate_non_empty_string_list_field` coerces `int`/`float` entries to strings in-place before checking. Booleans are excluded (`isinstance(True, int)` is True in Python).

## Root Cause

`frontmatter.py:1198` checks `isinstance(item, str)` which rejects YAML-parsed integers. YAML `depends_on: [5]` becomes `[5]` (int), not `["5"]` (str).

## Changes

- `src/gpd/core/frontmatter.py`: Added int/float-to-string coercion in `_validate_non_empty_string_list_field`, with bool exclusion.
- `tests/core/test_frontmatter.py`: 3 new tests (integer coercion, bool rejection, float coercion) + updated existing test that expected integer rejection to expect coercion instead.
- `CHANGELOG.md`: Added entry under vNEXT.

## Cross-platform Safety

Pure Python type check and string coercion. No file I/O or platform-specific behavior.

## Test Plan

- [x] `test_validate_non_empty_string_list_field_coerces_integers`
- [x] `test_validate_non_empty_string_list_field_rejects_bool`
- [x] `test_validate_non_empty_string_list_field_coerces_float`
- [x] `test_summary_coerces_integer_provides_entries` (updated from rejection test)
- [x] `test_summary_rejects_non_coercible_provides_entries` (new, booleans)
- [x] Full `uv run pytest`: 7284 passed, 43 skipped, 0 failed