### PR TITLE
[fix] Add citation-bibliography coherence check and broaden natbib support (BUG-076)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- Broaden citation regexes to detect natbib (`\citep`, `\citet`, `\citealt`, `\citealp`, `\citeauthor`, `\citeyear`, `\citetext`), capitalized (`\Cite*`), starred (`\cite*`), and biblatex (`\parencite`, `\textcite`, `\autocite`) variants across the paper-quality scorer and artifact builder. Add `check_citation_bib_coherence()` to `build_paper()` to warn when `.tex` citations and `.bib` entries are inconsistent, with `\nocite{*}` support.
 - Add result-consistency health check that cross-validates `state.json` intermediate results against SUMMARY.md `provides` frontmatter and warns on mismatches, with guards against empty-string false matches, short-string over-matching, and malformed state records.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.

--- a/src/gpd/core/paper_quality.py
+++ b/src/gpd/core/paper_quality.py
@@ -702,16 +702,38 @@ def score_paper_quality(data: PaperQualityInput) -> PaperQualityReport:
 
 _PLACEHOLDER_FINDING_RE = re.compile(r"\b(TODO|FIXME|PENDING|TBD|XXX)\b")
 
-# Matches all standard LaTeX/natbib/biblatex citation commands (including
+# Matches in-text LaTeX/natbib/biblatex citation commands (including
 # starred variants like \cite*{} and capitalized sentence-start forms).
+# Used by the quality scorer (paper_quality_artifacts.py) and draft lint.
+#
 # Lowercase: \cite, \citep, \citet, \citealt, \citealp, \citeauthor,
-#   \citeyear, \citetext, \nocite
+#   \citeyear
 # Capitalized: \Cite, \Citep, \Citet, \Citealt, \Citealp, \Citeauthor,
 #   \Citeyear
 # Biblatex: \parencite, \textcite, \autocite
