### PR TITLE
[fix] Return structured output from question resolve and calculation complete (BUG-005, BUG-017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- **Breaking (raw output only):** `gpd question resolve` and `gpd calculation complete` now return structured results (resolved/completed text, search text, remaining count) instead of a bare `1`. Raw JSON output changes from `{"result": "1"}` to a model with `resolved`/`completed`, `search_text`, and `remaining` fields. The prior `{"result": "1"}` output was a bug (unhelpful) and is not considered a stable contract.
 - Add `check_result_consistency` health check: cross-validates `state.json` intermediate results against SUMMARY `provides` frontmatter with guards against empty-string false matches, short-string over-matching, and malformed state records.
 - Fix Windows test compatibility: cross-platform absolute paths in MCP tests, `shlex.quote`-aware assertions, `encoding="utf-8"` on `read_text()`, POSIX display paths in CLI/git_ops, permission/LaTeX/tilde/bash test portability, and schema pattern alignment.
 - Split releases into a manual release-PR preparation workflow and a separate publish workflow for PyPI, npm, tags, and GitHub Releases.

--- a/src/gpd/core/extras.py
+++ b/src/gpd/core/extras.py
@@ -18,6 +18,8 @@ from gpd.core.observability import instrument_gpd_function
 __all__ = [
     "Approximation",
     "ApproximationCheckResult",
+    "CalculationCompleteResult",
+    "QuestionResolveResult",
     "Uncertainty",
     "ValidityStatus",
     "check_approximation_validity",
@@ -70,6 +72,27 @@ class Uncertainty(BaseModel):
     uncertainty: str = ""
     phase: str = ""
     method: str = ""
+
+
+class QuestionResolveResult(BaseModel):
+    """Result of resolving an open question."""
+
+    model_config = ConfigDict(frozen=True)
+
+    resolved: str
+    search_text: str
+    remaining: int
+    answer: str | None = None
+
+
+class CalculationCompleteResult(BaseModel):
+    """Result of completing a calculation."""
+
+    model_config = ConfigDict(frozen=True)
+
+    completed: str
+    search_text: str
+    remaining: int
 
 
 # ─── Approximation Validity Checking ─────────────────────────────────────────────
@@ -539,7 +562,9 @@ def question_list(state: dict) -> list[str | dict]:
     return list(state.get("open_questions", []))
 
 
-def question_resolve(state: dict, text: str, *, answer: str | None = None) -> int:
+def question_resolve(
+    state: dict, text: str, *, answer: str | None = None
+) -> QuestionResolveResult | int:
     """Resolve (remove) an open question matching the given text.
 
     First tries exact match (case-insensitive), then falls back to
@@ -549,7 +574,7 @@ def question_resolve(state: dict, text: str, *, answer: str | None = None) -> in
     recorded in ``state["resolved_questions"]`` before removal.
 
     Raises ValueError if text is empty or too short (< 3 chars).
-    Returns the number of questions removed (0 or 1).
+    Returns a QuestionResolveResult on success, or 0 if no match found.
     """
     if not text:
         raise ExtrasError("text required for question-resolve")
@@ -560,15 +585,19 @@ def question_resolve(state: dict, text: str, *, answer: str | None = None) -> in
         state["open_questions"] = []
 
     questions: list[object] = state["open_questions"]
-    before = len(questions)
 
-    def _resolve_at(idx: int) -> int:
+    def _resolve_at(idx: int) -> QuestionResolveResult:
         q_text = _item_text(questions[idx])
         questions.pop(idx)
         if answer is not None:
             resolved = state.setdefault("resolved_questions", [])
             resolved.append({"question": q_text, "answer": answer})
-        return before - len(questions)
+        return QuestionResolveResult(
+            resolved=q_text,
+            search_text=text,
+            remaining=len(questions),
+            answer=answer,
+        )
 
     # Try exact match (case-insensitive)
     for i, q in enumerate(questions):
@@ -612,14 +641,14 @@ def calculation_list(state: dict) -> list[str | dict]:
     return list(state.get("active_calculations", []))
 
 
-def calculation_complete(state: dict, text: str) -> int:
+def calculation_complete(state: dict, text: str) -> CalculationCompleteResult | int:
     """Complete (remove) an active calculation matching the given text.
 
     First tries exact match (case-insensitive), then falls back to
     word-boundary substring match. Removes only the first match.
 
     Raises ValueError if text is empty or too short (< 3 chars).
-    Returns the number of calculations removed (0 or 1).
+    Returns a CalculationCompleteResult on success, or 0 if no match found.
     """
     if not text:
         raise ExtrasError("text required for calculation-complete")
@@ -630,14 +659,17 @@ def calculation_complete(state: dict, text: str) -> int:
         state["active_calculations"] = []
 
     calculations: list[object] = state["active_calculations"]
-    before = len(calculations)
 
     # Try exact match (case-insensitive)
     for i, c in enumerate(calculations):
         c_text = _item_text(c)
         if c_text.lower() == text.lower():
             calculations.pop(i)
-            return before - len(calculations)
+            return CalculationCompleteResult(
+                completed=c_text,
+                search_text=text,
+                remaining=len(calculations),
+            )
 
     # Fall back to substring match with word-boundary-like assertions
     escaped = re.escape(text)
@@ -646,6 +678,10 @@ def calculation_complete(state: dict, text: str) -> int:
         c_text = _item_text(c)
         if pattern.search(c_text):
             calculations.pop(i)
-            return before - len(calculations)
+            return CalculationCompleteResult(
+                completed=c_text,
+                search_text=text,
+                remaining=len(calculations),
+            )
 
     return 0

--- a/tests/core/test_extras.py
+++ b/tests/core/test_extras.py
@@ -8,6 +8,8 @@ from gpd.core.errors import DuplicateApproximationError, ExtrasError
 from gpd.core.extras import (
     Approximation,
     ApproximationCheckResult,
+    CalculationCompleteResult,
+    QuestionResolveResult,
     Uncertainty,
     approximation_add,
     approximation_check,
@@ -211,7 +213,11 @@ def test_question_resolve_exact():
     state: dict = {}
     question_add(state, "What is the coupling?")
     removed = question_resolve(state, "What is the coupling?")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling?"
+    assert removed.search_text == "What is the coupling?"
+    assert removed.remaining == 0
+    assert removed.answer is None
     assert len(state["open_questions"]) == 0
 
 
@@ -219,7 +225,10 @@ def test_question_resolve_substring():
     state: dict = {}
     question_add(state, "What is the coupling constant in QCD?")
     removed = question_resolve(state, "coupling constant")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling constant in QCD?"
+    assert removed.search_text == "coupling constant"
+    assert removed.remaining == 0
 
 
 def test_question_resolve_no_match():
@@ -244,7 +253,10 @@ def test_question_resolve_with_answer_records_resolution():
     state: dict = {}
     question_add(state, "What is the coupling constant?")
     removed = question_resolve(state, "What is the coupling constant?", answer="g = 0.3")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling constant?"
+    assert removed.answer == "g = 0.3"
+    assert removed.remaining == 0
     assert len(state["open_questions"]) == 0
     assert len(state["resolved_questions"]) == 1
     assert state["resolved_questions"][0]["question"] == "What is the coupling constant?"
@@ -256,7 +268,8 @@ def test_question_resolve_without_answer_no_resolved_entry():
     state: dict = {}
     question_add(state, "Some question here")
     removed = question_resolve(state, "Some question here")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.answer is None
     assert "resolved_questions" not in state
 
 
@@ -265,7 +278,9 @@ def test_question_resolve_answer_with_substring_match():
     state: dict = {}
     question_add(state, "What is the coupling constant in QCD?")
     removed = question_resolve(state, "coupling constant", answer="alpha_s = 0.118")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling constant in QCD?"
+    assert removed.answer == "alpha_s = 0.118"
     assert state["resolved_questions"][0]["question"] == "What is the coupling constant in QCD?"
     assert state["resolved_questions"][0]["answer"] == "alpha_s = 0.118"
 
@@ -300,7 +315,10 @@ def test_calculation_complete_exact():
     state: dict = {}
     calculation_add(state, "Loop integrals")
     removed = calculation_complete(state, "Loop integrals")
-    assert removed == 1
+    assert isinstance(removed, CalculationCompleteResult)
+    assert removed.completed == "Loop integrals"
+    assert removed.search_text == "Loop integrals"
+    assert removed.remaining == 0
     assert len(state["active_calculations"]) == 0
 
 
@@ -308,7 +326,10 @@ def test_calculation_complete_substring():
     state: dict = {}
     calculation_add(state, "Computing loop integrals for QCD")
     removed = calculation_complete(state, "loop integrals")
-    assert removed == 1
+    assert isinstance(removed, CalculationCompleteResult)
+    assert removed.completed == "Computing loop integrals for QCD"
+    assert removed.search_text == "loop integrals"
+    assert removed.remaining == 0
 
 
 def test_calculation_complete_no_match():
@@ -335,7 +356,9 @@ def test_question_resolve_with_dict_items():
     """question_resolve should handle dict items via _item_text()."""
     state = {"open_questions": [{"text": "What is the coupling constant?"}]}
     removed = question_resolve(state, "What is the coupling constant?")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling constant?"
+    assert removed.remaining == 0
     assert len(state["open_questions"]) == 0
 
 
@@ -343,7 +366,9 @@ def test_question_resolve_substring_with_dict_items():
     """question_resolve substring match should work with dict items."""
     state = {"open_questions": [{"text": "What is the coupling constant in QCD?"}]}
     removed = question_resolve(state, "coupling constant")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "What is the coupling constant in QCD?"
+    assert removed.remaining == 0
 
 
 def test_question_resolve_mixed_str_and_dict():
@@ -355,7 +380,9 @@ def test_question_resolve_mixed_str_and_dict():
         ]
     }
     removed = question_resolve(state, "dict question about quarks")
-    assert removed == 1
+    assert isinstance(removed, QuestionResolveResult)
+    assert removed.resolved == "dict question about quarks"
+    assert removed.remaining == 1
     assert len(state["open_questions"]) == 1
     assert state["open_questions"][0] == "plain string question"
 
@@ -364,7 +391,9 @@ def test_calculation_complete_with_dict_items():
     """calculation_complete should handle dict items via _item_text()."""
     state = {"active_calculations": [{"text": "Loop integrals"}]}
     removed = calculation_complete(state, "Loop integrals")
-    assert removed == 1
+    assert isinstance(removed, CalculationCompleteResult)
+    assert removed.completed == "Loop integrals"
+    assert removed.remaining == 0
     assert len(state["active_calculations"]) == 0
 
 
@@ -372,7 +401,9 @@ def test_calculation_complete_substring_with_dict_items():
     """calculation_complete substring match should work with dict items."""
     state = {"active_calculations": [{"text": "Computing loop integrals for QCD"}]}
     removed = calculation_complete(state, "loop integrals")
-    assert removed == 1
+    assert isinstance(removed, CalculationCompleteResult)
+    assert removed.completed == "Computing loop integrals for QCD"
+    assert removed.remaining == 0
 
 
 def test_calculation_complete_mixed_str_and_dict():
@@ -384,6 +415,8 @@ def test_calculation_complete_mixed_str_and_dict():
         ]
     }
     removed = calculation_complete(state, "dict calc about renormalization")
