### PR TITLE
fix: auto-migrate ROADMAP.md and PROJECT.md from root to GPD/ (FULL-003, FULL-006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Get Physics Done are documented here.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.
 - fix: use `Path.replace()` instead of `Path.rename()` for atomic settings overwrite on Windows.
 - Fix catastrophic state reset: `_normalize_state_schema({})` now emits the integrity sentinel that triggers backup recovery, preventing silent data loss when `state.json` contains an empty object.
+- Auto-migrate `ROADMAP.md` and `PROJECT.md` from workspace root into `GPD/` on first command, so files placed at the root are found by all GPD operations.
 
 ## v1.1.0
 

--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -222,9 +222,17 @@ def _get_cwd() -> Path:
     return _cwd.resolve()
 
 
+def _migrate_planning_files(cwd: Path) -> None:
+    """Auto-migrate ROADMAP.md / PROJECT.md from root into GPD/ if needed."""
+    from gpd.core.project_files import migrate_root_planning_files
+
+    migrate_root_planning_files(cwd)
+
+
 def _status_command_reentry(cwd: Path | None = None) -> ProjectReentryResolution:
     """Resolve the shared re-entry contract for recovery/status commands."""
     workspace_cwd = (cwd or _get_cwd()).expanduser().resolve(strict=False)
+    _migrate_planning_files(workspace_cwd)
     return resolve_project_reentry(workspace_cwd)
 
 
@@ -240,6 +248,7 @@ def _status_command_cwd(cwd: Path | None = None) -> Path:
 def _state_command_cwd(cwd: Path | None = None) -> Path:
     """Resolve the effective cwd for state and project-contract commands."""
     workspace_cwd = (cwd or _get_cwd()).expanduser().resolve(strict=False)
+    _migrate_planning_files(workspace_cwd)
     resolved = resolve_project_root(workspace_cwd, require_layout=True)
     if resolved is not None:
         return resolved
@@ -249,6 +258,7 @@ def _state_command_cwd(cwd: Path | None = None) -> Path:
 def _project_scoped_cwd(cwd: Path | None = None) -> Path:
     """Resolve the nearest verified project root for project-scoped preflights."""
     workspace_cwd = (cwd or _get_cwd()).expanduser().resolve(strict=False)
+    _migrate_planning_files(workspace_cwd)
     resolved = resolve_project_root(workspace_cwd, require_layout=True)
     return resolved if resolved is not None else workspace_cwd
 

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -31,10 +31,12 @@ from gpd.core.constants import (
     MIN_PYTHON_MINOR,
     OPTIONAL_PLANNING_FILES,
     PLANNING_DIR_NAME,
+    PROJECT_FILENAME,
     RECOMMENDED_PYTHON_VERSION,
     REQUIRED_PLANNING_DIRS,
     REQUIRED_PLANNING_FILES,
     REQUIRED_SPECS_SUBDIRS,
+    ROADMAP_FILENAME,
     STATE_LINES_TARGET,
     UNCOMMITTED_FILES_THRESHOLD,
     ProjectLayout,
@@ -156,16 +158,33 @@ def check_environment() -> HealthCheck:
     return HealthCheck(status=status, label="Environment", details=details, issues=issues)
 
 
+_ROOT_MIGRATABLE_FILES = frozenset({ROADMAP_FILENAME, PROJECT_FILENAME})
+
+
 def check_project_structure(cwd: Path) -> HealthCheck:
     """Check that required GPD/ files and directories exist."""
     layout = ProjectLayout(cwd)
     issues: list[str] = []
+    warnings: list[str] = []
     details: dict[str, object] = {}
 
     for name in REQUIRED_PLANNING_FILES:
         full = layout.gpd / name
+        root_path = layout.root / name
         if full.exists():
             details[name] = "present"
+            if name in _ROOT_MIGRATABLE_FILES and root_path.exists():
+                warnings.append(
+                    f"{name} exists at both project root and {PLANNING_DIR_NAME}/ "
+                    f"— the root copy is unused. Consider removing ./{name}."
+                )
+        elif name in _ROOT_MIGRATABLE_FILES and root_path.exists():
+            details[name] = "present (at project root)"
+            warnings.append(
+                f"{name} found at project root but not in {PLANNING_DIR_NAME}/. "
+                f"Run any GPD command from the project root to auto-migrate, "
+                f"or copy it manually to {PLANNING_DIR_NAME}/{name}."
+            )
         else:
             details[name] = "missing"
             issues.append(f"Required file missing: {PLANNING_DIR_NAME}/{name}")
@@ -182,8 +201,8 @@ def check_project_structure(cwd: Path) -> HealthCheck:
         full = layout.gpd / name
         details[name] = "present" if full.exists() else "absent"
 
-    status = CheckStatus.FAIL if issues else CheckStatus.OK
-    return HealthCheck(status=status, label="Project Structure", details=details, issues=issues)
+    status = CheckStatus.FAIL if issues else (CheckStatus.WARN if warnings else CheckStatus.OK)
+    return HealthCheck(status=status, label="Project Structure", details=details, issues=issues, warnings=warnings)
 
 
 def check_knowledge_inventory(cwd: Path) -> HealthCheck:

--- a/src/gpd/core/project_files.py
+++ b/src/gpd/core/project_files.py
@@ -1,0 +1,40 @@
+"""Auto-migrate planning files from workspace root into GPD/."""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+
+from gpd.core.constants import PLANNING_DIR_NAME, PROJECT_FILENAME, ROADMAP_FILENAME
+
+logger = logging.getLogger("gpd")
+
+_MIGRATABLE_FILES = (ROADMAP_FILENAME, PROJECT_FILENAME)
+
+
+def migrate_root_planning_files(project_root: Path) -> list[str]:
+    """Copy ROADMAP.md and PROJECT.md from root to GPD/ if not already there.
+
+    Idempotent: files already in GPD/ are skipped. Errors are logged as
+    warnings and do not abort the caller.
+
+    Returns list of migrated filenames.
+    """
+    gpd_dir = project_root / PLANNING_DIR_NAME
+    migrated: list[str] = []
+    for filename in _MIGRATABLE_FILES:
+        gpd_path = gpd_dir / filename
+        root_path = project_root / filename
+        if gpd_path.exists() or not root_path.exists():
+            continue
+        try:
+            gpd_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(root_path, gpd_path)
+            migrated.append(filename)
+            logger.info("Copied %s from project root to %s/", filename, PLANNING_DIR_NAME)
+        except OSError as exc:
+            # Remove partial copy so next run retries from intact root
+            gpd_path.unlink(missing_ok=True)
+            logger.warning("Could not copy %s to %s/: %s", filename, PLANNING_DIR_NAME, exc)
+    return migrated

--- a/src/gpd/mcp/servers/__init__.py
+++ b/src/gpd/mcp/servers/__init__.py
@@ -89,9 +89,12 @@ def configure_mcp_logging(logger_name: str) -> logging.Logger:
 def resolve_absolute_project_dir(project_dir: str) -> Path | None:
     """Return an absolute project root path or ``None`` when the contract is violated."""
 
+    from gpd.core.project_files import migrate_root_planning_files
+
     cwd = Path(project_dir)
     if not cwd.is_absolute():
         return None
+    migrate_root_planning_files(cwd)
     return cwd
 
 

--- a/tests/core/test_project_files.py
+++ b/tests/core/test_project_files.py
@@ -1,0 +1,98 @@
+"""Tests for gpd.core.project_files — auto-migration of root planning files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gpd.core.constants import PLANNING_DIR_NAME, PROJECT_FILENAME, ROADMAP_FILENAME
+from gpd.core.project_files import migrate_root_planning_files
+
+
+def test_migrate_copies_root_roadmap_to_gpd(tmp_path: Path) -> None:
+    """FULL-003: ROADMAP.md at root is copied into GPD/."""
+    (tmp_path / ROADMAP_FILENAME).write_text("# Roadmap\n", encoding="utf-8")
+
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert migrated == [ROADMAP_FILENAME]
+    assert (tmp_path / PLANNING_DIR_NAME / ROADMAP_FILENAME).exists()
+    assert (tmp_path / PLANNING_DIR_NAME / ROADMAP_FILENAME).read_text(encoding="utf-8") == "# Roadmap\n"
+
+
+def test_migrate_copies_root_project_to_gpd(tmp_path: Path) -> None:
+    """FULL-006: PROJECT.md at root is copied into GPD/."""
+    (tmp_path / PROJECT_FILENAME).write_text("# Project\n", encoding="utf-8")
+
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert migrated == [PROJECT_FILENAME]
+    assert (tmp_path / PLANNING_DIR_NAME / PROJECT_FILENAME).exists()
+
+
+def test_migrate_copies_both_files(tmp_path: Path) -> None:
+    (tmp_path / ROADMAP_FILENAME).write_text("# R\n", encoding="utf-8")
+    (tmp_path / PROJECT_FILENAME).write_text("# P\n", encoding="utf-8")
+
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert set(migrated) == {ROADMAP_FILENAME, PROJECT_FILENAME}
+
+
+def test_migrate_skips_when_gpd_already_has_file(tmp_path: Path) -> None:
+    """No copy when GPD/ already has the file."""
+    gpd_dir = tmp_path / PLANNING_DIR_NAME
+    gpd_dir.mkdir()
+    (gpd_dir / ROADMAP_FILENAME).write_text("# GPD Roadmap\n", encoding="utf-8")
+    (tmp_path / ROADMAP_FILENAME).write_text("# Root Roadmap\n", encoding="utf-8")
+
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert migrated == []
+    # GPD/ version unchanged
+    assert (gpd_dir / ROADMAP_FILENAME).read_text(encoding="utf-8") == "# GPD Roadmap\n"
+
+
+def test_migrate_noop_when_neither_exists(tmp_path: Path) -> None:
+    """No error when files don't exist in either location."""
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert migrated == []
+
+
+def test_migrate_creates_gpd_dir_if_needed(tmp_path: Path) -> None:
+    """GPD/ directory is created during migration if it doesn't exist."""
+    assert not (tmp_path / PLANNING_DIR_NAME).exists()
+    (tmp_path / ROADMAP_FILENAME).write_text("# R\n", encoding="utf-8")
+
+    migrate_root_planning_files(tmp_path)
+
+    assert (tmp_path / PLANNING_DIR_NAME).is_dir()
+    assert (tmp_path / PLANNING_DIR_NAME / ROADMAP_FILENAME).exists()
+
+
+def test_migrate_is_idempotent(tmp_path: Path) -> None:
+    """Second call is a no-op."""
+    (tmp_path / ROADMAP_FILENAME).write_text("# R\n", encoding="utf-8")
+
+    first = migrate_root_planning_files(tmp_path)
+    second = migrate_root_planning_files(tmp_path)
+
+    assert first == [ROADMAP_FILENAME]
+    assert second == []
+
+
+def test_migrate_survives_permission_error(tmp_path: Path, monkeypatch) -> None:
+    """OSError during copy is caught and logged, not raised."""
+    import shutil
+
+    (tmp_path / ROADMAP_FILENAME).write_text("# R\n", encoding="utf-8")
+
+    def _failing_copy(*args, **kwargs):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(shutil, "copy2", _failing_copy)
+
+    migrated = migrate_root_planning_files(tmp_path)
+
+    assert migrated == []
+    assert not (tmp_path / PLANNING_DIR_NAME / ROADMAP_FILENAME).exists()


### PR DESCRIPTION
## Summary

- Users naturally place `ROADMAP.md` and `PROJECT.md` at the workspace root, but GPD only looks in `GPD/`. 14/14 stress-test researchers hit FULL-003.
- On first project-scoped command (CLI or MCP), root-level files are automatically copied into `GPD/`. One-time, idempotent, error-safe.
- Plan went through 7 revisions and 6 adversarial review rounds (4 internal + 2 Codex) resolving 3 FATALs, 7 SERIOUSes, 5 WARNINGs before implementation.

## Root Cause

`ProjectLayout` hardcodes all paths under `root / "GPD"`. When users place `ROADMAP.md` or `PROJECT.md` at the workspace root, every GPD operation fails to find them.

## Approach: Auto-Migrate at Entry Points

Instead of changing path resolution (which breaks `project_exists` semantics and file locking), we copy root files into `GPD/` before any command logic runs. All downstream code sees files in `GPD/` naturally — zero changes to `context.py`, `phases.py`, or canonical semantics.

## Changes

- **`src/gpd/core/project_files.py`** (NEW): `migrate_root_planning_files()` — copies `ROADMAP.md` and `PROJECT.md` from root to `GPD/` if GPD/ copies don't exist. Idempotent, error-safe (logs warning on failure, cleans up partial copies, never aborts).
- **`src/gpd/cli.py`**: Migration called from `_status_command_reentry()`, `_state_command_cwd()`, and `_project_scoped_cwd()` — the project-scoped cwd resolvers. NOT in `_get_cwd()` (avoids side effects on `--version` and non-project commands).
- **`src/gpd/mcp/servers/__init__.py`**: Migration called from `resolve_absolute_project_dir()` — covers all MCP server tool calls.
- **`src/gpd/core/health.py`**: `check_project_structure()` now reports WARN (not FAIL) when files exist at root only, and warns about orphaned root copies after migration.
- **`tests/core/test_project_files.py`** (NEW): 8 tests covering migration, idempotency, error handling, and directory creation.
- **`CHANGELOG.md`**: Added entry under vNEXT.

## Cross-platform Safety

Pure Python file operations (`shutil.copy2`, `Path.mkdir`). No platform-specific behavior. `copy2` preserves metadata. `mkdir(parents=True, exist_ok=True)` is safe on all platforms.

## Known Limitation

Migration runs on the resolved process cwd, not the project root. When a user runs GPD from a subdirectory, migration is a no-op (no root-level files in the subdirectory). This is not a regression — the behavior is identical to the current codebase. Users in subdirectories can pass `--cwd` explicitly.

## Test Plan

- [x] 8 unit tests for `migrate_root_planning_files()` (root-only, gpd-only, both, neither, idempotent, dir creation, permission error)
- [x] Full `uv run pytest`: 7264 passed, 43 skipped, 0 failed
- [x] Branch verified correct before AND after test run