+#
+# NOTE: \nocite is intentionally excluded — it does not represent an
+# in-text citation and must not inflate quality scores.  The coherence
+# checker uses _CITE_CMD_PREFIX_WITH_NOCITE instead.
+# NOTE: \citetext is intentionally excluded — it wraps other citation
+# commands (e.g. \citetext{see \citealp{a}; compare \citealp{b}}) and
+# the non-brace-aware regex \{([^}]*)\} truncates at the first inner
+# ``}``, producing garbage keys.  The inner \citealp commands are
+# already matched individually.
 _CITE_CMD_PREFIX = (
     r"\\(?:"
-    r"cite(?:p|t|alt|alp|author|year|text)?\*?"
+    r"cite(?:p|t|alt|alp|author|year)?\*?"
+    r"|Cite(?:p|t|alt|alp|author|year)?\*?"
+    r"|parencite|textcite|autocite"
+    r")"
+)
+
+# Extended prefix that additionally matches \nocite — used ONLY by the
+# citation-bibliography coherence checker in compiler.py where \nocite
+# keys need to be cross-referenced against the .bib file.
+_CITE_CMD_PREFIX_WITH_NOCITE = (
+    r"\\(?:"
+    r"cite(?:p|t|alt|alp|author|year)?\*?"
     r"|Cite(?:p|t|alt|alp|author|year)?\*?"
     r"|nocite"
     r"|parencite|textcite|autocite"

--- a/src/gpd/core/paper_quality.py
+++ b/src/gpd/core/paper_quality.py
@@ -701,8 +701,25 @@ def score_paper_quality(data: PaperQualityInput) -> PaperQualityReport:
 
 
 _PLACEHOLDER_FINDING_RE = re.compile(r"\b(TODO|FIXME|PENDING|TBD|XXX)\b")
-_MISSING_CITE_FINDING_RE = re.compile(r"\\cite\{MISSING:")
-_EMPTY_CITE_FINDING_RE = re.compile(r"\\cite\{\s*\}")
+
+# Matches all standard LaTeX/natbib/biblatex citation commands (including
+# starred variants like \cite*{} and capitalized sentence-start forms).
+# Lowercase: \cite, \citep, \citet, \citealt, \citealp, \citeauthor,
+#   \citeyear, \citetext, \nocite
+# Capitalized: \Cite, \Citep, \Citet, \Citealt, \Citealp, \Citeauthor,
+#   \Citeyear
+# Biblatex: \parencite, \textcite, \autocite
+_CITE_CMD_PREFIX = (
+    r"\\(?:"
+    r"cite(?:p|t|alt|alp|author|year|text)?\*?"
+    r"|Cite(?:p|t|alt|alp|author|year)?\*?"
+    r"|nocite"
+    r"|parencite|textcite|autocite"
+    r")"
+)
+
+_MISSING_CITE_FINDING_RE = re.compile(_CITE_CMD_PREFIX + r"(?:\[[^\]]*\])*\{MISSING:")
+_EMPTY_CITE_FINDING_RE = re.compile(_CITE_CMD_PREFIX + r"(?:\[[^\]]*\])*\{\s*\}")
 _EMPTY_REF_FINDING_RE = re.compile(r"\\ref\{\s*\}")
 _EMPTY_LABEL_FINDING_RE = re.compile(r"\\label\{\s*\}")
 _LABEL_FINDING_RE = re.compile(r"\\label\{([^}]+)\}")

--- a/src/gpd/core/paper_quality_artifacts.py
+++ b/src/gpd/core/paper_quality_artifacts.py
@@ -30,6 +30,7 @@ from gpd.core.frontmatter import (
 )
 from gpd.core.manuscript_artifacts import locate_publication_artifact, resolve_current_manuscript_resolution
 from gpd.core.paper_quality import (
+    _CITE_CMD_PREFIX,
     BinaryCheck,
     CitationsQualityInput,
     CompletenessQualityInput,
@@ -49,7 +50,7 @@ __all__ = ["build_paper_quality_input"]
 
 
 _PLACEHOLDER_RE = re.compile(r"TODO|FIXME|PENDING|TBD|\\text\{\[PENDING\]\}")
-_MISSING_CITE_RE = re.compile(r"\\cite\{MISSING:")
+_MISSING_CITE_RE = re.compile(_CITE_CMD_PREFIX + r"(?:\[[^\]]*\])*\{MISSING:")
 _ABSTRACT_RE = re.compile(
     r"(\\begin\{abstract\}[\s\S]*?\\end\{abstract\}|^\s{0,3}#{1,6}\s*abstract\b)",
     re.IGNORECASE | re.MULTILINE,
@@ -63,7 +64,7 @@ _CONCLUSION_RE = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 _SUPPLEMENT_RE = re.compile(r"appendix|supplement", re.IGNORECASE)
-_CITE_RE = re.compile(r"\\cite\{([^}]*)\}")
+_CITE_RE = re.compile(_CITE_CMD_PREFIX + r"(?:\[[^\]]*\])*\{([^}]*)\}")
 _BIB_ENTRY_RE = re.compile(r"@\w+\s*\{\s*([^,\s]+)\s*,")
 _DERIVATION_ARTIFACT_RE = re.compile(r"(?i)^derivation-(?!state\.).+\.(?:md|markdown|tex|py)$")
 _DERIVATION_ARTIFACT_SUFFIXES = (".md", ".markdown", ".tex", ".py")

--- a/src/gpd/mcp/paper/compiler.py
+++ b/src/gpd/mcp/paper/compiler.py
@@ -322,10 +322,10 @@ def check_citation_bib_coherence(
     Handles ``\\nocite{*}`` (standard LaTeX: all bib entries are considered
     referenced).  Splits multi-key citations (``\\cite{a,b,c}``).
     """
-    from gpd.core.paper_quality import _CITE_CMD_PREFIX
+    from gpd.core.paper_quality import _CITE_CMD_PREFIX_WITH_NOCITE
 
     all_cite_re = re.compile(
-        _CITE_CMD_PREFIX
+        _CITE_CMD_PREFIX_WITH_NOCITE
         + r"(?:\[[^\]]*\])*"  # optional [] arguments (natbib)
         + r"\{([^}]*)\}"  # capture the key list
     )
@@ -847,6 +847,10 @@ async def build_paper(
     tex_path = output_dir / f"{output_stem}.tex"
     if tex_path.exists():
         logger.warning("Skipping .tex write — %s already exists. Delete it to regenerate.", tex_path)
+        # BUG-076 fix: read on-disk content so the coherence check audits
+        # the file that will actually be compiled, not the freshly rendered
+        # string which may differ after manual edits or scaffold-once reruns.
+        tex_content = await asyncio.to_thread(tex_path.read_text, encoding="utf-8")
     else:
         await asyncio.to_thread(tex_path.write_text, tex_content, encoding="utf-8")
 

--- a/src/gpd/mcp/paper/compiler.py
+++ b/src/gpd/mcp/paper/compiler.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 import os
 import platform
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -276,6 +277,120 @@ def _reference_bibtex_keys_from_audit(audit: BibliographyAudit | None) -> dict[s
         if entry.reference_id:
             reference_bibtex_keys[entry.reference_id] = entry.key
     return reference_bibtex_keys
+
+
+class CitationCoherenceResult:
+    """Result of comparing .tex citations against .bib entries."""
+
+    __slots__ = (
+        "tex_cite_keys",
+        "bib_entry_keys",
+        "unreferenced_bib_keys",
+        "unresolved_cite_keys",
+        "warnings",
+    )
+
+    def __init__(
+        self,
+        tex_cite_keys: set[str],
+        bib_entry_keys: set[str],
+        unreferenced_bib_keys: set[str],
+        unresolved_cite_keys: set[str],
+        warnings: list[str],
+    ) -> None:
+        self.tex_cite_keys = tex_cite_keys
+        self.bib_entry_keys = bib_entry_keys
+        self.unreferenced_bib_keys = unreferenced_bib_keys
+        self.unresolved_cite_keys = unresolved_cite_keys
+        self.warnings = warnings
+
+
+_NOCITE_STAR_RE = re.compile(r"\\nocite\{\s*\*\s*\}")
+_BIB_KEY_RE = re.compile(r"@\w+\s*\{\s*([^,\s]+)\s*,")
+
+
+def check_citation_bib_coherence(
+    tex_content: str,
+    bib_content: str,
+) -> CitationCoherenceResult:
+    """Compare citation commands in rendered .tex against entries in .bib.
+
+    Operates on in-memory strings only -- no disk I/O.  Designed to run
+    inside ``build_paper()`` between the TeX render step and the artifact
+    manifest step.
+
+    Handles ``\\nocite{*}`` (standard LaTeX: all bib entries are considered
+    referenced).  Splits multi-key citations (``\\cite{a,b,c}``).
+    """
+    from gpd.core.paper_quality import _CITE_CMD_PREFIX
+
+    all_cite_re = re.compile(
+        _CITE_CMD_PREFIX
+        + r"(?:\[[^\]]*\])*"  # optional [] arguments (natbib)
+        + r"\{([^}]*)\}"  # capture the key list
+    )
+
+    # Detect \nocite{*} -- all bib entries are considered referenced
+    nocite_star = bool(_NOCITE_STAR_RE.search(tex_content))
+
+    # Parse all \cite-family commands from .tex
+    tex_cite_keys: set[str] = set()
+    for match in all_cite_re.finditer(tex_content):
+        for key in match.group(1).split(","):
+            stripped = key.strip()
+            if stripped:
+                tex_cite_keys.add(stripped)
+
+    # Parse all @type{key, entries from .bib
+    bib_entry_keys: set[str] = set()
+    for match in _BIB_KEY_RE.finditer(bib_content):
+        key = match.group(1).strip()
+        if key:
+            bib_entry_keys.add(key)
+
+    # If \nocite{*} is present, all bib entries count as referenced
+    if nocite_star:
+        unreferenced: set[str] = set()
+    else:
+        unreferenced = bib_entry_keys - tex_cite_keys
+
+    unresolved = tex_cite_keys - bib_entry_keys
+    # Remove the special "*" key from unresolved (it's a \nocite{*} artifact)
+    unresolved.discard("*")
+
+    warnings: list[str] = []
+
+    if bib_entry_keys and not tex_cite_keys and not nocite_star:
+        warnings.append(
+            f"Bibliography contains {len(bib_entry_keys)} entries but the "
+            f"manuscript body has zero \\cite{{}} commands. The bibliography "
+            f"will not appear in the compiled paper."
+        )
+    elif unreferenced:
+        sorted_keys = sorted(unreferenced)
+        preview = ", ".join(sorted_keys[:5])
+        suffix = f" (+{len(sorted_keys) - 5} more)" if len(sorted_keys) > 5 else ""
+        warnings.append(
+            f"{len(unreferenced)} bibliography entries are never cited: "
+            f"{preview}{suffix}"
+        )
+
+    if unresolved:
+        sorted_keys = sorted(unresolved)
+        preview = ", ".join(sorted_keys[:5])
+        suffix = f" (+{len(sorted_keys) - 5} more)" if len(sorted_keys) > 5 else ""
+        warnings.append(
+            f"{len(unresolved)} \\cite{{}} keys have no matching bibliography "
+            f"entry: {preview}{suffix}"
+        )
+
+    return CitationCoherenceResult(
+        tex_cite_keys=tex_cite_keys,
+        bib_entry_keys=bib_entry_keys,
+        unreferenced_bib_keys=unreferenced,
+        unresolved_cite_keys=unresolved,
+        warnings=warnings,
+    )
 
 
 def check_tex_file(
@@ -735,6 +850,14 @@ async def build_paper(
     else:
         await asyncio.to_thread(tex_path.write_text, tex_content, encoding="utf-8")
 
+    # --- Citation-bibliography coherence check (BUG-076) ---
+    citation_warnings: list[str] = []
+    if bib_content:
+        coherence = check_citation_bib_coherence(tex_content, bib_content)
+        for w in coherence.warnings:
+            logger.warning("Citation coherence: %s", w)
+        citation_warnings = coherence.warnings
+
     manifest = build_artifact_manifest(
         config,
         output_dir,
@@ -765,6 +888,7 @@ async def build_paper(
             manifest=manifest,
             success=False,
             errors=errors,
+            citation_warnings=citation_warnings,
         )
 
     # 5. Compile
@@ -801,4 +925,5 @@ async def build_paper(
         manifest=manifest,
         success=final_success,
         errors=errors,
+        citation_warnings=citation_warnings,
     )

--- a/src/gpd/mcp/paper/models.py
+++ b/src/gpd/mcp/paper/models.py
@@ -637,3 +637,4 @@ class PaperOutput(BaseModel):
     manifest: ArtifactManifest | None = None
     success: bool
     errors: list[str] = Field(default_factory=list)
+    citation_warnings: list[str] = Field(default_factory=list)

--- a/tests/core/test_paper_quality.py
+++ b/tests/core/test_paper_quality.py
@@ -747,3 +747,25 @@ def test_validate_tex_draft_ignores_commented_markup() -> None:
     )
 
     assert findings == []
+
+
+def test_validate_tex_draft_detects_natbib_empty_citep() -> None:
+    findings = validate_tex_draft(
+        "\\documentclass{article}\n"
+        "\\begin{document}\n"
+        "See \\citep{}.\n"
+        "\\end{document}\n"
+    )
+    checks = {finding.check for finding in findings}
+    assert "empty_citation_command" in checks
+
+
+def test_validate_tex_draft_detects_natbib_missing_citep() -> None:
+    findings = validate_tex_draft(
+        "\\documentclass{article}\n"
+        "\\begin{document}\n"
+        "See \\citep{MISSING:ref1}.\n"
+        "\\end{document}\n"
+    )
+    checks = {finding.check for finding in findings}
+    assert "missing_citation_placeholder" in checks

--- a/tests/core/test_paper_quality_artifacts.py
+++ b/tests/core/test_paper_quality_artifacts.py
@@ -1880,3 +1880,29 @@ def test_publication_review_surfaces_keep_protocol_bundle_guidance_additive() ->
     assert "bundle_expectations (optional):" not in experimental_template
     assert "omit `protocol_bundle_ids` and `bundle_expectations` entirely" in experimental_template.lower()
     assert "additive provenance" in experimental_template
+
+
+def test_build_paper_quality_input_counts_natbib_citations(tmp_path: Path) -> None:
+    """Ensure natbib commands like \\citep and \\citet are counted."""
+    _write(
+        tmp_path / "paper" / "natbib_test.md",
+        "# Natbib Test\n\n"
+        "## Abstract\nTest.\n\n"
+        "## Introduction\n"
+        "See \\citep{bench2026} and \\citet{other2025}.\n\n"
+        "## Conclusion\nDone.\n",
+    )
+    _write(
+        tmp_path / "paper" / "PAPER-CONFIG.json",
+        json.dumps(_paper_config_payload("Natbib Test", "mnras")),
+    )
+    _write(
+        tmp_path / "paper" / "refs.bib",
+        "@article{bench2026,\n  title={Benchmark},\n  author={Doe},\n  year={2026}\n}\n"
+        "@article{other2025,\n  title={Other},\n  author={Smith},\n  year={2025}\n}\n",
+    )
+
+    result = build_paper_quality_input(tmp_path)
+
+    assert result.citations.citation_keys_resolve.total == 2
+    assert result.citations.citation_keys_resolve.satisfied >= 1

--- a/tests/test_citation_coherence.py
+++ b/tests/test_citation_coherence.py
@@ -1,0 +1,171 @@
+"""Tests for citation-bibliography coherence check (BUG-076)."""
+
+from __future__ import annotations
+
+from gpd.mcp.paper.compiler import check_citation_bib_coherence
+
+
+class TestCitationBibCoherence:
+    """Unit tests for the coherence check function."""
+
+    def test_zero_citations_with_bib_entries_warns(self) -> None:
+        tex = r"\documentclass{article}\begin{document}Hello.\bibliography{refs}\end{document}"
+        bib = "@article{einstein1905,\n  title={Relativity},\n  author={Einstein, A.},\n  year={1905}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert len(result.warnings) == 1
+        assert "zero" in result.warnings[0].lower()
+        assert result.unreferenced_bib_keys == {"einstein1905"}
+        assert result.tex_cite_keys == set()
+
+    def test_all_cited_no_warnings(self) -> None:
+        tex = r"As shown in \cite{einstein1905}, relativity is fundamental."
+        bib = "@article{einstein1905,\n  title={Relativity},\n  author={Einstein, A.},\n  year={1905}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.warnings == []
+        assert result.unreferenced_bib_keys == set()
+        assert result.unresolved_cite_keys == set()
+
+    def test_partial_citation_warns_unreferenced(self) -> None:
+        tex = r"\cite{einstein1905}"
+        bib = (
+            "@article{einstein1905,\n  title={Relativity},\n  author={Einstein, A.},\n  year={1905}\n}\n"
+            "@article{dirac1928,\n  title={Quantum},\n  author={Dirac, P.},\n  year={1928}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert "dirac1928" in result.unreferenced_bib_keys
+        assert "einstein1905" not in result.unreferenced_bib_keys
+        assert len(result.warnings) == 1
+        assert "1 bibliography" in result.warnings[0]
+
+    def test_unresolved_citation_warns(self) -> None:
+        tex = r"\cite{nonexistent2026}"
+        bib = "@article{einstein1905,\n  title={Relativity},\n  author={Einstein, A.},\n  year={1905}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert "nonexistent2026" in result.unresolved_cite_keys
+        assert len(result.warnings) == 2  # unreferenced + unresolved
+
+    def test_natbib_citep_detected(self) -> None:
+        tex = r"\citep{a2020} and \citet{b2021}"
+        bib = (
+            "@article{a2020,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b2021,\n  title={B},\n  author={Doe},\n  year={2021}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"a2020", "b2021"}
+        assert result.warnings == []
+
+    def test_natbib_citealt_citealp_detected(self) -> None:
+        tex = r"\citealt{x} and \citealp{y}"
+        bib = (
+            "@article{x,\n  title={X},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{y,\n  title={Y},\n  author={Doe},\n  year={2020}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"x", "y"}
+        assert result.warnings == []
+
+    def test_capitalized_natbib_detected(self) -> None:
+        tex = r"\Citep{a2020} at the start of a sentence."
+        bib = "@article{a2020,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"a2020"}
+        assert result.warnings == []
+
+    def test_citeauthor_citeyear_detected(self) -> None:
+        tex = r"\citeauthor{a2020} (\citeyear{a2020})"
+        bib = "@article{a2020,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert "a2020" in result.tex_cite_keys
+        assert result.warnings == []
+
+    def test_optional_arguments_handled(self) -> None:
+        tex = r"\citep[see][p.~42]{key2020}"
+        bib = "@article{key2020,\n  title={K},\n  author={Doe},\n  year={2020}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"key2020"}
+        assert result.warnings == []
+
+    def test_multi_key_citation_split(self) -> None:
+        tex = r"\cite{a2020,b2021,c2022}"
+        bib = (
+            "@article{a2020,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b2021,\n  title={B},\n  author={Doe},\n  year={2021}\n}\n"
+            "@article{c2022,\n  title={C},\n  author={Doe},\n  year={2022}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"a2020", "b2021", "c2022"}
+        assert result.warnings == []
+
+    def test_empty_bib_no_warning(self) -> None:
+        tex = r"\documentclass{article}\begin{document}Hello.\end{document}"
+        bib = ""
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.warnings == []
+        assert result.bib_entry_keys == set()
+
+    def test_nocite_star_suppresses_unreferenced_warning(self) -> None:
+        tex = r"\nocite{*}"
+        bib = (
+            "@article{a,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b,\n  title={B},\n  author={Doe},\n  year={2020}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.unreferenced_bib_keys == set()
+        assert result.warnings == []
+
+    def test_nocite_star_with_no_cite_commands_no_warning(self) -> None:
+        """nocite{*} means all entries referenced; no zero-citation warning."""
+        tex = r"\documentclass{article}\begin{document}\nocite{*}\end{document}"
+        bib = "@article{x,\n  title={X},\n  author={Doe},\n  year={2020}\n}\n"
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.warnings == []
+        assert result.unreferenced_bib_keys == set()
+
+    def test_nocite_specific_key_counted_as_citation(self) -> None:
+        tex = r"\nocite{hidden_ref}"
+        bib = (
+            "@article{hidden_ref,\n  title={H},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{other,\n  title={O},\n  author={Doe},\n  year={2020}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert "hidden_ref" in result.tex_cite_keys
+        assert "other" in result.unreferenced_bib_keys
+
+    def test_biblatex_commands_detected(self) -> None:
+        tex = r"\parencite{a} and \textcite{b} and \autocite{c}"
+        bib = (
+            "@article{a,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b,\n  title={B},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{c,\n  title={C},\n  author={Doe},\n  year={2020}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"a", "b", "c"}
+        assert result.warnings == []
+
+    def test_citetext_nested_citealp_partially_extracted(self) -> None:
+        """citetext takes free-form text; nested \\citealp may be partially consumed.
+
+        The outer \\citetext{...} match consumes up to the first ``}``, which
+        swallows the first nested \\citealp.  The second nested \\citealp falls
+        outside the outer match and is correctly extracted.  This is a known
+        limitation (rare command, non-blocking warning).
+        """
+        tex = r"\citetext{see \citealp{a}; compare \citealp{b}}"
+        bib = (
+            "@article{a,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b,\n  title={B},\n  author={Doe},\n  year={2020}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        # "b" is detected from the second \citealp outside the citetext match
+        assert "b" in result.tex_cite_keys
+
+    def test_starred_natbib_variants_detected(self) -> None:
+        """Starred variants like \\cite*{} and \\citep*{} should be matched."""
+        tex = r"\cite*{a2020} and \citep*{b2021}"
+        bib = (
+            "@article{a2020,\n  title={A},\n  author={Doe},\n  year={2020}\n}\n"
+            "@article{b2021,\n  title={B},\n  author={Doe},\n  year={2021}\n}\n"
+        )
+        result = check_citation_bib_coherence(tex, bib)
+        assert result.tex_cite_keys == {"a2020", "b2021"}
+        assert result.warnings == []

--- a/tests/test_citation_coherence.py
+++ b/tests/test_citation_coherence.py
@@ -142,13 +142,14 @@ class TestCitationBibCoherence:
         assert result.tex_cite_keys == {"a", "b", "c"}
         assert result.warnings == []
 
-    def test_citetext_nested_citealp_partially_extracted(self) -> None:
-        """citetext takes free-form text; nested \\citealp may be partially consumed.
+    def test_citetext_ignored_inner_citealp_extracted(self) -> None:
+        r"""\\citetext is excluded from the regex (BUG-076 fix).
 
-        The outer \\citetext{...} match consumes up to the first ``}``, which
-        swallows the first nested \\citealp.  The second nested \\citealp falls
-        outside the outer match and is correctly extracted.  This is a known
-        limitation (rare command, non-blocking warning).
+        \\citetext wraps free-form text that may contain nested citation
+        commands like \\citealp.  Because the non-brace-aware regex
+        ``\{([^}]*)\}`` truncates at the first inner ``}``, including
+        \\citetext produces garbage keys.  Instead, \\citetext is ignored
+        and the inner \\citealp commands are matched individually.
         """
         tex = r"\citetext{see \citealp{a}; compare \citealp{b}}"
         bib = (
@@ -156,8 +157,10 @@ class TestCitationBibCoherence:
             "@article{b,\n  title={B},\n  author={Doe},\n  year={2020}\n}\n"
         )
         result = check_citation_bib_coherence(tex, bib)
-        # "b" is detected from the second \citealp outside the citetext match
+        # Both inner \citealp commands are now detected correctly
+        assert "a" in result.tex_cite_keys
         assert "b" in result.tex_cite_keys
+        assert result.warnings == []
 
     def test_starred_natbib_variants_detected(self) -> None:
         """Starred variants like \\cite*{} and \\citep*{} should be matched."""

--- a/tests/test_paper_e2e.py
+++ b/tests/test_paper_e2e.py
@@ -724,3 +724,35 @@ class TestClassFileFallback:
         assert "jheppub.sty not found" in output.errors[0]
         assert output.manifest_path == tmp_path / "ARTIFACT-MANIFEST.json"
         assert output.manifest is not None
+
+    @pytest.mark.asyncio
+    async def test_build_paper_warns_on_zero_citations(self, tmp_path, monkeypatch):
+        """BUG-076: build_paper warns when bib has entries but tex has no citations."""
+        from gpd.mcp.paper.compiler import build_paper
+
+        config = PaperConfig(
+            title="Test Paper",
+            authors=[Author(name="Test Author")],
+            abstract="Abstract text.",
+            sections=[Section(title="Introduction", content="No citations here.")],
+        )
+        bib = BibliographyData()
+        bib.entries["ref2020"] = Entry(
+            "article", [("title", "Ref"), ("author", "Doe"), ("year", "2020")]
+        )
+
+        output_stem = derive_output_filename(config)
+        pdf_path = tmp_path / f"{output_stem}.pdf"
+        mock_result = CompilationResult(success=True, pdf_path=pdf_path)
+        pdf_path.write_bytes(b"%PDF-fake")
+
+        async def mock_compile(tex_path, output_dir, compiler="pdflatex"):
+            return mock_result
+
+        _allow_journal_dependencies(monkeypatch)
+        monkeypatch.setattr("gpd.mcp.paper.compiler.compile_paper", mock_compile)
+
+        output = await build_paper(config, tmp_path, bib_data=bib)
+
+        assert output.citation_warnings
+        assert any("zero" in w.lower() for w in output.citation_warnings)


### PR DESCRIPTION
## Summary

- **Original problem:** `gpd paper-build` generates a paper with a `.bib` bibliography but the paper body may have zero `\cite{}` commands. No warning is surfaced. Additionally, the citation regex only matched `\cite{}`, missing natbib commands (`\citep`, `\citet`, etc.) used by MNRAS/JFM templates.

- **The fix:** (1) New `check_citation_bib_coherence()` function that compares `.tex` cite keys against `.bib` entries and warns on mismatches. Handles `\nocite{*}`, multi-key citations, and optional arguments. (2) Broadened citation regex across 4 sites to support all natbib/biblatex variants. (3) Split `\nocite` handling: coherence checker recognizes it, but quality scorer excludes it to prevent inflating citation credit.

- **Why this won't cause additional problems:** The coherence check is warning-only — it never blocks the build or modifies output. The broadened regex is a superset of the old pattern (`\cite{}` still matches). `\nocite` is excluded from quality scoring to prevent manuscripts gaining citation credit without in-text citations. The coherence check reads the same `.tex` content that gets compiled (reads from disk when scaffold-once preserves an existing file). `\citetext` was removed from the supported set because the regex can't parse its nested braces — inner `\citealp` commands are caught individually.

## Changes

- `src/gpd/core/paper_quality.py`: Shared `_CITE_CMD_PREFIX` constant (no `\nocite`), `_CITE_CMD_PREFIX_WITH_NOCITE` for coherence check, broadened finding regexes
- `src/gpd/mcp/paper/paper_quality_artifacts.py`: Uses shared constant for `_CITE_RE` and `_MISSING_CITE_RE`
- `src/gpd/mcp/paper/compiler.py`: New `check_citation_bib_coherence()`, integrated into `build_paper()`, reads on-disk tex when scaffold-once preserves existing file
- `src/gpd/mcp/paper/models.py`: `citation_warnings` field on `PaperOutput`
- `tests/`: 21 new tests (coherence function, natbib detection, e2e warning propagation)
- `CHANGELOG.md`: vNEXT entry

## Review trail

- Internal adversarial audit: 2 rounds to 0/0/0/0
- External Codex adversarial review: found 3 issues (nocite scoring inflation, wrong tex source, citetext garbage keys) — all fixed and re-audited to 0/0/0/0

## Test plan

- [x] `uv run ruff check src/` — all checks passed
- [x] Full suite: 7256 passed, 43 skipped, 0 failed (verified in main context)