-    assert removed == 1
+    assert isinstance(removed, CalculationCompleteResult)
+    assert removed.completed == "dict calc about renormalization"
+    assert removed.remaining == 1
     assert len(state["active_calculations"]) == 1
     assert state["active_calculations"][0] == "plain string calc"


### PR DESCRIPTION
## Summary

- **Original problem:** `gpd question resolve` and `gpd calculation complete` return just `0` or `1` — no confirmation of what was resolved/completed, no context.
- **The fix:** Return Pydantic models (`QuestionResolveResult`, `CalculationCompleteResult`) with the matched text, search term, and remaining count. The existing `_output()` renderer handles Pydantic models automatically (rich table in human mode, structured JSON in `--raw` mode).
- **Why this won't cause additional problems:** The `if res == 0:` guard in cli.py still works (`BaseModel != 0` is `True`). No cli.py changes needed. The failure path (return `0`) is unchanged. Only the success path now returns a model instead of `1`.

**Note:** This is a breaking change to `--raw` JSON output format (from `1` to a structured object). The current output was useless — documented in CHANGELOG.

## Test plan

- [x] `uv run pytest tests/core/test_extras.py` — 48 passed
- [x] Full suite: 7271 passed, 0 failed (verified in main context)
- [x] Adversarial audit: 0/0/0/0 (3 rounds)