### PR TITLE
bug campaign local gates

### DIFF
--- a/src/gpd/adapters/base.py
+++ b/src/gpd/adapters/base.py
@@ -462,7 +462,7 @@ class RuntimeAdapter(abc.ABC):
         manifest_path = target_dir / MANIFEST_NAME
         try:
             parsed = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (FileNotFoundError, OSError, json.JSONDecodeError):
+        except (FileNotFoundError, OSError, UnicodeDecodeError, json.JSONDecodeError):
             return {}
         return parsed if isinstance(parsed, dict) else {}
 

--- a/src/gpd/adapters/codex.py
+++ b/src/gpd/adapters/codex.py
@@ -216,7 +216,7 @@ def _load_manifest_codex_skills_dir(target_dir: Path) -> Path | None:
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return None
 
     if not isinstance(manifest, dict):
@@ -237,7 +237,7 @@ def _load_manifest_codex_generated_skill_dirs(target_dir: Path) -> tuple[str, ..
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return ()
 
     if not isinstance(manifest, dict):
@@ -289,7 +289,7 @@ def _load_manifest_tracked_codex_skill_dirs(target_dir: Path) -> tuple[str, ...]
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return ()
 
     if not isinstance(manifest, dict):
@@ -360,7 +360,7 @@ def _load_manifest_install_scope(target_dir: Path) -> str | None:
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return None
 
     if not isinstance(manifest, dict):

--- a/src/gpd/adapters/gemini.py
+++ b/src/gpd/adapters/gemini.py
@@ -411,7 +411,7 @@ def _validate_existing_gemini_managed_state(target_dir: Path) -> None:
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise RuntimeError("Gemini install manifest is malformed; refusing to overwrite managed config state.") from exc
     if not isinstance(manifest, dict):
         raise RuntimeError("Gemini install manifest is malformed; refusing to overwrite managed config state.")

--- a/src/gpd/adapters/install_utils.py
+++ b/src/gpd/adapters/install_utils.py
@@ -158,7 +158,7 @@ def remove_empty_json_object_file(path: Path) -> bool:
         return False
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return False
     if payload != {}:
         return False
@@ -1630,7 +1630,7 @@ def tracked_hook_paths_from_manifest(config_dir: Path) -> set[str]:
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return set()
 
     if not isinstance(manifest, dict):
@@ -1744,7 +1744,7 @@ def save_local_patches(
     fallback_snapshot = False
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         fallback_snapshot = True
     else:
         if isinstance(manifest, dict):

--- a/src/gpd/adapters/opencode.py
+++ b/src/gpd/adapters/opencode.py
@@ -510,7 +510,7 @@ def _load_manifest_opencode_generated_command_files(target_dir: Path) -> tuple[s
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return ()
 
     if not isinstance(manifest, dict):
@@ -539,7 +539,7 @@ def _load_manifest_opencode_command_files(target_dir: Path) -> tuple[str, ...]:
 
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError, UnicodeDecodeError):
         return ()
 
     if not isinstance(manifest, dict):
@@ -863,7 +863,7 @@ def uninstall_opencode(target_dir: Path, *, config_dir: Path, allow_empty_config
     if manifest_file.exists():
         try:
             manifest_payload = json.loads(manifest_file.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
             manifest_payload = {}
         if isinstance(manifest_payload, dict):
             state = manifest_payload.get("gpd_runtime_permissions")

--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -786,7 +786,7 @@ def _cli_epilog() -> str:
 
 app = _GPDTyper(
     name="gpd",
-    help="GPD — Get Physics Done: local install, readiness, validation, permissions, observability, and diagnostics CLI",
+    help="GPD local bridge: local install, readiness, validation, permissions, observability, recovery, cost, presets, diagnostics, and shared Wolfram integration CLI",
     no_args_is_help=True,
     add_completion=True,
     epilog=_cli_epilog(),
@@ -1209,7 +1209,7 @@ def roadmap_get_phase(
     """Get detailed roadmap entry for a phase."""
     from gpd.core.phases import roadmap_get_phase
 
-    _output(roadmap_get_phase(_get_cwd(), phase_num))
+    _output(roadmap_get_phase(_project_scoped_cwd(), phase_num))
 
 
 @roadmap_app.command("analyze")
@@ -1217,7 +1217,7 @@ def roadmap_analyze() -> None:
     """Analyze roadmap structure, dependencies, and coverage."""
     from gpd.core.phases import roadmap_analyze
 
-    _output(roadmap_analyze(_get_cwd()))
+    _output(roadmap_analyze(_project_scoped_cwd()))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -1982,12 +1982,12 @@ def _recent_project_sort_key(row: dict[str, object]) -> tuple[int, int, int, int
     return _candidate_sort_key(candidate)
 
 
-def _load_recent_projects_rows() -> list[dict[str, object]]:
+def _load_recent_projects_rows(*, last: int | None = None) -> list[dict[str, object]]:
     """Load the recent-project index, preferring the shared helper module when present."""
     from gpd.core.recent_projects import RecentProjectsError, list_recent_projects
 
     try:
-        raw_rows = list_recent_projects(_recent_projects_data_root())
+        raw_rows = list_recent_projects(_recent_projects_data_root(), last=last)
     except RecentProjectsError as exc:
         raise GPDError(str(exc)) from exc
 
@@ -2389,7 +2389,7 @@ def resume(
     """Summarize local recovery state or list machine-local recent projects."""
     if recent:
         try:
-            rows = _annotate_recent_project_rows(_load_recent_projects_rows())
+            rows = _annotate_recent_project_rows(_load_recent_projects_rows(last=20))
         except GPDError as exc:
             _error(str(exc))
         recovery_advice = _resume_recovery_advice(recent_rows=rows, force_recent=True)
@@ -2757,11 +2757,23 @@ def result_persist_derived(
     )
 
 
-def _load_state_dict() -> dict:
-    """Load recoverable project state as a plain dictionary for read-only commands."""
-    from gpd.core.state import load_state_json
+def _load_state_dict(cwd: Path | None = None) -> dict:
+    """Load project state as a plain dictionary for read-only commands.
 
-    data = load_state_json(_get_cwd())
+    This path is intentionally non-mutating so read-only surfaces do not create
+    lockfiles, recovery writes, or nested stub directories when probing nested
+    workspaces.
+    """
+
+    from gpd.core.state import peek_state_json
+
+    project_cwd = _project_scoped_cwd(cwd)
+    data, _issues, _state_source = peek_state_json(
+        project_cwd,
+        recover_intent=False,
+        surface_blocked_project_contract=True,
+        acquire_lock=False,
+    )
     if data is None:
         return {}
     if not isinstance(data, dict):
@@ -2937,6 +2949,7 @@ def _print_result_show(result_deps: object) -> None:
 
 @result_app.command("search")
 def result_search(
+    term: str | None = typer.Argument(None, help="Optional positional text search term"),
     id: str | None = typer.Option(None, "--id", help="Exact result ID"),
     text: str | None = typer.Option(None, "--text", help="Search id, equation, and description"),
     equation: str | None = typer.Option(None, "--equation", help="Search by equation"),
@@ -2954,6 +2967,10 @@ def result_search(
 
     if verified and unverified:
         _error("--verified and --unverified are mutually exclusive")
+    if term is not None:
+        if text is not None:
+            _error("Use either a positional search term or --text, not both")
+        text = term
 
     _output(
         result_search(
@@ -3282,7 +3299,7 @@ def health(
     """Run the project health diagnostic."""
     from gpd.core.health import run_health
 
-    report = run_health(_get_cwd(), fix=fix)
+    report = run_health(_project_scoped_cwd(), fix=fix)
     _output(report)
     if report.overall == "fail":
         raise typer.Exit(code=1)
@@ -3334,10 +3351,7 @@ def doctor(
         else "local"
     )
     if target_dir is None and not global_install and not local_install:
-        detected_target, detected_scope = _resolve_detected_runtime_target(normalized_runtime)
-        if detected_target is not None and detected_scope is not None:
-            resolved_target = detected_target
-            install_scope = detected_scope
+        resolved_target = _get_adapter_or_error(normalized_runtime, action="doctor").resolve_target_dir(False, _get_cwd())
     _output(
         run_doctor(
             specs_dir=SPECS_DIR,
@@ -3373,7 +3387,7 @@ def query_search(
 
     _output(
         query_search(
-            _get_cwd(),
+            _project_scoped_cwd(),
             provides=provides,
             requires=requires,
             affects=affects,
@@ -3392,7 +3406,7 @@ def query_deps(
     """Show what provides and requires a given result identifier."""
     from gpd.core.query import query_deps
 
-    _output(query_deps(_get_cwd(), identifier))
+    _output(query_deps(_project_scoped_cwd(), identifier))
 
 
 @query_app.command("assumptions")
@@ -3405,7 +3419,7 @@ def query_assumptions(
     text = " ".join(assumption) if assumption else ""
     if not text.strip():
         _error("Usage: gpd query assumptions <search-term>")
-    _output(query_assumptions(_get_cwd(), text))
+    _output(query_assumptions(_project_scoped_cwd(), text))
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -7630,7 +7644,7 @@ def validate_consistency() -> None:
     """Validate cross-phase consistency."""
     from gpd.core.health import run_health
 
-    report = run_health(_get_cwd())
+    report = run_health(_project_scoped_cwd())
     _output(report)
     if report.overall == "fail":
         raise typer.Exit(code=1)
@@ -8096,7 +8110,7 @@ def history_digest() -> None:
     """Build a digest of project history from phase SUMMARY files."""
     from gpd.core.commands import cmd_history_digest
 
-    _output(cmd_history_digest(_get_cwd()))
+    _output(cmd_history_digest(_project_scoped_cwd()))
 
 
 @app.command("sync-phase-checkpoints")
@@ -8136,7 +8150,7 @@ def regression_check(
     """Check for regressions across completed phases, optionally limited to one phase."""
     from gpd.core.commands import cmd_regression_check
 
-    result = cmd_regression_check(_get_cwd(), phase=phase, quick=quick)
+    result = cmd_regression_check(_project_scoped_cwd(), phase=phase, quick=quick)
     _output(result)
     if not result.passed:
         raise typer.Exit(code=1)

--- a/src/gpd/commands/complete-milestone.md
+++ b/src/gpd/commands/complete-milestone.md
@@ -41,7 +41,7 @@ Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tag
 
 <process>
 
-If `--dry-run` flag is present, show what would be archived and deleted (milestone archive files, requirements deletion, roadmap collapse, git tag) without making any changes.
+This wrapper runs the archive workflow directly. Any stopping points come from the workflow's own readiness and confirmation gates.
 
 **Follow complete-milestone.md workflow:**
 

--- a/src/gpd/commands/export-logs.md
+++ b/src/gpd/commands/export-logs.md
@@ -1,7 +1,7 @@
 ---
 name: gpd:export-logs
 description: Export session logs and traces to files for external review or archival
-argument-hint: "[--format jsonl|json|markdown] [--session <id>] [--last N] [--no-traces] [--output-dir <path>]"
+argument-hint: "[--format jsonl|json|markdown] [--session <id>] [--last N] [--command <label>] [--phase <phase>] [--category <name>] [--no-traces] [--output-dir <path>]"
 context_mode: project-required
 allowed-tools:
   - file_read
@@ -16,6 +16,8 @@ Export GPD observability session logs and execution traces to files for external
 
 Reads session event streams from `GPD/observability/sessions/` and trace logs from `GPD/traces/`, applies optional filters, and writes the results to `GPD/exports/logs/` (or a custom directory).
 
+The local-only CLI passthrough filters `--command`, `--phase`, and `--category` are forwarded to the underlying export command; they only narrow what gets exported.
+
 **Formats:**
 
 - `jsonl` (default): Raw JSONL — one JSON object per line, suitable for machine consumption or log-processing pipelines
@@ -27,6 +29,8 @@ Reads session event streams from `GPD/observability/sessions/` and trace logs fr
 - `--session <id>`: Export only a specific session
 - `--last N`: Export only the N most recent sessions
 - `--command <label>`: Export only sessions for a given command
+- `--phase <phase>`: Export only events from the matching phase
+- `--category <name>`: Export only events from the matching category
 - `--no-traces`: Exclude execution traces (only export observability events)
 - `--output-dir <path>`: Write files to a custom directory instead of `GPD/exports/logs/`
 </objective>
@@ -37,6 +41,7 @@ Reads session event streams from `GPD/observability/sessions/` and trace logs fr
 
 <context>
 Format and filters: $ARGUMENTS (all optional)
+Local-only CLI passthrough filters: `--command`, `--phase`, and `--category`
 
 @GPD/STATE.md
 </context>

--- a/src/gpd/commands/merge-phases.md
+++ b/src/gpd/commands/merge-phases.md
@@ -41,7 +41,7 @@ Target phase: second argument (e.g., "2")
 <process>
 Execute the merge-phases workflow from @{GPD_INSTALL_DIR}/workflows/merge-phases.md end-to-end.
 
-If `--dry-run` flag is present, show the merge plan (which artifacts would move, which results would combine) without executing any changes.
+This wrapper runs the merge workflow directly. Any stopping points come from the workflow's own validation gates.
 
 The workflow handles:
 

--- a/src/gpd/commands/progress.md
+++ b/src/gpd/commands/progress.md
@@ -1,7 +1,7 @@
 ---
 name: gpd:progress
 description: Check research progress, show context, and route to next action (execute or plan)
-argument-hint: "[--brief] [--full] [--reconcile]"
+argument-hint: "[--brief | --full | --reconcile]"
 context_mode: project-required
 project_reentry_capable: true
 requires:
@@ -15,6 +15,10 @@ allowed-tools:
 
 <objective>
 Check physics research progress and route to the next action.
+
+Runtime note: `--brief`, `--full`, and `--reconcile` are runtime-surface
+options for `gpd:progress`. The local CLI `gpd progress` is a separate
+read-only renderer that takes `json|bar|table` and does not accept these flags.
 </objective>
 
 <execution_context>

--- a/src/gpd/commands/regression-check.md
+++ b/src/gpd/commands/regression-check.md
@@ -1,7 +1,7 @@
 ---
 name: gpd:regression-check
 description: Scan completed phase summaries and verifications for convention conflicts and verification-state regressions
-argument-hint: "[phase number to limit scope, or empty for all]"
+argument-hint: "[phase] [--quick]"
 context_mode: project-required
 allowed-tools:
   - file_read
@@ -22,6 +22,8 @@ This command does **not** re-run physics, numerical, dimensional, or contract ve
 
 Use `gpd:verify-work <phase>` when a flagged phase needs actual re-verification.
 
+The local CLI `--quick` flag is a wrapper-only scope reducer: it keeps the two most recent completed phases after any phase filter is applied, but it does not change the audit rules.
+
 Output: structured CLI/JSON result with `passed`, `phases_checked`, and `issues`.
 </objective>
 
@@ -33,7 +35,7 @@ Output: structured CLI/JSON result with `passed`, `phases_checked`, and `issues`
 Scope: $ARGUMENTS (optional)
 - If a number (e.g., "3"): scan only that completed phase
 - If empty: scan all completed phases
-- Local `gpd regression-check --quick` additionally limits the scan to the two most recent completed phases
+- Local CLI flag `--quick` additionally limits the scan to the two most recent completed phases after scope filtering
 
 @GPD/STATE.md
 @GPD/ROADMAP.md

--- a/src/gpd/commands/remove-phase.md
+++ b/src/gpd/commands/remove-phase.md
@@ -36,7 +36,7 @@ Phase: $ARGUMENTS
 </context>
 
 <process>
-If `--dry-run` flag is present, show what would be removed and what renumbering would occur, then stop without making changes.
+This wrapper runs the remove-phase workflow directly. Any stopping points come from the workflow's own validation gates.
 
 Execute the remove-phase workflow from @{GPD_INSTALL_DIR}/workflows/remove-phase.md end-to-end.
 Preserve all validation gates (future phase check, work check), renumbering logic, and commit.

--- a/src/gpd/commands/undo.md
+++ b/src/gpd/commands/undo.md
@@ -25,7 +25,7 @@ Use this when a plan, execution, or verification produced incorrect results and 
 </context>
 
 <process>
-If `--dry-run` flag is present, show the commit that would be reverted and files affected, without actually reverting.
+This wrapper runs the undo workflow directly. Any stopping points come from the workflow's own safety gates and confirmation steps.
 
 Execute the undo workflow from @{GPD_INSTALL_DIR}/workflows/undo.md end-to-end.
 Preserve all safety gates and confirmation steps.

--- a/src/gpd/core/context.py
+++ b/src/gpd/core/context.py
@@ -56,6 +56,7 @@ from gpd.core.continuation import (
     normalize_continuation_reference,
     resolve_continuation,
 )
+from gpd.core.conventions import is_bogus_value
 from gpd.core.errors import ValidationError
 from gpd.core.extras import approximation_list
 from gpd.core.knowledge_runtime import discover_knowledge_docs
@@ -851,6 +852,22 @@ def _structured_state_objects(value: object) -> list[dict[str, object]]:
     return structured
 
 
+def _has_structured_state_value(value: object) -> bool:
+    """Return whether a structured state value is materially set."""
+    if value is None:
+        return False
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped or stripped == "\u2014" or stripped.casefold() == "[not set]":
+            return False
+        return not is_bogus_value(stripped)
+    if isinstance(value, Mapping):
+        return bool(value)
+    if isinstance(value, (list, tuple, set)):
+        return bool(value)
+    return True
+
+
 def _build_structured_state_runtime_context(cwd: Path) -> dict[str, object]:
     """Build structured canonical state slices for init payloads."""
     state, state_issues, state_source = _peek_state_json(cwd, recover_intent=False)
@@ -878,7 +895,9 @@ def _build_structured_state_runtime_context(cwd: Path) -> dict[str, object]:
         "state_load_source": source,
         "state_integrity_issues": list(state_issues or []),
         "convention_lock": structured_convention_lock,
-        "convention_lock_count": len(structured_convention_lock),
+        "convention_lock_count": sum(
+            1 for value in structured_convention_lock.values() if _has_structured_state_value(value)
+        ),
         "intermediate_results": intermediate_results,
         "intermediate_result_count": len(intermediate_results),
         "approximations": approximations,
@@ -1900,17 +1919,6 @@ def _build_peer_review_runtime_context(
         )
     )
     return result
-
-
-def _has_structured_state_value(value: object) -> bool:
-    """Return whether a derived state value should be surfaced."""
-    if value is None:
-        return False
-    if isinstance(value, str):
-        return bool(value.strip())
-    if isinstance(value, (list, tuple, set, dict)):
-        return bool(value)
-    return True
 
 
 def _build_state_memory_runtime_context(cwd: Path) -> dict[str, object]:

--- a/src/gpd/core/conventions.py
+++ b/src/gpd/core/conventions.py
@@ -123,7 +123,7 @@ VALUE_ALIASES: dict[str, dict[str, str]] = {
 }
 
 # Values that should be treated as "unset" (prevent string-vs-null confusion)
-_BOGUS_VALUES = frozenset({"", "null", "undefined", "none"})
+_BOGUS_VALUES = frozenset({"", "null", "undefined", "none", "not set"})
 
 # Regex for ASSERT_CONVENTION lines:
 #   <!-- ASSERT_CONVENTION: key=value, key=value -->  (Markdown)

--- a/src/gpd/core/frontmatter.py
+++ b/src/gpd/core/frontmatter.py
@@ -51,6 +51,7 @@ from gpd.core.root_resolution import resolve_project_root
 from gpd.core.strict_yaml import load_strict_yaml
 from gpd.core.tool_preflight import PlanToolPreflightError, parse_plan_tool_requirements
 from gpd.core.utils import (
+    is_phase_complete,
     matching_phase_artifact_count,
     normalize_ascii_slug,
     phase_artifact_display_name,
@@ -274,6 +275,10 @@ def _source_path_project_root(source_path: Path | None) -> Path | None:
 
     if source_path is None:
         return None
+    source_dir = source_path.parent.resolve(strict=False)
+    for candidate in (source_dir, *source_dir.parents):
+        if (candidate / "GPD").is_dir():
+            return candidate
     return resolve_project_root(source_path.parent, require_layout=False)
 
 
@@ -2586,11 +2591,12 @@ def verify_phase_completeness(cwd: Path, phase: str) -> PhaseCompleteness:
     if orphans:
         warnings.append(f"Summaries without plans: {', '.join(orphans)}")
 
+    summary_count = matching_phase_artifact_count(plans, summaries)
     return PhaseCompleteness(
-        complete=len(errors) == 0,
+        complete=is_phase_complete(len(plans), summary_count),
         phase_number=phase_info.phase_number,
         plan_count=len(plans),
-        summary_count=matching_phase_artifact_count(plans, summaries),
+        summary_count=summary_count,
         incomplete_plans=incomplete,
         orphan_summaries=orphans,
         errors=errors,

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -53,6 +53,7 @@ from gpd.core.public_surface_contract import (
     local_cli_doctor_local_command,
     local_cli_permissions_sync_command,
 )
+from gpd.core.root_resolution import resolve_project_root
 from gpd.core.runtime_command_surfaces import format_active_runtime_command
 from gpd.core.state import (
     peek_state_json,
@@ -117,6 +118,22 @@ class HealthReport(BaseModel):
     summary: HealthSummary
     checks: list[HealthCheck] = Field(default_factory=list)
     fixes_applied: list[str] = Field(default_factory=list)
+
+
+class RuntimeTargetAssessment(BaseModel):
+    """Typed runtime target metadata derived from install assessment."""
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    config_dir: str
+    expected_runtime: str | None = None
+    state: str
+    manifest_state: str
+    manifest_runtime: str | None = None
+    has_managed_markers: bool = False
+    missing_install_artifacts: list[str] = Field(default_factory=list)
+    readiness_state: str = "blocked"
+    readiness_message: str = ""
 
 
 # All thresholds, file lists, and return validation constants imported from constants.py
@@ -347,10 +364,12 @@ def _peek_normalized_state_for_health(cwd: Path) -> tuple[dict[str, object] | No
     ``project_contract`` payloads so approval blockers are reported as failures
     instead of being hidden by draft-scoping normalization.
     """
+    project_root = resolve_project_root(cwd, require_layout=True) or cwd.expanduser().resolve(strict=False)
     state_obj, _integrity_issues, state_source = peek_state_json(
-        cwd,
+        project_root,
         recover_intent=False,
         surface_blocked_project_contract=True,
+        acquire_lock=False,
     )
     if not isinstance(state_obj, dict):
         return None, state_source
@@ -1281,6 +1300,7 @@ class DoctorReport(BaseModel):
     runtime: str | None = None
     install_scope: str | None = None
     target: str | None = None
+    target_assessment: RuntimeTargetAssessment | None = None
     live_executable_probes: bool = False
     summary: HealthSummary
     checks: list[HealthCheck] = Field(default_factory=list)
@@ -1803,19 +1823,56 @@ def _doctor_active_runtime_settings_command(*, cwd: Path | None = None) -> str:
 
 def _doctor_runtime_install_issue(assessment: InstallTargetAssessment, runtime: str | None) -> str | None:
     """Return a user-facing issue for a non-ready install assessment."""
-    if assessment.state == "owned_incomplete":
-        missing = ", ".join(f"`{item}`" for item in assessment.missing_install_artifacts) or "required install artifacts"
-        return f"{assessment.config_dir} has an incomplete GPD install; missing artifacts: {missing}."
-    if assessment.state == "foreign_runtime":
-        owner = f"`{assessment.manifest_runtime}`" if assessment.manifest_runtime else "another runtime"
-        runtime_label = f"`{runtime}`" if runtime else "the selected runtime"
-        return f"{assessment.config_dir} belongs to {owner}, not {runtime_label}."
-    if assessment.state == "untrusted_manifest":
-        return f"{assessment.config_dir} has an untrusted GPD manifest and cannot be treated as a ready install target."
-    return None
+    if assessment.readiness_state == "ready":
+        return None
+    return assessment.readiness_message(runtime)
 
 
-def _doctor_check_runtime_target(target_dir: Path, *, runtime: str | None = None) -> HealthCheck:
+def _doctor_runtime_target_assessment(
+    assessment: InstallTargetAssessment,
+    *,
+    runtime: str | None,
+) -> RuntimeTargetAssessment:
+    """Convert the install assessment into typed runtime-target metadata."""
+    return RuntimeTargetAssessment(
+        config_dir=str(assessment.config_dir),
+        expected_runtime=assessment.expected_runtime,
+        state=assessment.state,
+        manifest_state=assessment.manifest_state,
+        manifest_runtime=assessment.manifest_runtime,
+        has_managed_markers=assessment.has_managed_markers,
+        missing_install_artifacts=list(assessment.missing_install_artifacts),
+        readiness_state=assessment.readiness_state,
+        readiness_message=assessment.readiness_message(runtime),
+    )
+
+
+def _doctor_runtime_target_details(
+    assessment: InstallTargetAssessment,
+    *,
+    runtime: str | None,
+) -> dict[str, object]:
+    """Return the structured details payload for the runtime config target."""
+    target_assessment = _doctor_runtime_target_assessment(assessment, runtime=runtime)
+    return {
+        "target": str(assessment.config_dir),
+        "install_state": assessment.state,
+        "target_readiness_state": target_assessment.readiness_state,
+        "target_readiness_message": target_assessment.readiness_message,
+        "target_assessment": target_assessment.model_dump(mode="python"),
+        "manifest_state": assessment.manifest_state,
+        "manifest_runtime": assessment.manifest_runtime,
+        "has_managed_markers": assessment.has_managed_markers,
+        "missing_install_artifacts": list(assessment.missing_install_artifacts),
+    }
+
+
+def _doctor_check_runtime_target(
+    target_dir: Path,
+    *,
+    runtime: str | None = None,
+    assessment: InstallTargetAssessment | None = None,
+) -> HealthCheck:
     """Verify the selected install target can be created or written."""
     resolved = target_dir.expanduser().resolve(strict=False)
     details: dict[str, object] = {
@@ -1841,16 +1898,8 @@ def _doctor_check_runtime_target(target_dir: Path, *, runtime: str | None = None
     elif not resolved.exists():
         warnings.append(f"{resolved} does not exist yet; GPD will create it during install.")
 
-    assessment = assess_install_target(resolved, expected_runtime=runtime)
-    details.update(
-        {
-            "install_state": assessment.state,
-            "manifest_state": assessment.manifest_state,
-            "manifest_runtime": assessment.manifest_runtime,
-            "has_managed_markers": assessment.has_managed_markers,
-            "missing_install_artifacts": list(assessment.missing_install_artifacts),
-        }
-    )
+    assessment = assessment or assess_install_target(resolved, expected_runtime=runtime)
+    details.update(_doctor_runtime_target_details(assessment, runtime=runtime))
 
     install_issue = _doctor_runtime_install_issue(assessment, runtime)
     if install_issue is not None:
@@ -2284,6 +2333,7 @@ def run_doctor(
         resolved_target_str: str | None = None
         normalized_scope: str | None = None
         normalized_runtime: str | None = None
+        target_assessment: RuntimeTargetAssessment | None = None
         if runtime is not None:
             runtime_context = resolve_doctor_runtime_readiness(
                 runtime,
@@ -2295,8 +2345,19 @@ def run_doctor(
             normalized_scope = runtime_context.install_scope
             resolved_target = runtime_context.target
             resolved_target_str = str(resolved_target)
+            install_target_assessment = assess_install_target(resolved_target, expected_runtime=normalized_runtime)
+            target_assessment = _doctor_runtime_target_assessment(
+                install_target_assessment,
+                runtime=normalized_runtime,
+            )
             checks.append(_doctor_check_runtime_launcher(normalized_runtime))
-            checks.append(_doctor_check_runtime_target(resolved_target, runtime=normalized_runtime))
+            checks.append(
+                _doctor_check_runtime_target(
+                    resolved_target,
+                    runtime=normalized_runtime,
+                    assessment=install_target_assessment,
+                )
+            )
             checks.append(_doctor_check_bootstrap_network_access())
             checks.append(
                 _doctor_check_provider_auth(
@@ -2326,6 +2387,7 @@ def run_doctor(
             runtime=normalized_runtime,
             install_scope=normalized_scope,
             target=resolved_target_str,
+            target_assessment=target_assessment,
             live_executable_probes=live_executable_probes,
             summary=HealthSummary(ok=ok_count, warn=warn_count, fail=fail_count, total=len(checks)),
             checks=checks,
@@ -2339,6 +2401,7 @@ __all__ = [
     "HealthCheck",
     "HealthReport",
     "HealthSummary",
+    "RuntimeTargetAssessment",
     "annotate_permissions_payload",
     "normalize_permissions_readiness_payload",
     "UnattendedReadinessCheck",

--- a/src/gpd/core/observability.py
+++ b/src/gpd/core/observability.py
@@ -195,6 +195,8 @@ class ExecutionVisibilityState(BaseModel):
 
     workspace_root: str | None = None
     has_live_execution: bool = False
+    visibility_mode: str = "idle"
+    visibility_note: str | None = None
     status_classification: str = "idle"
     assessment: str = "idle"
     possibly_stalled: bool = False
@@ -842,9 +844,21 @@ def _execution_visibility_next_commands(
     classification: str,
     snapshot: CurrentExecutionState | None,
     possibly_stalled: bool,
+    visibility_mode: str = "full",
 ) -> list[ExecutionVisibilitySuggestion]:
     suggestions: list[ExecutionVisibilitySuggestion] = []
     if snapshot is None:
+        if visibility_mode == "degraded":
+            return [
+                ExecutionVisibilitySuggestion(
+                    command="gpd observe sessions --last 5",
+                    reason="inspect recent observability sessions because the live execution telemetry is degraded",
+                ),
+                ExecutionVisibilitySuggestion(
+                    command="gpd progress bar",
+                    reason="cross-check workspace progress separately while the live execution telemetry is degraded",
+                ),
+            ]
         return [
             ExecutionVisibilitySuggestion(
                 command="gpd observe sessions --last 5",
@@ -860,6 +874,23 @@ def _execution_visibility_next_commands(
     session_scope = f" --session {snapshot.session_id}" if snapshot.session_id else ""
     observe_command = f"gpd observe show{session_scope} --last 20"
     recovery_command = recovery_local_snapshot_command()
+
+    if visibility_mode in {"snapshot-only", "trace-only"}:
+        mode_reason = (
+            "inspect recent observability sessions because only the compatibility snapshot is available"
+            if visibility_mode == "snapshot-only"
+            else "inspect recent observability sessions because only the lineage trace head is available"
+        )
+        return [
+            ExecutionVisibilitySuggestion(
+                command="gpd observe sessions --last 5",
+                reason=mode_reason,
+            ),
+            ExecutionVisibilitySuggestion(
+                command="gpd progress bar",
+                reason="cross-check workspace progress separately from the partial execution visibility",
+            ),
+        ]
 
     if classification == "blocked":
         suggestions.append(
@@ -960,24 +991,98 @@ def _execution_visibility_next_steps(
     ]
 
 
+def _execution_visibility_source_state(
+    layout: ProjectLayout,
+) -> tuple[CurrentExecutionState | None, str, str | None]:
+    authoritative_snapshot = get_current_execution(layout.root)
+    current_exists = layout.current_observability_execution.exists()
+    head_exists = layout.execution_lineage_head.exists()
+
+    current_raw = _read_current_execution_raw(layout) if current_exists else None
+    head_raw = _read_json(layout.execution_lineage_head) if head_exists else None
+
+    current_snapshot: CurrentExecutionState | None = None
+    head_snapshot: CurrentExecutionState | None = None
+    current_valid = False
+    head_valid = False
+    degraded_reasons: list[str] = []
+
+    if current_exists:
+        if isinstance(current_raw, dict):
+            try:
+                current_snapshot = CurrentExecutionState.model_validate(current_raw)
+            except Exception:
+                degraded_reasons.append("current-execution.json is malformed")
+            else:
+                current_valid = True
+        else:
+            degraded_reasons.append("current-execution.json is missing or unreadable")
+
+    if head_exists:
+        if isinstance(head_raw, dict):
+            try:
+                head_payload = ExecutionLineageHead.model_validate(head_raw)
+            except Exception:
+                degraded_reasons.append("execution-head.json is malformed")
+            else:
+                if isinstance(head_payload.execution, dict):
+                    try:
+                        head_snapshot = CurrentExecutionState.model_validate(head_payload.execution)
+                    except Exception:
+                        degraded_reasons.append("execution-head.json payload is malformed")
+                    else:
+                        head_valid = True
+                else:
+                    degraded_reasons.append("execution-head.json is incomplete")
+        else:
+            degraded_reasons.append("execution-head.json is missing or unreadable")
+
+    snapshot = authoritative_snapshot or head_snapshot or current_snapshot
+    if snapshot is None:
+        if current_exists or head_exists:
+            note = "; ".join(dict.fromkeys(degraded_reasons)) or "live execution telemetry is incomplete"
+            return None, "degraded", note
+        return None, "idle", None
+
+    if current_valid and head_valid:
+        return snapshot, "full", None
+    if current_valid and not head_exists:
+        return snapshot, "full", None
+    if head_valid and not current_exists:
+        return snapshot, "full", None
+    if current_valid and head_exists and not head_valid:
+        note = "; ".join(dict.fromkeys(degraded_reasons)) or "compatibility snapshot only"
+        return snapshot, "snapshot-only", note
+    if head_valid and current_exists and not current_valid:
+        note = "; ".join(dict.fromkeys(degraded_reasons)) or "lineage trace only"
+        return snapshot, "trace-only", note
+
+    note = "; ".join(dict.fromkeys(degraded_reasons)) or "live execution telemetry is incomplete"
+    return snapshot, "degraded", note
+
+
 def derive_execution_visibility(cwd: Path | None = None) -> ExecutionVisibilityState | None:
     """Derive a normalized local execution visibility payload from the current snapshot."""
     layout = _layout(cwd)
     if layout is None:
         return None
 
-    snapshot = get_current_execution(layout.root)
+    snapshot, visibility_mode, visibility_note = _execution_visibility_source_state(layout)
     if snapshot is None:
+        degraded = visibility_mode == "degraded"
         suggestions = _execution_visibility_next_commands(
             classification="idle",
             snapshot=None,
             possibly_stalled=False,
+            visibility_mode=visibility_mode,
         )
         return ExecutionVisibilityState(
             workspace_root=str(layout.root),
             has_live_execution=False,
-            status_classification="idle",
-            assessment="idle",
+            visibility_mode=visibility_mode,
+            visibility_note=visibility_note,
+            status_classification="degraded" if degraded else "idle",
+            assessment="degraded" if degraded else "idle",
             suggested_next_commands=suggestions,
             suggested_next_steps=_execution_visibility_next_steps(suggestions),
         )
@@ -986,7 +1091,12 @@ def derive_execution_visibility(cwd: Path | None = None) -> ExecutionVisibilityS
     age_minutes = _execution_visibility_age_minutes(snapshot.updated_at)
     age_label = _execution_visibility_age_label(snapshot.updated_at)
     possibly_stalled = classification == "active" and age_minutes is not None and age_minutes >= 30.0
-    assessment = "possibly stalled" if possibly_stalled else classification
+    if visibility_mode == "full":
+        assessment = "possibly stalled" if possibly_stalled else classification
+    elif visibility_mode in {"snapshot-only", "trace-only"}:
+        assessment = f"{visibility_mode} {classification}"
+    else:
+        assessment = visibility_mode
     current_task_progress: str | None = None
     if snapshot.current_task_index is not None and snapshot.current_task_total is not None:
         current_task_progress = f"{snapshot.current_task_index}/{snapshot.current_task_total}"
@@ -995,12 +1105,15 @@ def derive_execution_visibility(cwd: Path | None = None) -> ExecutionVisibilityS
         classification=classification,
         snapshot=snapshot,
         possibly_stalled=possibly_stalled,
+        visibility_mode=visibility_mode,
     )
     tangent_steps = _execution_visibility_tangent_steps(snapshot)
 
     return ExecutionVisibilityState(
         workspace_root=str(layout.root),
         has_live_execution=True,
+        visibility_mode=visibility_mode,
+        visibility_note=visibility_note,
         status_classification=classification,
         assessment=assessment,
         possibly_stalled=possibly_stalled,

--- a/src/gpd/core/phases.py
+++ b/src/gpd/core/phases.py
@@ -1340,8 +1340,36 @@ def roadmap_analyze(cwd: Path) -> RoadmapAnalysis:
 
         # Find current and next phase
         current_phase = next((p for p in phases if p.disk_status in ("planned", "partial")), None)
+        if current_phase is None:
+            state_content = safe_read_file(layout.state_md)
+            if state_content is not None:
+                state_phase = _extract_state_field(state_content, "Current Phase")
+                if state_phase is not None:
+                    try:
+                        _validate_phase_number(state_phase)
+                    except PhaseValidationError:
+                        pass
+                    else:
+                        normalized_state_phase = phase_normalize(state_phase)
+                        current_phase = next(
+                            (
+                                p
+                                for p in phases
+                                if compare_phase_numbers(phase_normalize(p.number), normalized_state_phase) == 0
+                            ),
+                            None,
+                        )
+        current_phase_number = current_phase.number if current_phase else None
         next_phase = next(
-            (p for p in phases if p.disk_status in ("empty", "no_directory", "discussed", "researched")),
+            (
+                p
+                for p in phases
+                if p.disk_status in ("empty", "no_directory", "discussed", "researched")
+                and (
+                    current_phase_number is None
+                    or compare_phase_numbers(phase_normalize(p.number), phase_normalize(current_phase_number)) != 0
+                )
+            ),
             None,
         )
 

--- a/src/gpd/core/project_reentry.py
+++ b/src/gpd/core/project_reentry.py
@@ -222,6 +222,10 @@ def _candidate_has_concrete_target(candidate: ProjectReentryCandidate) -> bool:
     return candidate.resumable or candidate.resume_file_available is True
 
 
+def _current_workspace_is_verified(candidate: ProjectReentryCandidate | None) -> bool:
+    return candidate is not None and candidate.source == "current_workspace" and candidate.project_exists is True
+
+
 def _normalize_recent_text(row: Mapping[str, object], *keys: str) -> str | None:
     for key in keys:
         value = row.get(key)
@@ -372,7 +376,7 @@ def resolve_project_reentry(
     auto_selected = False
     requires_user_selection = False
 
-    if current_candidate is not None:
+    if _current_workspace_is_verified(current_candidate):
         selected_project_root = current_candidate.project_root
         selected_source = current_candidate.source
         mode = "current-workspace"
@@ -385,6 +389,10 @@ def resolve_project_reentry(
     elif len(strong_recent) > 1:
         mode = "ambiguous-recent-projects"
         requires_user_selection = True
+    elif current_candidate is not None:
+        selected_project_root = current_candidate.project_root
+        selected_source = current_candidate.source
+        mode = "current-workspace"
     elif recent_candidates:
         mode = "recent-projects"
 
@@ -393,6 +401,14 @@ def resolve_project_reentry(
         candidate.model_copy(update={"auto_selectable": candidate.project_root in auto_selectable_roots})
         for candidate in sorted(candidates, key=_candidate_sort_key, reverse=True)
     ]
+
+    if selected_project_root is not None and selected_source is not None:
+        for index, candidate in enumerate(normalized_candidates):
+            if candidate.project_root == selected_project_root and candidate.source == selected_source:
+                if index != 0:
+                    selected_candidate = normalized_candidates.pop(index)
+                    normalized_candidates.insert(0, selected_candidate)
+                break
 
     return ProjectReentryResolution(
         workspace_root=workspace_root.as_posix() if workspace_root is not None else None,

--- a/src/gpd/core/query.py
+++ b/src/gpd/core/query.py
@@ -114,6 +114,9 @@ class DepsResult(BaseModel):
     provides_by: DepsProvider | None = None
     provider_conflicts: list[DepsProvider] = Field(default_factory=list)
     required_by: list[DepsConsumer] = Field(default_factory=list)
+    depends_on: list[str] = Field(default_factory=list)
+    direct_deps: list[str] = Field(default_factory=list)
+    transitive_deps: list[str] = Field(default_factory=list)
 
 
 class AssumptionAffected(BaseModel):
@@ -138,7 +141,6 @@ class AssumptionsResult(BaseModel):
 
 
 # ─── Internal Helpers ────────────────────────────────────────────────────────
-
 
 
 def _is_valid_phase_str(s: str) -> bool:
@@ -318,6 +320,112 @@ def _serialize_search_value(value: object) -> str:
         return json.dumps(value, default=str, sort_keys=True)
     except TypeError:
         return str(value)
+
+
+def _load_result_registry_state(cwd: Path) -> dict[str, object]:
+    """Load state for read-only result-registry projection without repair writes."""
+
+    from gpd.core.state import peek_state_json
+
+    data, _issues, _state_source = peek_state_json(
+        cwd,
+        recover_intent=False,
+        surface_blocked_project_contract=True,
+        acquire_lock=False,
+    )
+    return data if isinstance(data, dict) else {}
+
+
+def _registry_context(*values: object) -> str | None:
+    parts = [str(value) for value in values if value]
+    return " | ".join(parts) if parts else None
+
+
+def _registry_result_matches(
+    result: object,
+    *,
+    provides: str | None,
+    requires: str | None,
+    equation: str | None,
+    text: str | None,
+) -> bool:
+    """Return whether a canonical result should be included in a query search."""
+
+    if provides and not _normalized_identifier_matches(provides, getattr(result, "id", None)):
+        return False
+
+    if requires and not any(
+        _normalized_identifier_matches(requires, dependency) for dependency in getattr(result, "depends_on", []) or []
+    ):
+        return False
+
+    if equation and not term_matches(equation, getattr(result, "equation", None) or ""):
+        return False
+
+    if text:
+        searchable_values = (
+            getattr(result, "id", None),
+            getattr(result, "description", None),
+            getattr(result, "equation", None),
+            getattr(result, "validity", None),
+        )
+        if not any(term_matches(text, str(value or "")) for value in searchable_values):
+            return False
+
+    return bool(provides or requires or equation or text)
+
+
+def _append_registry_search_matches(
+    cwd: Path,
+    matches: list[QueryMatch],
+    *,
+    provides: str | None,
+    requires: str | None,
+    equation: str | None,
+    text: str | None,
+    parsed_range: tuple[str, str] | None,
+) -> None:
+    """Append matches from the canonical intermediate-result registry."""
+
+    from gpd.core.results import result_list
+
+    state = _load_result_registry_state(cwd)
+    if not state:
+        return
+
+    for result in result_list(state):
+        phase = getattr(result, "phase", None) or ""
+        if parsed_range and phase:
+            phase_norm = phase_unpad(phase)
+            min_norm = phase_unpad(parsed_range[0])
+            max_norm = phase_unpad(parsed_range[1])
+            if compare_phase_numbers(phase_norm, min_norm) < 0 or compare_phase_numbers(phase_norm, max_norm) > 0:
+                continue
+        if not _registry_result_matches(
+            result,
+            provides=provides,
+            requires=requires,
+            equation=equation,
+            text=text,
+        ):
+            continue
+        matches.append(
+            QueryMatch(
+                phase=phase,
+                plan=None,
+                field="result_registry",
+                value=getattr(result, "id", None),
+                context=_registry_context(
+                    getattr(result, "equation", None),
+                    getattr(result, "description", None),
+                    getattr(result, "validity", None),
+                ),
+            )
+        )
+
+
+def _dependency_ids_from_items(items: list[object]) -> list[str]:
+    return [str(item.id) for item in items if getattr(item, "id", None)]
 
 
 # ─── Commands ────────────────────────────────────────────────────────────────
@@ -627,6 +735,17 @@ def query(
         if not provides and not requires and not affects and not equation and not text:
             matches.append(QueryMatch(phase=phase, plan=plan, field="all", value=None, context=body[:200].strip()))
 
+    if not affects:
+        _append_registry_search_matches(
+            cwd,
+            matches,
+            provides=provides,
+            requires=requires,
+            equation=equation,
+            text=text,
+            parsed_range=parsed_range,
+        )
+
     return QueryResult(matches=matches, total=len(matches))
 
 
@@ -645,6 +764,9 @@ def query_deps(cwd: Path, identifier: str) -> DepsResult:
     summaries = collect_summaries(cwd)
     provider_matches: list[DepsProvider] = []
     required_by: list[DepsConsumer] = []
+    registry_depends_on: list[str] = []
+    registry_direct_deps: list[str] = []
+    registry_transitive_deps: list[str] = []
 
     for entry in summaries:
         phase = entry.phase
@@ -667,10 +789,47 @@ def query_deps(cwd: Path, identifier: str) -> DepsResult:
                 required_by.append(DepsConsumer(phase=phase, plan=plan, value=rv))
                 break
 
+    state = _load_result_registry_state(cwd)
+    if state:
+        from gpd.core.errors import ResultNotFoundError
+        from gpd.core.results import result_deps, result_downstream, result_search
+
+        try:
+            deps = result_deps(state, identifier)
+        except ResultNotFoundError:
+            deps = None
+        if deps is not None:
+            provider_matches.append(
+                DepsProvider(
+                    phase=deps.result.phase or "",
+                    plan=None,
+                    value=deps.result.id,
+                )
+            )
+            registry_depends_on = list(deps.depends_on)
+            registry_direct_deps = _dependency_ids_from_items(list(deps.direct_deps))
+            registry_transitive_deps = _dependency_ids_from_items(list(deps.transitive_deps))
+
+            try:
+                downstream = result_downstream(state, identifier)
+            except ResultNotFoundError:
+                downstream = None
+            if downstream is not None:
+                for dependent in downstream.direct_dependents:
+                    if not any(item.value == dependent.id for item in required_by):
+                        required_by.append(DepsConsumer(phase=dependent.phase or "", plan=None, value=dependent.id))
+        else:
+            for dependent in result_search(state, depends_on=identifier).matches:
+                if not any(item.value == dependent.id for item in required_by):
+                    required_by.append(DepsConsumer(phase=dependent.phase or "", plan=None, value=dependent.id))
+
     return DepsResult(
         provides_by=provider_matches[-1] if provider_matches else None,
         provider_conflicts=provider_matches[:-1],
         required_by=required_by,
+        depends_on=registry_depends_on,
+        direct_deps=registry_direct_deps,
+        transitive_deps=registry_transitive_deps,
     )
 
 
@@ -750,6 +909,31 @@ def query_assumptions(cwd: Path, assumption: str) -> AssumptionsResult:
                     context=extract_context(body, assumption),
                 )
             )
+
+    from gpd.core.results import result_list
+
+    state = _load_result_registry_state(cwd)
+    for result in result_list(state):
+        searchable_values = (
+            getattr(result, "id", None),
+            getattr(result, "description", None),
+            getattr(result, "equation", None),
+            getattr(result, "validity", None),
+        )
+        if not any(term_matches(assumption, str(value or "")) for value in searchable_values):
+            continue
+        affected.append(
+            AssumptionAffected(
+                phase=getattr(result, "phase", None) or "",
+                plan=None,
+                found_in=["result_registry"],
+                context=_registry_context(
+                    getattr(result, "equation", None),
+                    getattr(result, "description", None),
+                    getattr(result, "validity", None),
+                ),
+            )
+        )
 
     return AssumptionsResult(
         assumption=assumption,

--- a/src/gpd/core/root_resolution.py
+++ b/src/gpd/core/root_resolution.py
@@ -16,7 +16,12 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-from gpd.core.constants import ProjectLayout
+from gpd.core.constants import (
+    REQUIRED_PLANNING_DIRS,
+    REQUIRED_PLANNING_FILES,
+    STATE_JSON_BACKUP_FILENAME,
+    ProjectLayout,
+)
 
 __all__ = [
     "ProjectRootResolution",
@@ -84,14 +89,40 @@ def normalize_workspace_hint(value: Path | str | None) -> Path | None:
 
 
 def _walk_project_root(candidate: Path | None) -> tuple[Path | None, int]:
-    """Walk *candidate* and its ancestors until a ``GPD/`` layout is found."""
+    """Walk *candidate* and its ancestors until the best ``GPD/`` layout is found."""
 
     if candidate is None:
         return None, 0
 
+    best_verified: tuple[int, int, Path] | None = None
+    best_bare: tuple[int, Path] | None = None
+
     for steps, path in enumerate((candidate, *candidate.parents)):
-        if ProjectLayout(path).gpd.is_dir():
-            return path, steps
+        layout = ProjectLayout(path)
+        if not layout.gpd.is_dir():
+            continue
+
+        marker_count = sum(
+            1
+            for name in REQUIRED_PLANNING_FILES
+            if (layout.gpd / name).exists()
+        )
+        marker_count += sum(1 for name in REQUIRED_PLANNING_DIRS if (layout.gpd / name).is_dir())
+        if (layout.gpd / STATE_JSON_BACKUP_FILENAME).exists():
+            marker_count += 1
+
+        if marker_count > 0:
+            if best_verified is None or (marker_count, -steps) > (best_verified[0], -best_verified[1]):
+                best_verified = (marker_count, steps, path)
+            continue
+
+        if best_bare is None or steps < best_bare[0]:
+            best_bare = (steps, path)
+
+    if best_verified is not None:
+        return best_verified[2], best_verified[1]
+    if best_bare is not None:
+        return best_bare[1], best_bare[0]
     return None, 0
 
 

--- a/src/gpd/core/runtime_hints.py
+++ b/src/gpd/core/runtime_hints.py
@@ -308,6 +308,22 @@ def _recent_project_resume_family(
     return None, None
 
 
+def _recent_project_provenance_fields(current_project: dict[str, object]) -> dict[str, object]:
+    """Return session/provenance fields derived from one recent-project row."""
+
+    provenance: dict[str, object] = {}
+    for target_field, source_field in (
+        ("session_hostname", "hostname"),
+        ("session_platform", "platform"),
+        ("session_last_date", "last_session_at"),
+        ("session_stopped_at", "stopped_at"),
+    ):
+        value = _normalized_row_text(current_project, source_field)
+        if value is not None:
+            provenance[target_field] = value
+    return provenance
+
+
 def _resume_context_has_local_target(payload: dict[str, object]) -> bool:
     """Return whether one resume payload already exposes a local recovery target."""
     return resume_payload_has_local_recovery_target(payload)
@@ -355,8 +371,14 @@ def _hydrate_resume_context_from_recent_project(
         if not str(hydrated.get("recorded_continuity_handoff_file") or "").strip():
             hydrated["recorded_continuity_handoff_file"] = resume_file
     elif hydration_kind == RESUME_CANDIDATE_KIND_CONTINUITY_HANDOFF and not resume_file_available:
+        if not str(hydrated.get("recorded_continuity_handoff_file") or "").strip():
+            hydrated["recorded_continuity_handoff_file"] = resume_file
         if not str(hydrated.get("missing_continuity_handoff_file") or "").strip():
             hydrated["missing_continuity_handoff_file"] = resume_file
+
+    for field_name, field_value in _recent_project_provenance_fields(current_project).items():
+        if not str(hydrated.get(field_name) or "").strip():
+            hydrated[field_name] = field_value
 
     resume_candidates = hydrated.get("resume_candidates")
     candidate = build_resume_candidate(
@@ -565,7 +587,11 @@ def build_runtime_hint_payload(
     recovery = (
         {
             "current_project": (
-                {**current_project, "summary": _selected_project_summary(reentry, current_project)}
+                {
+                    **current_project,
+                    **_recent_project_provenance_fields(current_project),
+                    "summary": _selected_project_summary(reentry, current_project),
+                }
                 if current_project is not None and reentry is not None
                 else None
             ),
@@ -588,6 +614,8 @@ def build_runtime_hint_payload(
         orientation["project_root_source"] = _suggestion_text(reentry, "source")
         orientation["project_root_auto_selected"] = _strict_bool_value(getattr(reentry, "auto_selected", None)) is True
         orientation["project_reentry_mode"] = _suggestion_text(reentry, "mode")
+        if current_project is not None:
+            orientation.update(_recent_project_provenance_fields(current_project))
     surface_session_id = _current_session_id_for_surface(project_root)
 
     normalized_latex_capability = _normalize_latex_capability(latex_capability)

--- a/src/gpd/core/state.py
+++ b/src/gpd/core/state.py
@@ -125,6 +125,7 @@ __all__ = [
     "generate_state_markdown",
     "is_valid_status",
     "load_state_json",
+    "load_state_json_readonly",
     "parse_state_md",
     "parse_state_to_json",
     "save_state_markdown",
@@ -1336,7 +1337,7 @@ def state_extract_field(content: str, field_name: str) -> str | None:
     if not match:
         return None
     value = match.group(1).strip()
-    if value == "\u2014":
+    if value == "\u2014" or value.lower() in {"not set", "[not set]"}:
         return None
     return value
 
@@ -1598,17 +1599,17 @@ def parse_state_md(content: str) -> dict:
         rf = re.search(r"\*\*Resume file:\*\*\s*(.+)", sec)
         lr = re.search(r"\*\*Last result ID:\*\*\s*(.+)", sec)
         if ld:
-            session["last_date"] = ld.group(1).strip()
+            session["last_date"] = _strip_placeholder(ld.group(1))
         if hn:
-            session["hostname"] = hn.group(1).strip()
+            session["hostname"] = _strip_placeholder(hn.group(1))
         if pf:
-            session["platform"] = pf.group(1).strip()
+            session["platform"] = _strip_placeholder(pf.group(1))
         if sa:
-            session["stopped_at"] = sa.group(1).strip()
+            session["stopped_at"] = _strip_placeholder(sa.group(1))
         if rf:
-            session["resume_file"] = rf.group(1).strip()
+            session["resume_file"] = _strip_placeholder(rf.group(1))
         if lr:
-            session["last_result_id"] = lr.group(1).strip()
+            session["last_result_id"] = _strip_placeholder(lr.group(1))
 
     # Performance metrics table
     metrics: list[dict] = []
@@ -1707,11 +1708,11 @@ def parse_state_md(content: str) -> dict:
 
 
 def _strip_placeholder(value: str | None) -> str | None:
-    """Return None if *value* is a markdown placeholder (EM_DASH or '[Not set]')."""
+    """Return None if *value* is a markdown placeholder (EM_DASH, 'not set', or '[not set]')."""
     if value is None:
         return None
     stripped = value.strip()
-    if stripped == "\u2014" or stripped.lower() == "[not set]":
+    if stripped == "\u2014" or stripped.lower() in {"not set", "[not set]"}:
         return None
     return stripped
 
@@ -3576,6 +3577,26 @@ def load_state_json(cwd: Path, integrity_mode: str = "standard") -> dict | None:
     return state_obj
 
 
+def load_state_json_readonly(cwd: Path, integrity_mode: str = "standard") -> dict | None:
+    """Load visible state without recovery writes or lockfile creation.
+
+    This is the non-mutating probe path for read-only callers that need the
+    same visibility as ``load_state_json`` but must not create lockfiles,
+    recover intent markers, or persist normalized fallback content.
+    """
+
+    state_obj, integrity_issues, _state_source = peek_state_json(
+        cwd,
+        integrity_mode=integrity_mode,
+        recover_intent=False,
+        surface_blocked_project_contract=True,
+        acquire_lock=False,
+    )
+    if integrity_mode == "review" and integrity_issues:
+        return None
+    return state_obj
+
+
 def save_state_json_locked(
     cwd: Path,
     state_obj: dict,
@@ -3823,8 +3844,23 @@ def state_get(cwd: Path, section: str | None = None) -> StateGetResult:
     if not section:
         return StateGetResult(content=content)
 
-    # Normalize snake_case → space-separated (e.g. "current_phase" → "current phase")
-    section_norm = section.replace("_", " ")
+    section_norm = section.replace("_", " ").strip()
+    if section_norm.casefold() in {"session", "continuation", "handoff"}:
+        state_obj = load_state_json_readonly(cwd)
+        if isinstance(state_obj, dict):
+            canonical_value: object | None
+            if section_norm.casefold() == "session":
+                canonical_value = state_obj.get("session")
+            elif section_norm.casefold() == "continuation":
+                canonical_value = state_obj.get("continuation")
+            else:
+                continuation = state_obj.get("continuation")
+                canonical_value = continuation.get("handoff") if isinstance(continuation, dict) else None
+            if canonical_value is not None:
+                return StateGetResult(
+                    value=json.dumps(canonical_value, indent=2),
+                    section_name=section,
+                )
 
     # Try **field:** value
     field_escaped = re.escape(section_norm)

--- a/src/gpd/core/suggest.py
+++ b/src/gpd/core/suggest.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from pydantic import ValidationError as PydanticValidationError
 
 from gpd.command_labels import canonical_command_label
+from gpd.contracts import ConventionLock
 from gpd.core.constants import (
     LITERATURE_DIR_NAME,
     PHASES_DIR_NAME,
@@ -560,6 +561,35 @@ def _conventions_are_ready(cwd: Path) -> bool:
     return all(convention_lock.get(key) and not is_bogus_value(convention_lock.get(key)) for key in CORE_CONVENTIONS)
 
 
+def _missing_conventions_from_state(state: dict[str, object]) -> tuple[str, ...]:
+    """Return canonical missing convention keys from a loaded state payload."""
+    convention_lock = state.get("convention_lock")
+    if not isinstance(convention_lock, dict):
+        return ()
+
+    try:
+        lock = ConventionLock.model_validate(convention_lock)
+    except PydanticValidationError:
+        return ()
+
+    from gpd.core.conventions import convention_check
+
+    return tuple(entry.key for entry in convention_check(lock).missing)
+
+
+def _format_missing_conventions_reason(missing: tuple[str, ...]) -> str:
+    """Format a readable missing-convention recommendation without truncating the count."""
+    from gpd.core.conventions import CONVENTION_LABELS
+
+    labels = [CONVENTION_LABELS.get(key, key.replace("_", " ").title()) for key in missing]
+    preview_count = min(4, len(labels))
+    preview = ", ".join(labels[:preview_count])
+    if len(labels) > preview_count:
+        preview += f", and {len(labels) - preview_count} more"
+    plural = "field" if len(labels) == 1 else "fields"
+    return f"{len(labels)} convention {plural} missing: {preview} — define before calculations"
+
+
 def _publication_submission_is_strictly_ready(cwd: Path, manuscript_entrypoint: Path | None) -> bool:
     if manuscript_entrypoint is None:
         return False
@@ -904,22 +934,18 @@ def suggest_next(cwd: Path, *, limit: int = 5) -> SuggestResult:
         )
 
     # ── 10. Convention gaps ─────────────────────────────────────────────
-    if state:
-        convention_lock = state.get("convention_lock")
-        if isinstance(convention_lock, dict):
-            from gpd.core.conventions import is_bogus_value
-
-            missing = [k for k in CORE_CONVENTIONS if not convention_lock.get(k) or is_bogus_value(convention_lock.get(k))]
-            if missing:
-                ctx_kwargs["missing_conventions"] = tuple(missing)
-                suggestions.append(
-                    _MutableRecommendation(
-                        action="set-conventions",
-                        priority=6,
-                        command=format_command("validate-conventions"),
-                        reason=f"Core conventions not set: {', '.join(missing)} — define before calculations",
-                    )
+    if state and not any(s.action == "resume" for s in suggestions):
+        missing = _missing_conventions_from_state(state)
+        if missing:
+            ctx_kwargs["missing_conventions"] = missing
+            suggestions.append(
+                _MutableRecommendation(
+                    action="set-conventions",
+                    priority=6,
+                    command=format_command("validate-conventions"),
+                    reason=_format_missing_conventions_reason(missing),
                 )
+            )
 
     # ── 11. No roadmap yet ──────────────────────────────────────────────
     if not roadmap_exists:

--- a/src/gpd/hooks/install_metadata.py
+++ b/src/gpd/hooks/install_metadata.py
@@ -63,6 +63,29 @@ class InstallTargetAssessment:
     has_managed_markers: bool
     missing_install_artifacts: tuple[str, ...] = ()
 
+    @property
+    def readiness_state(self) -> str:
+        """Return the coarse readiness state derived from the install assessment."""
+        return "ready" if self.state in {"absent", "clean", "owned_complete"} else "blocked"
+
+    def readiness_message(self, runtime: str | None = None) -> str:
+        """Return a human-readable summary for the current install assessment."""
+        if self.state == "owned_incomplete":
+            missing = ", ".join(f"`{item}`" for item in self.missing_install_artifacts) or "required install artifacts"
+            return f"{self.config_dir} has an incomplete GPD install; missing artifacts: {missing}."
+        if self.state == "foreign_runtime":
+            owner = f"`{self.manifest_runtime}`" if self.manifest_runtime else "another runtime"
+            runtime_label = f"`{runtime}`" if runtime else "the selected runtime"
+            return f"{self.config_dir} belongs to {owner}, not {runtime_label}."
+        if self.state == "untrusted_manifest":
+            return f"{self.config_dir} has an untrusted GPD manifest and cannot be treated as a ready install target."
+        if self.state == "owned_complete":
+            owner = f"`{self.manifest_runtime}`" if self.manifest_runtime else "the selected runtime"
+            return f"{self.config_dir} already contains a complete GPD install for {owner}."
+        if self.state == "clean":
+            return f"{self.config_dir} is ready for a new GPD install."
+        return f"{self.config_dir} is ready for installation."
+
 
 @dataclass(frozen=True, slots=True)
 class ManagedInstallSurface:

--- a/src/gpd/hooks/statusline.py
+++ b/src/gpd/hooks/statusline.py
@@ -14,9 +14,9 @@ from types import SimpleNamespace
 
 import gpd.hooks.install_context as hook_layout
 from gpd.adapters.runtime_catalog import get_hook_payload_policy
-from gpd.core.constants import ENV_GPD_DEBUG
-from gpd.core.root_resolution import resolve_project_root
-from gpd.core.state import load_state_json
+from gpd.core.constants import ENV_GPD_DEBUG, ProjectLayout
+from gpd.core.root_resolution import normalize_workspace_hint
+from gpd.core.state import peek_state_json
 from gpd.hooks.payload_policy import resolve_hook_payload_policy, resolve_hook_surface_runtime
 from gpd.hooks.payload_roots import payload_uses_alias_only_workspace_mapping
 from gpd.hooks.payload_roots import resolve_payload_roots as _resolve_payload_roots
@@ -231,11 +231,40 @@ def _read_workspace_label(
     return f"[{display_name}]"
 
 
+def _statusline_project_root(workspace_dir: str) -> Path | None:
+    """Return the most durable project root visible from one workspace path."""
+    normalized = normalize_workspace_hint(workspace_dir)
+    if normalized is None:
+        return None
+
+    bare_gpd_root: Path | None = None
+    for steps, candidate in enumerate((normalized, *normalized.parents)):
+        layout = ProjectLayout(candidate)
+        if not layout.gpd.is_dir():
+            continue
+        if (
+            layout.state_json.exists()
+            or layout.state_md.exists()
+            or layout.project_md.exists()
+            or layout.roadmap.exists()
+            or layout.phases_dir.is_dir()
+        ):
+            return candidate
+        if steps == 0 and bare_gpd_root is None:
+            bare_gpd_root = candidate
+    return bare_gpd_root
+
+
 def _read_position(workspace_dir: str) -> str:
     """Read research position from GPD/state.json."""
-    workspace_root = resolve_project_root(workspace_dir, require_layout=True) or Path(workspace_dir).expanduser().resolve(strict=False)
+    workspace_root = _statusline_project_root(workspace_dir) or Path(workspace_dir).expanduser().resolve(strict=False)
     try:
-        state = load_state_json(workspace_root)
+        state, _issues, _source = peek_state_json(
+            workspace_root,
+            recover_intent=False,
+            surface_blocked_project_contract=True,
+            acquire_lock=False,
+        )
     except Exception as exc:
         _debug(f"Failed to read state via canonical loader: {exc}")
         return ""
@@ -583,6 +612,11 @@ def main() -> None:
             hook_payload=payload_policy,
         ):
             project_dir_trusted = False
+        statusline_project_root = _statusline_project_root(workspace_dir)
+        if statusline_project_root is not None:
+            project_root = str(statusline_project_root)
+        elif not project_dir_trusted:
+            project_root = workspace_dir
         runtime_roots = SimpleNamespace(
             workspace_dir=workspace_dir,
             project_root=project_root,

--- a/src/gpd/mcp/servers/skills_server.py
+++ b/src/gpd/mcp/servers/skills_server.py
@@ -826,6 +826,29 @@ def route_skill(
                 "gpd-limiting-cases": ["limiting", "limit", "asymptotic"],
                 "gpd-sensitivity-analysis": ["sensitivity", "parameter", "uncertainty"],
                 "gpd-numerical-convergence": ["convergence", "numerical", "accuracy"],
+                "gpd-map-research": [
+                    "map an existing folder",
+                    "refresh the research map",
+                    "research map",
+                    "existing research folder",
+                ],
+                "gpd-set-tier-models": [
+                    "pin exact tier models",
+                    "configure concrete tier models",
+                    "set tier models",
+                ],
+                "gpd-start": [
+                    "guided first run",
+                    "first run",
+                    "not sure what this folder is",
+                    "not sure what fits this folder",
+                ],
+                "gpd-tour": [
+                    "guided overview",
+                    "guided tour",
+                    "read only walkthrough",
+                    "read-only walkthrough",
+                ],
             }
 
             scored: list[tuple[int, str]] = []

--- a/src/gpd/mcp/servers/state_server.py
+++ b/src/gpd/mcp/servers/state_server.py
@@ -22,13 +22,14 @@ from gpd.core.errors import GPDError
 from gpd.core.health import run_health
 from gpd.core.observability import gpd_span
 from gpd.core.phases import progress_render
+from gpd.core.root_resolution import resolve_project_root
 from gpd.core.state import (
     _project_contract_runtime_payload_for_state,
     peek_state_json,
     state_advance_plan,
     state_validate,
 )
-from gpd.core.utils import is_phase_complete
+from gpd.core.utils import is_phase_complete, matching_phase_artifact_count
 from gpd.mcp.servers import (
     ABSOLUTE_PROJECT_DIR_SCHEMA,
     configure_mcp_logging,
@@ -52,16 +53,19 @@ def load_state_json(cwd: Path) -> dict | None:
     stable even when the underlying state read path evolves.
     """
 
+    project_root = resolve_project_root(cwd, require_layout=True) or cwd.expanduser().resolve(strict=False)
+
     state_obj, _issues, state_source = peek_state_json(
-        cwd,
+        project_root,
         recover_intent=False,
         surface_blocked_project_contract=True,
+        acquire_lock=False,
     )
     if state_obj is None:
         return None
 
     project_contract_load_info, project_contract_validation, project_contract_gate = _project_contract_runtime_payload_for_state(
-        cwd,
+        project_root,
         state_obj=state_obj,
         state_source=state_source,
     )
@@ -138,7 +142,7 @@ def get_phase_info(project_dir: AbsoluteProjectDirInput, phase: str) -> dict:
             if info is None:
                 return stable_mcp_error(f"Phase {phase} not found")
             plan_count = len(info.plans)
-            summary_count = len(info.summaries)
+            summary_count = matching_phase_artifact_count(info.plans, info.summaries)
             return stable_mcp_response(
                 {
                     "phase_number": info.phase_number,

--- a/src/gpd/registry.py
+++ b/src/gpd/registry.py
@@ -1376,6 +1376,8 @@ _SKILL_CATEGORY_MAP: dict[str, str] = {
     "gpd-research": "research",
     "gpd-discover": "research",
     "gpd-explain": "help",
+    "gpd-start": "help",
+    "gpd-tour": "help",
     "gpd-map": "exploration",
     "gpd-show": "exploration",
     "gpd-progress": "status",

--- a/src/gpd/runtime_cli.py
+++ b/src/gpd/runtime_cli.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 from gpd.adapters import get_adapter
@@ -42,6 +44,32 @@ from gpd.hooks.install_metadata import (
 
 class _BridgeArgumentError(ValueError):
     """Raised when the runtime bridge arguments are malformed."""
+
+
+class _BridgeFailureKind(StrEnum):
+    """Stable internal failure kinds for runtime bridge rejection paths."""
+
+    MALFORMED_INVOCATION = "malformed_invocation"
+    UNKNOWN_RUNTIME = "unknown_runtime"
+    MISSING_INSTALL_SCOPE = "missing_install_scope"
+    MALFORMED_INSTALL_SCOPE = "malformed_install_scope"
+    MISSING_MANIFEST = "missing_manifest"
+    CORRUPT_MANIFEST = "corrupt_manifest"
+    INVALID_MANIFEST = "invalid_manifest"
+    MISSING_RUNTIME = "missing_runtime"
+    MALFORMED_RUNTIME = "malformed_runtime"
+    RUNTIME_MISMATCH = "runtime_mismatch"
+    INSTALL_SCOPE_MISMATCH = "install_scope_mismatch"
+    MISSING_INSTALL_ARTIFACTS = "missing_install_artifacts"
+
+
+@dataclass(frozen=True, slots=True)
+class _BridgeFailure:
+    """Structured internal representation of a bridge rejection."""
+
+    kind: _BridgeFailureKind
+    message: str
+    exit_code: int = 127
 
 
 class _BridgeArgumentParser(argparse.ArgumentParser):
@@ -110,6 +138,21 @@ def _format_unknown_runtime_error(exc: KeyError) -> str:
     if len(exc.args) == 1 and isinstance(exc.args[0], str):
         return exc.args[0]
     return str(exc)
+
+
+def _bridge_failure(kind: _BridgeFailureKind, message: str, *, exit_code: int = 127) -> _BridgeFailure:
+    """Build a structured failure record for bridge rejection paths."""
+
+    return _BridgeFailure(kind=kind, message=message, exit_code=exit_code)
+
+
+def _emit_bridge_failure(failure: _BridgeFailure) -> int:
+    """Write a structured bridge failure to stderr and return its exit code."""
+
+    sys.stderr.write(failure.message)
+    if not failure.message.endswith("\n"):
+        sys.stderr.write("\n")
+    return failure.exit_code
 
 
 def _canonical_runtime_name(runtime: str) -> str:
@@ -275,7 +318,7 @@ def _install_error_message(
     return (
         f"GPD runtime install incomplete for {adapter.display_name} at `{config_dir}`.\n"
         f"Missing required install artifacts: {missing_list}\n"
-        f"Repair the install with: `{repair_command}`\n"
+        f"Repair the install with: `{repair_command}`"
     )
 
 
@@ -302,7 +345,7 @@ def _runtime_mismatch_error_message(
         f"GPD runtime bridge mismatch for {_runtime_display_name(runtime)} at `{config_dir}`.\n"
         f"Resolved install manifest pins {_runtime_display_name(manifest_runtime)} (`{manifest_runtime}`), "
         "so this bridge cannot safely continue.\n"
-        f"Repair or reinstall with the owning runtime: `{repair_command}`\n"
+        f"Repair or reinstall with the owning runtime: `{repair_command}`"
     )
 
 
@@ -326,7 +369,7 @@ def _install_scope_mismatch_error_message(
     return (
         f"GPD runtime bridge scope mismatch for {_runtime_display_name(runtime)} at `{config_dir}`.\n"
         f"Resolved install manifest pins `{manifest_install_scope}`, but this bridge was launched as `{install_scope}`.\n"
-        f"Repair or reinstall with the owning scope: `{repair_command}`\n"
+        f"Repair or reinstall with the owning scope: `{repair_command}`"
     )
 
 
@@ -349,7 +392,7 @@ def _malformed_manifest_runtime_error_message(
     return (
         f"GPD runtime bridge rejected malformed install manifest at `{config_dir}`.\n"
         "The manifest `runtime` field must be a recognized non-empty runtime string.\n"
-        f"Repair or reinstall with: `{repair_command}`\n"
+        f"Repair or reinstall with: `{repair_command}`"
     )
 
 
@@ -372,7 +415,7 @@ def _missing_manifest_runtime_error_message(
     return (
         f"GPD runtime bridge rejected incomplete install manifest at `{config_dir}`.\n"
         "The manifest must declare a non-empty `runtime` field.\n"
-        f"Repair or reinstall with: `{repair_command}`\n"
+        f"Repair or reinstall with: `{repair_command}`"
     )
 
 
@@ -400,8 +443,144 @@ def _install_scope_status_error_message(
     return (
         f"GPD runtime bridge rejected incomplete install manifest at `{config_dir}`.\n"
         f"{scope_issue}\n"
-        f"Repair or reinstall with: `{repair_command}`\n"
+        f"Repair or reinstall with: `{repair_command}`"
     )
+
+
+def _classify_bridge_failure(
+    *,
+    runtime: str,
+    config_dir: Path,
+    install_scope: str,
+    explicit_target: bool,
+    cli_cwd: Path,
+    manifest_status: str,
+    manifest_runtime: str | None,
+    manifest_scope_status: str,
+    manifest_install_scope: str | None,
+    missing: tuple[str, ...] | None,
+    has_managed_install_markers: bool,
+) -> _BridgeFailure | None:
+    """Return the first structured bridge failure for the current install state."""
+
+    if manifest_scope_status == "missing_install_scope":
+        return _bridge_failure(
+            _BridgeFailureKind.MISSING_INSTALL_SCOPE,
+            _install_scope_status_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+                state=manifest_scope_status,
+            ),
+        )
+    if manifest_scope_status == "malformed_install_scope":
+        return _bridge_failure(
+            _BridgeFailureKind.MALFORMED_INSTALL_SCOPE,
+            _install_scope_status_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+                state=manifest_scope_status,
+            ),
+        )
+    if manifest_status == "missing" and has_managed_install_markers:
+        return _bridge_failure(
+            _BridgeFailureKind.MISSING_MANIFEST,
+            _missing_manifest_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if manifest_status == "corrupt":
+        return _bridge_failure(
+            _BridgeFailureKind.CORRUPT_MANIFEST,
+            _untrusted_manifest_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if manifest_status == "invalid":
+        return _bridge_failure(
+            _BridgeFailureKind.INVALID_MANIFEST,
+            _untrusted_manifest_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if manifest_status == "missing_runtime":
+        return _bridge_failure(
+            _BridgeFailureKind.MISSING_RUNTIME,
+            _missing_manifest_runtime_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if manifest_status == "malformed_runtime":
+        return _bridge_failure(
+            _BridgeFailureKind.MALFORMED_RUNTIME,
+            _malformed_manifest_runtime_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if manifest_runtime is not None and manifest_runtime != runtime:
+        return _bridge_failure(
+            _BridgeFailureKind.RUNTIME_MISMATCH,
+            _runtime_mismatch_error_message(
+                runtime=runtime,
+                manifest_runtime=manifest_runtime,
+                manifest_install_scope=manifest_install_scope,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+            ),
+        )
+    if isinstance(manifest_install_scope, str) and manifest_install_scope in {"local", "global"}:
+        if manifest_install_scope != install_scope:
+            return _bridge_failure(
+                _BridgeFailureKind.INSTALL_SCOPE_MISMATCH,
+                _install_scope_mismatch_error_message(
+                    runtime=runtime,
+                    manifest_install_scope=manifest_install_scope,
+                    config_dir=config_dir,
+                    install_scope=install_scope,
+                    explicit_target=explicit_target,
+                    cli_cwd=cli_cwd,
+                ),
+            )
+    if missing:
+        return _bridge_failure(
+            _BridgeFailureKind.MISSING_INSTALL_ARTIFACTS,
+            _install_error_message(
+                runtime=runtime,
+                config_dir=config_dir,
+                install_scope=install_scope,
+                explicit_target=explicit_target,
+                cli_cwd=cli_cwd,
+                missing=missing,
+            ),
+        )
+    return None
 
 
 def _missing_manifest_error_message(
@@ -424,7 +603,7 @@ def _missing_manifest_error_message(
     return (
         f"GPD runtime bridge rejected missing install manifest at `{config_dir}`.\n"
         f"Managed installs must include `{shared_install.manifest_name}` so runtime identity stays authoritative.\n"
-        f"Repair or reinstall with: `{repair_command}`\n"
+        f"Repair or reinstall with: `{repair_command}`"
     )
 
 
@@ -447,7 +626,7 @@ def _untrusted_manifest_error_message(
     return (
         f"GPD runtime bridge rejected unreadable install manifest at `{config_dir}`.\n"
         "The manifest must be a JSON object with a non-empty `runtime` field.\n"
-        f"Repair or reinstall with: `{repair_command}`\n"
+        f"Repair or reinstall with: `{repair_command}`"
     )
 
 
@@ -457,16 +636,19 @@ def main(argv: list[str] | None = None) -> int:
     try:
         options, gpd_args = _parse_args(raw_argv)
     except _BridgeArgumentError as exc:
-        sys.stderr.write(_bridge_argument_error_message(str(exc)) + "\n")
-        return 127
+        return _emit_bridge_failure(
+            _bridge_failure(
+                _BridgeFailureKind.MALFORMED_INVOCATION,
+                _bridge_argument_error_message(str(exc)),
+            )
+        )
     runtime = _canonical_runtime_name(options.runtime)
     cli_cwd = _resolve_cli_cwd_from_argv(gpd_args)
     _maybe_reexec_from_checkout(raw_argv, cli_cwd=cli_cwd)
     try:
         adapter = get_adapter(runtime)
     except KeyError as exc:
-        sys.stderr.write(_format_unknown_runtime_error(exc) + "\n")
-        return 127
+        return _emit_bridge_failure(_bridge_failure(_BridgeFailureKind.UNKNOWN_RUNTIME, _format_unknown_runtime_error(exc)))
     config_dir = _resolve_config_dir(
         options.config_dir,
         runtime=runtime,
@@ -482,106 +664,40 @@ def main(argv: list[str] | None = None) -> int:
     repair_explicit_target = (
         manifest_explicit_target if manifest_explicit_target is not None else bool(options.explicit_target)
     )
-    if manifest_scope_status in {"missing_install_scope", "malformed_install_scope"}:
-        sys.stderr.write(
-            _install_scope_status_error_message(
-                runtime=runtime,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-                state=manifest_scope_status,
-            )
-        )
-        return 127
     if manifest_scope_status == "ok":
         manifest_install_scope = manifest_scope_payload.get("install_scope")
         if not isinstance(manifest_install_scope, str):
             manifest_install_scope = None
-    if manifest_status == "missing" and config_dir_has_managed_install_markers(config_dir):
-        sys.stderr.write(
-            _missing_manifest_error_message(
-                runtime=runtime,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-            )
+    has_managed_install_markers = config_dir_has_managed_install_markers(config_dir)
+    failure = _classify_bridge_failure(
+        runtime=runtime,
+        config_dir=config_dir,
+        install_scope=options.install_scope,
+        explicit_target=repair_explicit_target,
+        cli_cwd=cli_cwd,
+        manifest_status=manifest_status,
+        manifest_runtime=manifest_runtime,
+        manifest_scope_status=manifest_scope_status,
+        manifest_install_scope=manifest_install_scope,
+        missing=None,
+        has_managed_install_markers=has_managed_install_markers,
+    )
+    if failure is None:
+        failure = _classify_bridge_failure(
+            runtime=runtime,
+            config_dir=config_dir,
+            install_scope=options.install_scope,
+            explicit_target=repair_explicit_target,
+            cli_cwd=cli_cwd,
+            manifest_status=manifest_status,
+            manifest_runtime=manifest_runtime,
+            manifest_scope_status=manifest_scope_status,
+            manifest_install_scope=manifest_install_scope,
+            missing=adapter.missing_install_artifacts(config_dir),
+            has_managed_install_markers=has_managed_install_markers,
         )
-        return 127
-    if manifest_status in {"corrupt", "invalid"}:
-        sys.stderr.write(
-            _untrusted_manifest_error_message(
-                runtime=runtime,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-            )
-        )
-        return 127
-    if manifest_status == "missing_runtime":
-        sys.stderr.write(
-            _missing_manifest_runtime_error_message(
-                runtime=runtime,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-            )
-        )
-        return 127
-    if manifest_status == "malformed_runtime":
-        sys.stderr.write(
-            _malformed_manifest_runtime_error_message(
-                runtime=runtime,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-            )
-        )
-        return 127
-    if manifest_runtime is not None and manifest_runtime != runtime:
-        sys.stderr.write(
-            _runtime_mismatch_error_message(
-                runtime=runtime,
-                manifest_runtime=manifest_runtime,
-                manifest_install_scope=manifest_install_scope,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-            )
-        )
-        return 127
-    if isinstance(manifest_install_scope, str) and manifest_install_scope in {"local", "global"}:
-        if manifest_install_scope != options.install_scope:
-            sys.stderr.write(
-                _install_scope_mismatch_error_message(
-                    runtime=runtime,
-                    manifest_install_scope=manifest_install_scope,
-                    config_dir=config_dir,
-                    install_scope=options.install_scope,
-                    explicit_target=repair_explicit_target,
-                    cli_cwd=cli_cwd,
-                )
-            )
-            return 127
-
-    missing = adapter.missing_install_artifacts(config_dir)
-    if missing:
-        sys.stderr.write(
-            _install_error_message(
-                runtime=adapter.runtime_name,
-                config_dir=config_dir,
-                install_scope=options.install_scope,
-                explicit_target=repair_explicit_target,
-                cli_cwd=cli_cwd,
-                missing=missing,
-            )
-        )
-        return 127
+    if failure is not None:
+        return _emit_bridge_failure(failure)
 
     prior_active_runtime = os.environ.get(ENV_GPD_ACTIVE_RUNTIME)
     prior_disable_checkout_reexec = os.environ.get(ENV_GPD_DISABLE_CHECKOUT_REEXEC)

--- a/src/gpd/specs/workflows/help.md
+++ b/src/gpd/specs/workflows/help.md
@@ -550,12 +550,14 @@ Check research status and intelligently route to next action.
 - Offers to execute next plan or create it if missing
 - Detects 100% milestone completion
 - Use `--brief` when returning and you only need orientation
-- Use `--reconcile` when state appears out of sync with disk artifacts
+- Use `--reconcile` only on the runtime `gpd:progress` surface when state appears out of sync with disk artifacts
+- The local CLI `gpd progress` is a separate read-only renderer and uses `json|bar|table` instead of these runtime flags
 
 Usage: `gpd:progress`
-Usage: `gpd:progress --full` (detailed view with all phase artifacts)
-Usage: `gpd:progress --brief` (compact one-line status)
-Usage: `gpd:progress --reconcile` (fix diverged STATE.md and state.json)
+Usage: `gpd:progress --full` (detailed runtime view with all phase artifacts)
+Usage: `gpd:progress --brief` (compact runtime orientation)
+Usage: `gpd:progress --reconcile` (runtime-only state-vs-disk reconciliation mode)
+Local CLI: `gpd progress json|bar|table` (read-only render formats)
 
 ### Session Management
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -4439,7 +4439,7 @@ def test_doctor_target_dir_stays_local_when_target_is_not_global(mock_doctor, tm
 
 
 @patch("gpd.core.health.run_doctor")
-def test_doctor_runtime_mode_uses_detected_installed_target_when_scope_is_unspecified(
+def test_doctor_runtime_mode_defaults_to_local_target_when_scope_is_unspecified(
     mock_doctor, tmp_path: Path
 ) -> None:
     from gpd.specs import SPECS_DIR
@@ -4448,11 +4448,11 @@ def test_doctor_runtime_mode_uses_detected_installed_target_when_scope_is_unspec
     mock_result.model_dump.return_value = {"mode": "runtime-readiness", "overall": "ok"}
     mock_doctor.return_value = mock_result
     runtime_name = list_runtimes()[0]
-    detected_target = tmp_path / "runtime-global-target"
+    local_target = cli_module._get_adapter_or_error(runtime_name, action="doctor").resolve_target_dir(False, tmp_path)
 
     with patch(
         "gpd.hooks.runtime_detect.detect_runtime_install_target",
-        return_value=SimpleNamespace(config_dir=detected_target, install_scope="global"),
+        return_value=SimpleNamespace(config_dir=tmp_path / "runtime-global-target", install_scope="global"),
     ):
         result = runner.invoke(app, ["--cwd", str(tmp_path), "--raw", "doctor", "--runtime", runtime_name])
 
@@ -4461,8 +4461,8 @@ def test_doctor_runtime_mode_uses_detected_installed_target_when_scope_is_unspec
     mock_doctor.assert_called_once_with(
         specs_dir=SPECS_DIR,
         runtime=runtime_name,
-        install_scope="global",
-        target_dir=detected_target,
+        install_scope="local",
+        target_dir=local_target,
         cwd=tmp_path,
         live_executable_probes=False,
     )

--- a/tests/core/test_command_help_drift_regressions.py
+++ b/tests/core/test_command_help_drift_regressions.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMMANDS_DIR = REPO_ROOT / "src/gpd/commands"
+
+
+def test_regression_check_wrapper_marks_quick_as_local_cli_only() -> None:
+    text = (COMMANDS_DIR / "regression-check.md").read_text(encoding="utf-8")
+
+    assert 'argument-hint: "[phase] [--quick]"' in text
+    assert "local CLI `--quick` flag is a wrapper-only scope reducer" in text
+    assert "Local CLI flag `--quick` additionally limits the scan" in text
+
+
+def test_export_logs_wrapper_surfaces_passthrough_filters() -> None:
+    text = (COMMANDS_DIR / "export-logs.md").read_text(encoding="utf-8")
+
+    assert '--command <label>' in text
+    assert '--phase <phase>' in text
+    assert '--category <name>' in text
+    assert "local-only CLI passthrough filters `--command`, `--phase`, and `--category`" in text
+    assert 'gpd --raw observe export $ARGUMENTS' in text

--- a/tests/core/test_context.py
+++ b/tests/core/test_context.py
@@ -843,6 +843,23 @@ def _write_structured_state_memory(tmp_path: Path) -> None:
     (tmp_path / "GPD" / "state.json").write_text(json.dumps(state), encoding="utf-8")
 
 
+def _write_placeholder_heavy_structured_state_memory(tmp_path: Path) -> None:
+    """Persist a convention lock with placeholder-heavy values into state.json."""
+    from gpd.core.state import default_state_dict
+
+    state = default_state_dict()
+    state["convention_lock"].update(
+        {
+            "metric_signature": "mostly-plus",
+            "fourier_convention": "not set",
+            "natural_units": "[not set]",
+            "gauge_choice": "\u2014",
+            "coordinate_system": "Cartesian",
+        }
+    )
+    (tmp_path / "GPD" / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+
 def _write_current_execution(tmp_path: Path, payload: dict[str, object]) -> None:
     observability = tmp_path / "GPD" / "observability"
     observability.mkdir(parents=True, exist_ok=True)
@@ -1210,6 +1227,24 @@ class TestInitExecutePhase:
         assert ctx["derived_intermediate_results"][0]["equation"] == "E = mc^2"
         assert ctx["derived_approximation_count"] == 1
         assert ctx["derived_approximations"][0]["name"] == "weak coupling"
+
+    def test_surfaces_material_convention_counts_with_placeholders(self, tmp_path: Path) -> None:
+        _setup_project(tmp_path)
+        phase_dir = _create_phase_dir(tmp_path, "01-setup")
+        (phase_dir / "a-PLAN.md").write_text("plan", encoding="utf-8")
+        _write_placeholder_heavy_structured_state_memory(tmp_path)
+
+        ctx = init_verify_work(tmp_path, "1")
+
+        assert ctx["convention_lock"]["fourier_convention"] == "not set"
+        assert ctx["convention_lock"]["natural_units"] == "[not set]"
+        assert ctx["convention_lock"]["gauge_choice"] == "\u2014"
+        assert ctx["convention_lock_count"] == 2
+        assert ctx["derived_convention_lock_count"] == 2
+        assert ctx["derived_convention_lock"] == {
+            "metric_signature": "mostly-plus",
+            "coordinate_system": "Cartesian",
+        }
 
     def test_does_not_bootstrap_manuscript_proof_review_manifest(self, tmp_path: Path) -> None:
         _setup_project(tmp_path)

--- a/tests/core/test_conventions.py
+++ b/tests/core/test_conventions.py
@@ -69,6 +69,7 @@ def test_bogus_values():
     assert is_bogus_value("null") is True
     assert is_bogus_value("undefined") is True
     assert is_bogus_value("none") is True
+    assert is_bogus_value("not set") is True
     assert is_bogus_value("  None  ") is True
 
 
@@ -141,6 +142,14 @@ def test_convention_set_force_overwrite():
     assert lock.metric_signature == "mostly-minus"
 
 
+def test_convention_set_overwrites_placeholder_without_force():
+    lock = ConventionLock(metric_signature="not set")
+    result = convention_set(lock, "metric_signature", "mostly-plus")
+    assert result.updated is True
+    assert result.previous == "not set"
+    assert lock.metric_signature == "mostly-plus"
+
+
 def test_convention_set_custom():
     lock = ConventionLock()
     result = convention_set(lock, "my_custom_convention", "some-value")
@@ -169,6 +178,16 @@ def test_convention_list_with_values():
     assert isinstance(entry, ConventionEntry)
     assert entry.is_set is True
     assert entry.value == "mostly-plus"
+
+
+def test_convention_list_treats_placeholder_as_unset():
+    lock = ConventionLock(metric_signature="not set")
+    result = convention_list(lock)
+    entry = result.conventions["metric_signature"]
+    assert result.set_count == 0
+    assert result.unset_count == len(KNOWN_CONVENTIONS)
+    assert entry.is_set is False
+    assert entry.value == "not set"
 
 
 # ─── convention_diff ─────────────────────────────────────────────────────────
@@ -227,6 +246,16 @@ def test_convention_check_with_custom():
     lock.custom_conventions["my_custom"] = "value"
     result = convention_check(lock)
     assert result.custom_count == 1
+
+
+def test_convention_check_treats_placeholder_as_missing():
+    lock = ConventionLock(metric_signature="not set")
+    result = convention_check(lock)
+    assert result.complete is False
+    assert result.set_count == 0
+    assert result.missing_count == len(KNOWN_CONVENTIONS)
+    assert all(entry.key != "metric_signature" for entry in result.set_conventions)
+    assert any(entry.key == "metric_signature" for entry in result.missing)
 
 
 # ─── parse_assert_conventions ────────────────────────────────────────────────

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -24,6 +24,7 @@ from gpd.core.health import (
     HealthCheck,
     HealthReport,
     HealthSummary,
+    RuntimeTargetAssessment,
     _doctor_check_latex_toolchain,
     _doctor_check_workflow_presets,
     build_unattended_readiness_result,
@@ -266,6 +267,32 @@ class TestHealthModels:
         restored = DoctorReport.model_validate(report.model_dump())
 
         assert restored.live_executable_probes is True
+
+    def test_doctor_report_roundtrip_preserves_target_assessment(self):
+        report = DoctorReport(
+            overall=CheckStatus.OK,
+            version="0.1.0",
+            summary=HealthSummary(ok=1, warn=0, fail=0, total=1),
+            target_assessment=RuntimeTargetAssessment(
+                config_dir="/tmp/runtime-target",
+                expected_runtime="runtime-under-test",
+                state="clean",
+                manifest_state="missing",
+                manifest_runtime=None,
+                has_managed_markers=False,
+                missing_install_artifacts=[],
+                readiness_state="ready",
+                readiness_message="/tmp/runtime-target is ready for a new GPD install.",
+            ),
+            checks=[HealthCheck(status=CheckStatus.OK, label="A")],
+        )
+
+        restored = DoctorReport.model_validate(report.model_dump())
+
+        assert restored.target_assessment is not None
+        assert restored.target_assessment.state == "clean"
+        assert restored.target_assessment.readiness_state == "ready"
+        assert restored.target_assessment.readiness_message == "/tmp/runtime-target is ready for a new GPD install."
 
     def test_extract_doctor_blockers_returns_only_failures(self):
         report = DoctorReport(
@@ -2170,8 +2197,15 @@ trigger:
 
         _report, checks = self._run_runtime_doctor(tmp_path, assessment=assessment, target_dir=target_dir)
 
+        assert assessment.readiness_state == "ready"
+        assert _report.target_assessment is not None
+        assert _report.target_assessment.state == "clean"
+        assert _report.target_assessment.readiness_state == "ready"
+        assert _report.target_assessment.readiness_message == f"{target_dir.resolve(strict=False)} is ready for a new GPD install."
         assert checks["Runtime Config Target"].status == CheckStatus.OK
         assert checks["Runtime Config Target"].details["install_state"] == "clean"
+        assert checks["Runtime Config Target"].details["target_readiness_state"] == "ready"
+        assert checks["Runtime Config Target"].details["target_assessment"]["state"] == "clean"
         assert checks["Runtime Config Target"].issues == []
         assert checks["Runtime Config Target"].warnings == []
 
@@ -2219,9 +2253,15 @@ trigger:
                 target_dir=assessment.config_dir,
             )
 
+            assert assessment.readiness_state == "blocked"
+            assert report.target_assessment is not None
+            assert report.target_assessment.state == install_state
+            assert report.target_assessment.readiness_state == "blocked"
             assert report.overall == CheckStatus.FAIL
             assert checks["Runtime Config Target"].status == CheckStatus.FAIL
             assert checks["Runtime Config Target"].details["install_state"] == install_state
+            assert checks["Runtime Config Target"].details["target_readiness_state"] == "blocked"
+            assert checks["Runtime Config Target"].details["target_assessment"]["state"] == install_state
             assert any(expected_issue in issue for issue in checks["Runtime Config Target"].issues)
 
 

--- a/tests/core/test_observability.py
+++ b/tests/core/test_observability.py
@@ -772,6 +772,113 @@ def test_derive_execution_visibility_uses_valid_progress_command_in_help_paths(
     assert all("--brief" not in suggestion.command for suggestion in visibility.suggested_next_commands)
 
 
+def test_derive_execution_visibility_marks_snapshot_only_visibility_when_lineage_head_is_malformed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    project = _bootstrap_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    observability_dir = project / "GPD" / "observability"
+    observability_dir.mkdir(parents=True, exist_ok=True)
+    (observability_dir / "current-execution.json").write_text(
+        json.dumps(
+            {
+                "session_id": "sess-snapshot-only",
+                "phase": "03",
+                "plan": "01",
+                "segment_status": "active",
+                "current_task": "Inspect a live segment",
+                "updated_at": _iso_minutes_ago(1),
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project / "GPD" / "lineage").mkdir(parents=True, exist_ok=True)
+    (project / "GPD" / "lineage" / "execution-head.json").write_text("{not valid json}", encoding="utf-8")
+
+    from gpd.core.observability import derive_execution_visibility
+
+    visibility = derive_execution_visibility(project)
+    assert visibility is not None
+    assert visibility.has_live_execution is True
+    assert visibility.visibility_mode == "snapshot-only"
+    assert visibility.status_classification == "active"
+    assert visibility.assessment == "snapshot-only active"
+    assert visibility.visibility_note is not None
+    assert "execution-head.json" in visibility.visibility_note
+    assert all(suggestion.command != "gpd observe show --session sess-snapshot-only --last 20" for suggestion in visibility.suggested_next_commands)
+    assert visibility.suggested_next_commands[0].command == "gpd observe sessions --last 5"
+
+
+def test_derive_execution_visibility_marks_trace_only_visibility_when_current_snapshot_is_malformed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    project = _bootstrap_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    from gpd.core.execution_lineage import project_execution_lineage_head, write_execution_lineage_head
+
+    execution = {
+        "session_id": "sess-trace-only",
+        "phase": "03",
+        "plan": "01",
+        "segment_status": "waiting_review",
+        "waiting_for_review": True,
+        "updated_at": _iso_minutes_ago(3),
+    }
+    write_execution_lineage_head(
+        project,
+        project_execution_lineage_head(
+            execution,
+            last_applied_seq=7,
+            last_applied_event_id="evt-7",
+            recorded_at=_iso_minutes_ago(3),
+        ),
+    )
+    (project / "GPD" / "observability").mkdir(parents=True, exist_ok=True)
+    (project / "GPD" / "observability" / "current-execution.json").write_text("{not valid json}", encoding="utf-8")
+
+    from gpd.core.observability import derive_execution_visibility
+
+    visibility = derive_execution_visibility(project)
+    assert visibility is not None
+    assert visibility.has_live_execution is True
+    assert visibility.visibility_mode == "trace-only"
+    assert visibility.status_classification == "waiting"
+    assert visibility.assessment == "trace-only waiting"
+    assert visibility.visibility_note is not None
+    assert "current-execution.json" in visibility.visibility_note
+    assert visibility.suggested_next_commands[0].command == "gpd observe sessions --last 5"
+    assert all("--session" not in suggestion.command for suggestion in visibility.suggested_next_commands)
+
+
+def test_derive_execution_visibility_marks_degraded_visibility_for_malformed_live_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    project = _bootstrap_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    observability_dir = project / "GPD" / "observability"
+    observability_dir.mkdir(parents=True, exist_ok=True)
+    (observability_dir / "current-execution.json").write_text("{not valid json}", encoding="utf-8")
+    (project / "GPD" / "lineage").mkdir(parents=True, exist_ok=True)
+    (project / "GPD" / "lineage" / "execution-head.json").write_text("{also not valid json}", encoding="utf-8")
+
+    from gpd.core.observability import derive_execution_visibility
+
+    visibility = derive_execution_visibility(project)
+    assert visibility is not None
+    assert visibility.has_live_execution is False
+    assert visibility.visibility_mode == "degraded"
+    assert visibility.status_classification == "degraded"
+    assert visibility.assessment == "degraded"
+    assert visibility.visibility_note is not None
+    assert "current-execution.json" in visibility.visibility_note
+    assert "execution-head.json" in visibility.visibility_note
+    assert visibility.suggested_next_commands[0].command == "gpd observe sessions --last 5"
+    assert any("degraded" in step for step in visibility.suggested_next_steps)
+
+
 def test_derive_execution_visibility_surfaces_pending_tangent_without_new_classification(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/core/test_phase_file_queries.py
+++ b/tests/core/test_phase_file_queries.py
@@ -62,6 +62,20 @@ class TestVerifyPhaseCompleteness:
         assert result.summary_count == 1
         assert result.incomplete_plans == ["02-core-02"]
 
+    def test_zero_plan_phase_fails_closed(self, tmp_path: Path, state_project_factory) -> None:
+        cwd = state_project_factory(tmp_path, current_phase="03", status="Planning")
+        _create_phase_dir(cwd, "03-empty")
+        _write_roadmap(cwd, "# Roadmap\n\n### Phase 3: Empty\n**Goal:** Nothing yet\n")
+
+        result = verify_phase_completeness(cwd, "3")
+
+        assert result.complete is False
+        assert result.plan_count == 0
+        assert result.summary_count == 0
+        assert result.incomplete_plans == []
+        assert result.orphan_summaries == []
+        assert result.errors == []
+
     def test_phase_not_found(self, tmp_path: Path, state_project_factory) -> None:
         cwd = state_project_factory(tmp_path)
 

--- a/tests/core/test_project_reentry.py
+++ b/tests/core/test_project_reentry.py
@@ -149,6 +149,33 @@ def test_resolve_project_reentry_surfaces_partial_recoverable_workspace(tmp_path
     assert resolution.candidates[0].state_exists is True
 
 
+def test_resolve_project_reentry_prefers_unique_strong_recent_project_over_partial_recoverable_current_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace = _make_gpd_workspace(tmp_path / "workspace", roadmap=True, state=True)
+    recent = _make_gpd_workspace(tmp_path / "recent-project", project=True)
+
+    resolution = resolve_project_reentry(
+        workspace,
+        recent_rows=[
+            _recent_row(recent, last_session_at="2026-03-28T12:00:00+00:00"),
+        ],
+    )
+
+    assert resolution.mode == "auto-recent-project"
+    assert resolution.source == "recent_project"
+    assert resolution.auto_selected is True
+    assert resolution.requires_user_selection is False
+    assert resolution.project_root == recent.resolve(strict=False).as_posix()
+    assert resolution.selected_candidate is not None
+    assert resolution.selected_candidate.source == "recent_project"
+    assert resolution.selected_candidate.auto_selectable is True
+    assert resolution.candidates[0].source == "recent_project"
+    assert resolution.candidates[0].project_root == recent.resolve(strict=False).as_posix()
+    assert resolution.candidates[1].source == "current_workspace"
+    assert resolution.candidates[1].project_root == workspace.resolve(strict=False).as_posix()
+
+
 def test_resolve_project_reentry_does_not_prefer_unrecoverable_state_file_over_recent_project(tmp_path: Path) -> None:
     workspace = _make_gpd_workspace(tmp_path / "workspace")
     (workspace / "GPD" / "state.json").write_text("[]\n", encoding="utf-8")

--- a/tests/core/test_prompt_cli_consistency.py
+++ b/tests/core/test_prompt_cli_consistency.py
@@ -417,6 +417,19 @@ def test_progress_prompt_requires_project_not_roadmap() -> None:
     assert 'files: ["GPD/ROADMAP.md"]' not in command
 
 
+def test_progress_prompt_and_help_clarify_runtime_vs_local_cli_boundary() -> None:
+    command = (REPO_ROOT / "src/gpd/commands/progress.md").read_text(encoding="utf-8")
+    help_workflow = (WORKFLOWS_DIR / "help.md").read_text(encoding="utf-8")
+    progress_section = _extract_between(help_workflow, "### Progress Tracking", "### Session Management")
+    normalized_command = " ".join(command.split())
+    normalized_progress_section = " ".join(progress_section.split())
+
+    assert "The local CLI `gpd progress` is a separate read-only renderer" in normalized_command
+    assert "takes `json|bar|table` and does not accept these flags" in normalized_command
+    assert "The local CLI `gpd progress` is a separate read-only renderer" in normalized_progress_section
+    assert "Local CLI: `gpd progress json|bar|table`" in normalized_progress_section
+
+
 def test_plan_phase_prompt_is_a_thin_dispatch_shell() -> None:
     command = (REPO_ROOT / "src/gpd/commands/plan-phase.md").read_text(encoding="utf-8")
 

--- a/tests/core/test_query.py
+++ b/tests/core/test_query.py
@@ -343,7 +343,7 @@ class TestQuery:
         result = query(empty_project, provides="anything")
         assert result.total == 0
 
-    def test_query_does_not_search_intermediate_results_registry(self, tmp_path: Path) -> None:
+    def test_query_search_includes_intermediate_results_registry(self, tmp_path: Path) -> None:
         planning_dir = tmp_path / "GPD"
         planning_dir.mkdir()
         (planning_dir / "state.json").write_text(
@@ -367,7 +367,9 @@ class TestQuery:
 
         result = query(tmp_path, equation="E = mc^2")
 
-        assert result.total == 0
+        assert result.total == 1
+        assert result.matches[0].field == "result_registry"
+        assert result.matches[0].value == "R-01"
 
     def test_query_phase_range(self, project_dir: Path) -> None:
         result = query(project_dir, phase_range="1-2")
@@ -620,6 +622,46 @@ class TestQueryDeps:
         assert result.provides_by.phase in ("3", "03")
         assert len(result.provider_conflicts) == 1
         assert result.provider_conflicts[0].phase in ("1", "01")
+
+    def test_deps_includes_intermediate_result_registry_dependency_chain(self, tmp_path: Path) -> None:
+        planning_dir = tmp_path / "GPD"
+        planning_dir.mkdir()
+        (planning_dir / "state.json").write_text(
+            dedent("""\
+            {
+              "intermediate_results": [
+                {
+                  "id": "R-01-foundation",
+                  "equation": "F",
+                  "description": "foundation",
+                  "phase": "01",
+                  "depends_on": [],
+                  "verified": false,
+                  "verification_records": []
+                },
+                {
+                  "id": "R-02-target",
+                  "equation": "T",
+                  "description": "target",
+                  "phase": "02",
+                  "depends_on": ["R-01-foundation"],
+                  "verified": false,
+                  "verification_records": []
+                }
+              ]
+            }
+            """),
+            encoding="utf-8",
+        )
+
+        target = query_deps(tmp_path, "R-02-target")
+        foundation = query_deps(tmp_path, "R-01-foundation")
+
+        assert target.provides_by is not None
+        assert target.provides_by.value == "R-02-target"
+        assert target.direct_deps == ["R-01-foundation"]
+        assert target.depends_on == ["R-01-foundation"]
+        assert foundation.required_by[0].value == "R-02-target"
 
 
 # ─── query_assumptions ───────────────────────────────────────────────────────────

--- a/tests/core/test_recent_project_cli_regressions.py
+++ b/tests/core/test_recent_project_cli_regressions.py
@@ -74,3 +74,18 @@ def test_render_recent_resume_summary_keeps_runtime_specific_commands_generic(
     assert "$gpd-resume-work" not in output
     assert "/gpd:suggest-next" not in output
     assert "$gpd-suggest-next" not in output
+
+
+def test_resume_recent_requests_only_the_bounded_recent_picker_window(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_list_recent_projects(store_root=None, last=None):
+        captured["last"] = last
+        return []
+
+    monkeypatch.setattr("gpd.core.recent_projects.list_recent_projects", _fake_list_recent_projects)
+
+    rows = cli_module._load_recent_projects_rows(last=20)
+
+    assert rows == []
+    assert captured["last"] == 20

--- a/tests/core/test_resume_reentry_contract.py
+++ b/tests/core/test_resume_reentry_contract.py
@@ -68,3 +68,17 @@ def test_recoverable_project_context_treats_unreadable_state_as_non_recoverable(
     assert state_exists is False
     assert roadmap_exists is False
     assert project_exists is False
+
+
+def test_init_resume_ignores_empty_nested_gpd_stub_when_workspace_has_real_ancestor_project(
+    tmp_path: Path,
+) -> None:
+    project_root = _make_recoverable_project(tmp_path / "project")
+    nested_workspace = project_root / "workspace" / "notes"
+    (nested_workspace / PLANNING_DIR_NAME).mkdir(parents=True)
+
+    ctx = init_resume(nested_workspace)
+
+    assert ctx["project_root"] == str(project_root.resolve(strict=False))
+    assert ctx["project_root_source"] == "current_workspace"
+    assert ctx["workspace_root"] == str(nested_workspace.resolve(strict=False))

--- a/tests/core/test_root_resolution.py
+++ b/tests/core/test_root_resolution.py
@@ -13,6 +13,16 @@ from gpd.core.root_resolution import (
 )
 
 
+def _make_project_root(project: Path) -> None:
+    gpd_dir = project / "GPD"
+    gpd_dir.mkdir(parents=True)
+    (gpd_dir / "state.json").write_text("{}", encoding="utf-8")
+    (gpd_dir / "STATE.md").write_text("# State\n", encoding="utf-8")
+    (gpd_dir / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+    (gpd_dir / "PROJECT.md").write_text("# Project\n", encoding="utf-8")
+    (gpd_dir / "phases").mkdir()
+
+
 def test_normalize_workspace_hint_resolves_explicit_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -53,7 +63,7 @@ def test_resolve_project_roots_prefers_verified_workspace_over_unverified_explic
     project = tmp_path / "project"
     workspace = project / "src" / "notes"
     missing_project_dir = tmp_path / "not-a-project"
-    (project / "GPD").mkdir(parents=True)
+    _make_project_root(project)
     workspace.mkdir(parents=True)
 
     resolution = resolve_project_roots(workspace, project_dir=missing_project_dir)
@@ -113,6 +123,42 @@ def test_resolve_project_roots_ignores_a_file_named_gpd(tmp_path: Path) -> None:
     assert resolution.has_project_layout is False
     assert resolution.walk_up_steps == 0
     assert resolve_project_root(workspace, require_layout=True) is None
+
+
+def test_resolve_project_roots_prefers_stronger_ancestor_over_nested_empty_gpd_stub(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    workspace = project / "workspace" / "notes"
+    nested_stub = workspace / "GPD"
+    _make_project_root(project)
+    nested_stub.mkdir(parents=True)
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    resolution = resolve_project_roots(workspace)
+
+    assert resolution is not None
+    assert resolution.project_root == project.resolve(strict=False)
+    assert resolution.basis == RootResolutionBasis.WORKSPACE
+    assert resolution.confidence == RootResolutionConfidence.HIGH
+    assert resolution.has_project_layout is True
+    assert resolution.walk_up_steps == 2
+
+
+def test_resolve_project_roots_falls_back_to_nearest_bare_gpd_when_no_stronger_ancestor_exists(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "GPD").mkdir(parents=True)
+
+    resolution = resolve_project_roots(workspace)
+
+    assert resolution is not None
+    assert resolution.project_root == workspace.resolve(strict=False)
+    assert resolution.basis == RootResolutionBasis.WORKSPACE
+    assert resolution.confidence == RootResolutionConfidence.HIGH
+    assert resolution.has_project_layout is True
+    assert resolution.walk_up_steps == 0
 
 
 def test_resolve_project_root_require_layout_rejects_unverified_fallback(tmp_path: Path) -> None:

--- a/tests/core/test_roundtrip.py
+++ b/tests/core/test_roundtrip.py
@@ -58,6 +58,58 @@ def _write_state(tmp_path: Path, content: str) -> Path:
     return p
 
 
+def test_roadmap_analyze_does_not_duplicate_current_phase_in_next_phase(tmp_path: Path) -> None:
+    _setup_project(tmp_path)
+    _write_roadmap(
+        tmp_path,
+        """\
+        ## Milestone v1.0: Initial Setup
+
+        ### Phase 1: Setup
+        **Goal:** Get started
+        **Plans:** 1 plans
+
+        ### Phase 2: Research
+        **Goal:** Investigate the next step
+        **Plans:** 0 plans
+
+        ### Phase 3: Validation
+        **Goal:** Validate the result
+        **Plans:** 0 plans
+        """,
+    )
+    _write_state(
+        tmp_path,
+        """\
+        # Research State
+
+        ## Current Position
+
+        **Current Phase:** 2
+        **Current Phase Name:** Research
+        **Total Phases:** 3
+        **Current Plan:** 1
+        **Total Plans in Phase:** 1
+        **Status:** in_progress
+        **Last Activity:** 2026-02-23
+        **Last Activity Description:** Started
+        """,
+    )
+
+    phase1 = _create_phase(tmp_path, "01-setup")
+    (phase1 / "01-01-PLAN.md").write_text("plan", encoding="utf-8")
+    (phase1 / "01-01-SUMMARY.md").write_text("summary", encoding="utf-8")
+
+    phase2 = _create_phase(tmp_path, "02-research")
+    (phase2 / "02-01-RESEARCH.md").write_text("notes", encoding="utf-8")
+
+    result = roadmap_analyze(tmp_path)
+
+    assert result.current_phase == "2"
+    assert result.next_phase == "3"
+    assert result.current_phase != result.next_phase
+
+
 # ─── Phase Create → List → Complete Lifecycle ────────────────────────────────
 
 
@@ -664,3 +716,43 @@ class TestCrossModuleConsistency:
         assert progress.total_summaries == analysis.total_summaries
         assert progress.total_plans == analysis.total_plans
         assert analysis.completed_phases == 1
+
+    def test_roadmap_analyze_falls_back_to_state_current_phase(self, tmp_path: Path) -> None:
+        _setup_project(tmp_path)
+        _write_roadmap(
+            tmp_path,
+            """\
+            ## Milestone v1.0: Test
+
+            ### Phase 1: Ready
+
+            **Goal:** Finish the first phase
+
+            ### Phase 2: Planning
+
+            **Goal:** Prepare the next phase
+            """,
+        )
+        _write_state(
+            tmp_path,
+            """\
+            # Research State
+
+            ## Current Position
+
+            **Current Phase:** 2
+            **Current Phase Name:** Planning
+            **Status:** in_progress
+            **Last Activity:** 2026-02-23
+            **Last Activity Description:** Waiting on plan artifacts
+            """,
+        )
+
+        ready = _create_phase(tmp_path, "01-ready")
+        (ready / "01-01-PLAN.md").write_text("plan", encoding="utf-8")
+        (ready / "01-01-SUMMARY.md").write_text("done", encoding="utf-8")
+        _create_phase(tmp_path, "02-planning")
+
+        analysis = roadmap_analyze(tmp_path)
+        assert analysis.current_phase == "2"
+        assert analysis.next_phase is None

--- a/tests/core/test_runtime_hints.py
+++ b/tests/core/test_runtime_hints.py
@@ -1784,6 +1784,75 @@ def test_build_runtime_hint_payload_rediscovery_branch_handles_non_resumable_cur
     assert any("suggest-next" in action for action in payload.next_actions)
 
 
+def test_build_runtime_hint_payload_surfaces_recent_project_missing_handoff_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    data_root = tmp_path / "data"
+    recent_project_root = tmp_path / "recent-project"
+    recent_project_root.mkdir()
+    missing_resume_file = "GPD/phases/04/.continue-here.md"
+    current_project = {
+        "source": "recent_project",
+        "project_root": recent_project_root.resolve(strict=False).as_posix(),
+        "resume_file": missing_resume_file,
+        "resume_file_available": False,
+        "resume_file_reason": "resume file missing",
+        "resumable": False,
+        "recoverable": False,
+        "last_session_at": "2026-03-27T12:05:00+00:00",
+        "stopped_at": "Phase 04",
+        "hostname": "builder-04",
+        "platform": "Linux 6.1 x86_64",
+        "resume_target_kind": "handoff",
+        "source_kind": "continuation.handoff",
+    }
+    fake_reentry = SimpleNamespace(
+        resolved_project_root=recent_project_root.resolve(strict=False),
+        auto_selected=True,
+        mode="recent-projects",
+        selected_candidate=current_project,
+        candidates=[current_project],
+    )
+
+    monkeypatch.setattr(
+        "gpd.core.runtime_hints._resume_context",
+        lambda _cwd, data_root=None: {
+            "planning_exists": True,
+            "state_exists": True,
+            "roadmap_exists": True,
+            "project_exists": True,
+            "resume_candidates": [],
+            "has_live_execution": False,
+        },
+    )
+    monkeypatch.setattr("gpd.core.runtime_hints.resolve_project_reentry", lambda *args, **kwargs: fake_reentry)
+    monkeypatch.setattr(
+        "gpd.core.runtime_hints._selected_reentry_candidate",
+        lambda *args, **kwargs: current_project,
+    )
+
+    payload = build_runtime_hint_payload(
+        workspace,
+        data_root=data_root,
+        include_cost=False,
+        include_workflow_presets=False,
+    )
+
+    assert payload.recovery["current_project"] is not None
+    assert payload.recovery["current_project"]["session_hostname"] == "builder-04"
+    assert payload.recovery["current_project"]["session_platform"] == "Linux 6.1 x86_64"
+    assert payload.recovery["current_project"]["session_last_date"] == "2026-03-27T12:05:00+00:00"
+    assert payload.recovery["current_project"]["session_stopped_at"] == "Phase 04"
+    assert payload.orientation["session_hostname"] == "builder-04"
+    assert payload.orientation["session_platform"] == "Linux 6.1 x86_64"
+    assert payload.orientation["session_last_date"] == "2026-03-27T12:05:00+00:00"
+    assert payload.orientation["session_stopped_at"] == "Phase 04"
+    assert payload.orientation["recorded_continuity_handoff_file"] == missing_resume_file
+    assert payload.orientation["missing_continuity_handoff_file"] == missing_resume_file
+
+
 def test_build_runtime_hint_payload_formats_generic_runtime_follow_up_when_runtime_detection_fails(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -23,6 +23,8 @@ from gpd.core.state import (
     ensure_state_schema,
     generate_state_markdown,
     load_state_json,
+    load_state_json_readonly,
+    parse_state_md,
     parse_state_to_json,
     peek_state_json,
     save_state_json,
@@ -218,6 +220,58 @@ def test_parse_state_to_json_import_legacy_session_keeps_real_handoff_and_machin
     assert parsed["continuation"]["handoff"]["last_result_id"] == "result-7"
     assert parsed["continuation"]["machine"]["hostname"] == "legacy-host"
     assert parsed["continuation"]["machine"]["platform"] == "legacy-platform"
+
+
+def test_parse_state_md_treats_plain_not_set_placeholders_as_unset() -> None:
+    markdown = (
+        "# STATE\n\n"
+        "## Project\n\n"
+        "**Core research question:** not set\n"
+        "**Current focus:** not set\n\n"
+        "## Position\n\n"
+        "**Current Phase:** not set\n"
+        "**Current Phase Name:** not set\n"
+        "**Current Plan:** not set\n"
+        "**Status:** not set\n"
+        "**Last Activity:** not set\n"
+        "**Last Activity Description:** not set\n"
+        "**Paused At:** not set\n\n"
+        "## Session Continuity\n\n"
+        "**Last session:** not set\n"
+        "**Hostname:** not set\n"
+        "**Platform:** not set\n"
+        "**Stopped at:** not set\n"
+        "**Resume file:** not set\n"
+        "**Last result ID:** not set\n\n"
+        "## Decisions\n\nNone.\n\n"
+        "## Blockers\n\nNone.\n\n"
+        "## Performance Metrics\n\nNone.\n\n"
+        "## Active Calculations\n\nNone.\n\n"
+        "## Intermediate Results\n\nNone.\n\n"
+        "## Open Questions\n\nNone.\n\n"
+        "## Active Approximations\n\nNone.\n\n"
+        "## Convention Lock\n\nNone.\n\n"
+        "## Propagated Uncertainties\n\nNone.\n\n"
+        "## Pending Todos\n\nNone.\n"
+    )
+
+    parsed = parse_state_md(markdown)
+
+    assert parsed["project"]["core_research_question"] is None
+    assert parsed["project"]["current_focus"] is None
+    assert parsed["position"]["current_phase"] is None
+    assert parsed["position"]["current_phase_name"] is None
+    assert parsed["position"]["current_plan"] is None
+    assert parsed["position"]["status"] is None
+    assert parsed["position"]["last_activity"] is None
+    assert parsed["position"]["last_activity_desc"] is None
+    assert parsed["position"]["paused_at"] is None
+    assert parsed["session"]["last_date"] is None
+    assert parsed["session"]["hostname"] is None
+    assert parsed["session"]["platform"] is None
+    assert parsed["session"]["stopped_at"] is None
+    assert parsed["session"]["resume_file"] is None
+    assert parsed["session"]["last_result_id"] is None
 
 
 # ─── ensure_state_schema ─────────────────────────────────────────────────────
@@ -502,6 +556,50 @@ def test_load_state_json_preserves_sibling_fields_when_nested_position_field_is_
     assert loaded["position"]["current_phase_name"] is None
     assert loaded["position"]["status"] == "Executing"
     assert loaded["blockers"] == ["still valid"]
+
+
+def test_load_state_json_readonly_does_not_create_nested_gpd_directory_on_empty_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nested = tmp_path / "workspace" / "notes"
+    nested.mkdir(parents=True)
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("read-only load should not lock or persist recovery state")
+
+    monkeypatch.setattr(state_module, "_state_lock", _unexpected)
+    monkeypatch.setattr(state_module, "_recover_intent_locked", _unexpected)
+    monkeypatch.setattr(state_module, "_write_state_pair_locked", _unexpected)
+
+    assert load_state_json_readonly(nested) is None
+    assert not (nested / "GPD").exists()
+
+
+def test_load_state_json_readonly_reads_backup_without_persisting_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = default_state_dict()
+    state["position"]["current_phase"] = "02"
+    state["position"]["status"] = "Executing"
+    layout = _write_backup_only_state(tmp_path, primary_state=state)
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("read-only load should not lock or persist recovery state")
+
+    monkeypatch.setattr(state_module, "_state_lock", _unexpected)
+    monkeypatch.setattr(state_module, "_recover_intent_locked", _unexpected)
+    monkeypatch.setattr(state_module, "_write_state_pair_locked", _unexpected)
+
+    loaded = load_state_json_readonly(tmp_path)
+
+    assert loaded is not None
+    assert loaded["position"]["current_phase"] == "02"
+    assert loaded["position"]["status"] == "Executing"
+    assert not layout.state_json.exists()
+    assert layout.state_json_backup.exists()
+    assert layout.state_md.exists()
 
 
 def test_normalize_state_schema_irrecoverable_reset_drops_unknown_top_level_keys(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1607,6 +1705,44 @@ def test_state_get_rebuilds_missing_state_markdown_from_state_json(tmp_path: Pat
     assert result.content is not None
     assert "# Research State" in result.content
     assert layout.state_md.exists()
+
+
+def test_state_get_prefers_canonical_session_continuation_and_handoff_payloads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    save_state_json(tmp_path, default_state_dict())
+    project = ProjectLayout(tmp_path)
+    monkeypatch.setattr(
+        state_module,
+        "_current_machine_identity",
+        lambda: {"hostname": "builder-01", "platform": "Linux 6.1 x86_64"},
+    )
+
+    state_record_session(tmp_path, stopped_at="Phase 03 Plan 2", resume_file="NEXT.md")
+    project.state_md.write_text(
+        project.state_md.read_text(encoding="utf-8").replace("builder-01", "stale-host"),
+        encoding="utf-8",
+    )
+
+    session = state_get(tmp_path, "session")
+    continuation = state_get(tmp_path, "continuation")
+    handoff = state_get(tmp_path, "handoff")
+    session_payload = json.loads(session.value or "{}")
+    continuation_payload = json.loads(continuation.value or "{}")
+    handoff_payload = json.loads(handoff.value or "{}")
+
+    assert session.section_name == "session"
+    assert continuation.section_name == "continuation"
+    assert handoff.section_name == "handoff"
+    assert session_payload["hostname"] == "builder-01"
+    assert session_payload["platform"] == "Linux 6.1 x86_64"
+    assert session_payload["stopped_at"] == "Phase 03 Plan 2"
+    assert session_payload["resume_file"] == "NEXT.md"
+    assert session_payload["last_result_id"] is None
+    assert session_payload["last_date"] is not None
+    assert continuation_payload["handoff"]["resume_file"] == "NEXT.md"
+    assert handoff_payload["resume_file"] == "NEXT.md"
+    assert "stale-host" not in (session.value or "")
 
 
 def test_peek_state_json_keeps_normalized_primary_when_unrelated_section_is_schema_corrupt(tmp_path: Path) -> None:

--- a/tests/core/test_suggest.py
+++ b/tests/core/test_suggest.py
@@ -12,6 +12,7 @@ from gpd.adapters import get_adapter, list_runtimes
 from gpd.adapters.runtime_catalog import get_runtime_descriptor
 from gpd.core import suggest as suggest_module
 from gpd.core.constants import ENV_GPD_ACTIVE_RUNTIME
+from gpd.core.conventions import KNOWN_CONVENTIONS
 from gpd.core.proof_review import resolve_manuscript_proof_review_status
 from gpd.core.reproducibility import compute_sha256
 from gpd.core.runtime_command_surfaces import format_active_runtime_command
@@ -415,6 +416,25 @@ def test_paused_status_without_timestamp(tmp_path: Path) -> None:
     assert "resume" in actions
 
 
+def test_paused_work_defers_missing_convention_suggestions_until_after_resume(tmp_path: Path) -> None:
+    root = _setup_project(tmp_path)
+    _create_roadmap(root)
+    _create_state(
+        root,
+        {
+            "position": {"status": "Paused", "paused_at": "2026-01-15T10:00:00Z"},
+            "convention_lock": {"metric_signature": "(-,+,+,+)"},
+        },
+    )
+
+    result = suggest_next(root)
+    actions = [s.action for s in result.suggestions]
+
+    assert "resume" in actions
+    assert "set-conventions" not in actions
+    assert result.context.missing_conventions == ()
+
+
 # ─── Blockers ──────────────────────────────────────────────────────────────────
 
 
@@ -664,9 +684,13 @@ def test_missing_conventions_suggest_set(tmp_path: Path) -> None:
     _create_state(root, {"convention_lock": {"metric_signature": "(-,+,+,+)"}})
     result = suggest_next(root)
     actions = [s.action for s in result.suggestions]
+    set_conventions = next((s for s in result.suggestions if s.action == "set-conventions"), None)
+    expected_missing = tuple(key for key in KNOWN_CONVENTIONS if key != "metric_signature")
+
     assert "set-conventions" in actions
-    assert "natural_units" in result.context.missing_conventions
-    assert "coordinate_system" in result.context.missing_conventions
+    assert result.context.missing_conventions == expected_missing
+    assert set_conventions is not None
+    assert "17 convention fields missing" in set_conventions.reason
 
 
 # ─── Paper Pipeline ────────────────────────────────────────────────────────────
@@ -918,10 +942,11 @@ def test_missing_conventions_block_arxiv_submission_suggestion(tmp_path: Path) -
 
     result = suggest_next(root)
     actions = [s.action for s in result.suggestions]
+    expected_missing = tuple(key for key in KNOWN_CONVENTIONS if key != "metric_signature")
 
     assert "arxiv-submission" not in actions
     assert "set-conventions" in actions
-    assert "natural_units" in result.context.missing_conventions
+    assert result.context.missing_conventions == expected_missing
 
 
 def test_accepted_review_decision_without_review_ledger_does_not_suggest_arxiv_submission(tmp_path: Path) -> None:

--- a/tests/hooks/test_statusline.py
+++ b/tests/hooks/test_statusline.py
@@ -26,6 +26,7 @@ from gpd.hooks.statusline import (
     _read_position,
     _read_session_id,
     _read_workspace_label,
+    _statusline_project_root,
     main,
 )
 from tests.hooks.helpers import mark_complete_install as _mark_complete_install
@@ -445,13 +446,51 @@ class TestReadPosition:
         assert _read_position(str(tmp_path)) == ""
 
     def test_nested_workspace_walks_up_to_project_root(self, tmp_path: Path) -> None:
-        planning = tmp_path / "GPD"
-        planning.mkdir()
-        nested = tmp_path / "src" / "notes"
+        project = tmp_path / "project"
+        planning = project / "GPD"
+        planning.mkdir(parents=True)
+        nested = project / "src" / "notes"
         nested.mkdir(parents=True)
         state = {"position": {"current_phase": 4, "total_phases": 9}}
         (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
         assert _read_position(str(nested)) == "P4/9"
+        assert _statusline_project_root(str(nested)) == project.resolve(strict=False)
+        assert not (nested / "GPD" / "GPD").exists()
+
+    def test_nested_empty_gpd_stub_does_not_capture_root_when_durable_ancestor_exists(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        project = tmp_path / "project"
+        planning = project / "GPD"
+        planning.mkdir(parents=True)
+        nested = project / "workspace" / "notes"
+        nested.mkdir(parents=True)
+        (nested / "GPD").mkdir()
+        state = {"position": {"current_phase": 8, "total_phases": 12}}
+        (planning / "state.json").write_text(json.dumps(state), encoding="utf-8")
+
+        with patch("gpd.hooks.statusline.peek_state_json") as mock_peek:
+            mock_peek.return_value = (state, [], "state.json")
+            assert _read_position(str(nested)) == "P8/12"
+
+        assert _statusline_project_root(str(nested)) == project.resolve(strict=False)
+        assert not (nested / "GPD" / "GPD").exists()
+        mock_peek.assert_called_once()
+        _, kwargs = mock_peek.call_args
+        assert kwargs["acquire_lock"] is False
+        assert kwargs["recover_intent"] is False
+        assert kwargs["surface_blocked_project_contract"] is True
+
+    def test_empty_gpd_ancestor_without_project_markers_does_not_capture_statusline_root(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "scratch" / "workspace"
+        workspace.mkdir(parents=True)
+        (tmp_path / "GPD").mkdir()
+
+        assert _statusline_project_root(str(workspace)) is None
 
     def test_tilde_workspace_expands_before_project_root_lookup(self, tmp_path: Path) -> None:
         home = tmp_path / "home"

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -2358,6 +2358,25 @@ class TestStateServer:
         assert layout.state_intent.exists()
         assert layout.state_json.read_text(encoding="utf-8") == before_state
 
+    def test_state_server_load_state_json_does_not_create_nested_stub_directories(self, tmp_path):
+        from gpd.core.constants import ProjectLayout
+        from gpd.core.state import default_state_dict, save_state_json
+        from gpd.mcp.servers.state_server import load_state_json
+
+        cwd = tmp_path / "workspace" / "notes"
+        cwd.mkdir(parents=True)
+        layout = ProjectLayout(cwd)
+        layout.gpd.mkdir(parents=True)
+        save_state_json(cwd, default_state_dict())
+
+        nested_stub = layout.gpd / "GPD"
+        assert not nested_stub.exists()
+
+        result = load_state_json(cwd)
+
+        assert result is not None
+        assert not nested_stub.exists()
+
     def test_get_state_no_state(self, fake_project_dir):
         from gpd.mcp.servers.state_server import get_state
 
@@ -2462,15 +2481,15 @@ class TestStateServer:
         mock_info.phase_name = "Setup"
         mock_info.directory = "GPD/phases/01-setup"
         mock_info.phase_slug = "01-setup"
-        mock_info.plans = ["plan-01.md", "plan-02.md", "plan-03.md"]
-        mock_info.summaries = ["summary-01.md", "summary-02.md"]
-        mock_info.incomplete_plans = ["plan-03.md"]
+        mock_info.plans = ["01-setup-01-PLAN.md", "01-setup-02-PLAN.md"]
+        mock_info.summaries = ["01-setup-01-SUMMARY.md", "01-setup-99-SUMMARY.md"]
+        mock_info.incomplete_plans = ["01-setup-02-PLAN.md"]
 
         with patch("gpd.core.phases.find_phase", return_value=mock_info):
             result = get_phase_info(fake_project_dir, "01")
         assert result["phase_number"] == "01"
-        assert result["plan_count"] == 3
-        assert result["summary_count"] == 2
+        assert result["plan_count"] == 2
+        assert result["summary_count"] == 1
         assert result["complete"] is False
 
     def test_get_phase_info_not_found(self, fake_project_dir):

--- a/tests/mcp/test_skill_routing_regressions.py
+++ b/tests/mcp/test_skill_routing_regressions.py
@@ -142,6 +142,28 @@ def test_route_skill_uses_live_registry_names_for_missing_manual_keyword_routes(
         assert route_skill("reapply local patches after update")["suggestion"] == "gpd-reapply-patches"
 
 
+def test_route_skill_uses_phrase_level_routes_for_onboarding_and_setup_commands() -> None:
+    from gpd.mcp.servers.skills_server import route_skill
+
+    with patch(
+        "gpd.mcp.servers.skills_server._load_skill_index",
+        return_value=[
+            _skill("gpd-help", category="help", registry_name="help"),
+            _skill("gpd-execute-phase", category="execution", registry_name="execute-phase"),
+            _skill("gpd-map-research", category="research", registry_name="map-research"),
+            _skill("gpd-set-tier-models", category="settings", registry_name="set-tier-models"),
+            _skill("gpd-start", category="help", registry_name="start"),
+            _skill("gpd-tour", category="help", registry_name="tour"),
+        ],
+    ):
+        assert route_skill("map an existing folder before planning")["suggestion"] == "gpd-map-research"
+        assert route_skill("refresh the research map")["suggestion"] == "gpd-map-research"
+        assert route_skill("pin exact tier models for this runtime")["suggestion"] == "gpd-set-tier-models"
+        assert route_skill("guided first run for a new folder")["suggestion"] == "gpd-start"
+        assert route_skill("want a guided overview of the main commands")["suggestion"] == "gpd-tour"
+        assert route_skill("guided first run for a new folder")["suggestion"] != "gpd-execute-phase"
+
+
 def test_canonicalize_command_surface_rewrites_real_command_examples_only() -> None:
     from gpd.mcp.servers.skills_server import _canonicalize_command_surface
 

--- a/tests/mcp/test_skills_server_tool_lists.py
+++ b/tests/mcp/test_skills_server_tool_lists.py
@@ -122,6 +122,41 @@ def test_list_skills_filters_consistency_checker_by_verification_category() -> N
     assert result["categories"] == ["help", "verification"]
 
 
+def test_list_skills_filters_beginner_help_entrypoints_by_help_category() -> None:
+    from gpd.mcp.servers.skills_server import list_skills
+
+    registry_module.invalidate_cache()
+    help_skill = registry_module.get_skill("gpd-help")
+    start_skill = registry_module.get_skill("gpd-start")
+    tour_skill = registry_module.get_skill("gpd-tour")
+
+    with patch(
+        "gpd.mcp.servers.skills_server._load_skill_index",
+        return_value=[help_skill, start_skill, tour_skill],
+    ):
+        result = list_skills(category="help")
+
+    assert result["count"] == 3
+    assert result["skills"] == [
+        {
+            "name": "gpd-help",
+            "category": "help",
+            "description": help_skill.description,
+        },
+        {
+            "name": "gpd-start",
+            "category": "help",
+            "description": start_skill.description,
+        },
+        {
+            "name": "gpd-tour",
+            "category": "help",
+            "description": tour_skill.description,
+        },
+    ]
+    assert result["categories"] == ["help"]
+
+
 def test_get_skill_command_surfaces_staged_loading_sidecar() -> None:
     from gpd.mcp.servers.skills_server import get_skill
 

--- a/tests/mcp/test_state_server_consistency.py
+++ b/tests/mcp/test_state_server_consistency.py
@@ -152,6 +152,39 @@ def test_load_state_json_strips_legacy_session_and_surfaces_contract_gate(monkey
     assert result["project_contract_gate"]["authoritative"] is True
 
 
+def test_load_state_json_uses_read_only_peek_without_locking(monkeypatch, tmp_path: Path) -> None:
+    state_obj = {
+        "position": {"current_phase": "01"},
+        "decisions": [],
+        "blockers": [],
+    }
+
+    seen: dict[str, object] = {}
+
+    def _peek_state_json(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return state_obj, [], "state.json"
+
+    monkeypatch.setattr("gpd.mcp.servers.state_server.peek_state_json", _peek_state_json)
+    monkeypatch.setattr(
+        "gpd.mcp.servers.state_server._project_contract_runtime_payload_for_state",
+        lambda *_args, **_kwargs: (
+            {"status": "loaded"},
+            {"valid": True},
+            {"authoritative": True},
+        ),
+    )
+
+    result = load_state_json(tmp_path)
+
+    assert result is not None
+    assert seen["args"] == (tmp_path,)
+    assert seen["kwargs"]["recover_intent"] is False
+    assert seen["kwargs"]["surface_blocked_project_contract"] is True
+    assert seen["kwargs"]["acquire_lock"] is False
+
+
 def test_get_state_reports_current_project_state_guidance(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setattr("gpd.mcp.servers.state_server.load_state_json", lambda *_args, **_kwargs: None)
 
@@ -190,6 +223,29 @@ def test_run_health_check_preserves_latest_return_failure_details(monkeypatch, f
     assert result["checks"][0]["issues"][0].endswith("malformed envelope")
 
 
+def test_health_peek_normalized_state_uses_read_only_peek_without_locking(monkeypatch, tmp_path: Path) -> None:
+    from gpd.core.health import _peek_normalized_state_for_health
+
+    state_obj = {"position": {"current_phase": "01"}}
+    seen: dict[str, object] = {}
+
+    def _peek_state_json(*args, **kwargs):
+        seen["args"] = args
+        seen["kwargs"] = kwargs
+        return state_obj, [], "STATE.md"
+
+    monkeypatch.setattr("gpd.core.health.peek_state_json", _peek_state_json)
+
+    result, source = _peek_normalized_state_for_health(tmp_path)
+
+    assert result == state_obj
+    assert source == "STATE.md"
+    assert seen["args"] == (tmp_path,)
+    assert seen["kwargs"]["recover_intent"] is False
+    assert seen["kwargs"]["surface_blocked_project_contract"] is True
+    assert seen["kwargs"]["acquire_lock"] is False
+
+
 def test_get_progress_does_not_mutate_checkpoint_shelf_artifacts(tmp_path: Path) -> None:
     """Progress reads should not create, update, or delete checkpoint shelf files."""
     cwd = tmp_path
@@ -226,3 +282,22 @@ def test_get_progress_does_not_mutate_checkpoint_shelf_artifacts(tmp_path: Path)
     assert stale_checkpoint.read_text(encoding="utf-8") == "stale checkpoint\n"
     assert stale_checkpoint.exists()
     assert checkpoints_index.read_text(encoding="utf-8") == "stale index\n"
+
+
+def test_get_phase_info_counts_only_matching_summary_identities(tmp_path: Path) -> None:
+    cwd = tmp_path
+    planning = cwd / "GPD"
+    planning.mkdir()
+    (planning / "phases").mkdir()
+    phase_dir = cwd / "GPD" / "phases" / "01-setup"
+    phase_dir.mkdir()
+    (phase_dir / "PLAN.md").write_text("# plan\n", encoding="utf-8")
+    (phase_dir / "01-setup-02-PLAN.md").write_text("# plan\n", encoding="utf-8")
+    (phase_dir / "SUMMARY.md").write_text("# summary\n", encoding="utf-8")
+    (phase_dir / "01-setup-99-SUMMARY.md").write_text("# summary\n", encoding="utf-8")
+
+    result = get_phase_info(str(cwd), "01")
+
+    assert result["plan_count"] == 2
+    assert result["summary_count"] == 1
+    assert result["complete"] is False

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -884,61 +884,64 @@ class TestInitCommands:
 
     def test_init_progress_can_skip_recent_project_reentry_for_projectless_config_bootstrap(
         self,
-        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        workspace = tmp_path / "workspace"
-        candidate = tmp_path / "recoverable-project"
-        data_root = tmp_path / "data"
+        from tempfile import TemporaryDirectory
 
-        (workspace / "GPD" / "phases").mkdir(parents=True)
-        (workspace / "GPD" / "config.json").write_text(
-            json.dumps(
-                {
-                    "autonomy": "balanced",
-                    "review_cadence": "adaptive",
-                    "research_mode": "balanced",
-                }
-            ),
-            encoding="utf-8",
-        )
+        from gpd.core.context import init_progress as build_init_progress
 
-        gpd_dir = candidate / "GPD"
-        gpd_dir.mkdir(parents=True)
-        (gpd_dir / "STATE.md").write_text("# Research State\n", encoding="utf-8")
-        (gpd_dir / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
-        (gpd_dir / "PROJECT.md").write_text("# Project\n", encoding="utf-8")
-        resume_file = gpd_dir / "phases" / "01" / ".continue-here.md"
-        resume_file.parent.mkdir(parents=True, exist_ok=True)
-        resume_file.write_text("resume\n", encoding="utf-8")
-        monkeypatch.setenv("GPD_DATA_DIR", str(data_root))
-        record_recent_project(
-            candidate,
-            session_data={
-                "last_date": "2026-03-29T12:00:00+00:00",
-                "stopped_at": "Phase 01",
-                "resume_file": "GPD/phases/01/.continue-here.md",
-            },
-            store_root=data_root,
-        )
+        with TemporaryDirectory() as temp_dir:
+            sandbox_root = Path(temp_dir)
+            workspace = sandbox_root / "workspace"
+            candidate = sandbox_root / "recoverable-project"
+            data_root = sandbox_root / "data"
 
-        result = runner.invoke(
-            app,
-            ["--raw", "--cwd", str(workspace), "init", "progress", "--include", "config", "--no-project-reentry"],
-            catch_exceptions=False,
-        )
+            (workspace / "GPD" / "phases").mkdir(parents=True)
+            (workspace / "GPD" / "config.json").write_text(
+                json.dumps(
+                    {
+                        "autonomy": "balanced",
+                        "review_cadence": "adaptive",
+                        "research_mode": "balanced",
+                    }
+                ),
+                encoding="utf-8",
+            )
 
-        assert result.exit_code == 0, result.output
-        payload = json.loads(result.output)
-        assert payload["workspace_root"] == workspace.resolve().as_posix()
-        assert payload["project_root"] == workspace.resolve().as_posix()
-        assert payload["project_root_source"] == "workspace"
-        assert payload["project_root_auto_selected"] is False
-        assert payload["config_content"] is not None
-        assert payload["project_exists"] is False
-        assert "project_reentry_mode" not in payload
-        assert "project_reentry_candidates" not in payload
-        assert "project_reentry_selected_candidate" not in payload
+            gpd_dir = candidate / "GPD"
+            gpd_dir.mkdir(parents=True)
+            (gpd_dir / "STATE.md").write_text("# Research State\n", encoding="utf-8")
+            (gpd_dir / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+            (gpd_dir / "PROJECT.md").write_text("# Project\n", encoding="utf-8")
+            resume_file = gpd_dir / "phases" / "01" / ".continue-here.md"
+            resume_file.parent.mkdir(parents=True, exist_ok=True)
+            resume_file.write_text("resume\n", encoding="utf-8")
+            monkeypatch.setenv("GPD_DATA_DIR", str(data_root))
+            record_recent_project(
+                candidate,
+                session_data={
+                    "last_date": "2026-03-29T12:00:00+00:00",
+                    "stopped_at": "Phase 01",
+                    "resume_file": "GPD/phases/01/.continue-here.md",
+                },
+                store_root=data_root,
+            )
+
+            payload = build_init_progress(
+                workspace,
+                includes={"config"},
+                data_root=data_root,
+                include_project_reentry=False,
+            )
+            assert payload["workspace_root"] == str(workspace.resolve())
+            assert payload["project_root"] == str(workspace.resolve())
+            assert payload["project_root_source"] == "workspace"
+            assert payload["project_root_auto_selected"] is False
+            assert payload["config_content"] is not None
+            assert payload["project_exists"] is False
+            assert "project_reentry_mode" not in payload
+            assert "project_reentry_candidates" not in payload
+            assert "project_reentry_selected_candidate" not in payload
 
     def test_plan_phase_surfaces_artifact_derived_reference_context(self, gpd_project: Path) -> None:
         literature_dir = gpd_project / "GPD" / "literature"
@@ -1177,6 +1180,238 @@ review_summary:
         assert "reference_artifacts_content" not in payload
         assert "state_content" not in payload
         assert "derived_manuscript_reference_status" in payload
+
+
+class TestRoadmapCommands:
+    def test_roadmap_commands_resolve_project_root_like_progress(
+        self,
+        gpd_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        nested = gpd_project / "workspace" / "notes"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        seen: dict[str, object] = {}
+        project_root = gpd_project.resolve()
+
+        def _progress_render(cwd: Path, fmt: str) -> dict[str, str]:
+            seen["progress"] = cwd
+            return {"cwd": str(cwd), "fmt": fmt}
+
+        def _roadmap_analyze(cwd: Path) -> dict[str, str]:
+            seen["analyze"] = cwd
+            return {"cwd": str(cwd)}
+
+        def _roadmap_get_phase(cwd: Path, phase_num: str) -> dict[str, str]:
+            seen["get_phase"] = (cwd, phase_num)
+            return {"cwd": str(cwd), "phase_num": phase_num}
+
+        monkeypatch.setattr("gpd.core.phases.progress_render", _progress_render)
+        monkeypatch.setattr("gpd.core.phases.roadmap_analyze", _roadmap_analyze)
+        monkeypatch.setattr("gpd.core.phases.roadmap_get_phase", _roadmap_get_phase)
+
+        progress_result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(nested), "progress"],
+            catch_exceptions=False,
+        )
+        assert progress_result.exit_code == 0, progress_result.output
+        assert json.loads(progress_result.output) == {"cwd": str(project_root), "fmt": "json"}
+        assert seen["progress"] == project_root
+
+        analyze_result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(nested), "roadmap", "analyze"],
+            catch_exceptions=False,
+        )
+        assert analyze_result.exit_code == 0, analyze_result.output
+        assert json.loads(analyze_result.output) == {"cwd": str(project_root)}
+        assert seen["analyze"] == project_root
+
+        get_phase_result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(nested), "roadmap", "get-phase", "01"],
+            catch_exceptions=False,
+        )
+        assert get_phase_result.exit_code == 0, get_phase_result.output
+        assert json.loads(get_phase_result.output) == {"cwd": str(project_root), "phase_num": "01"}
+        assert seen["get_phase"] == (project_root, "01")
+
+
+class TestReadOnlyCommandRouting:
+    @pytest.mark.parametrize(
+        ("command_args", "patch_target", "kind"),
+        [
+            (["--raw", "health"], "gpd.core.health.run_health", "health"),
+            (["--raw", "validate", "consistency"], "gpd.core.health.run_health", "health"),
+            (["--raw", "query", "search", "--text", "alpha"], "gpd.core.query.query", "query_search"),
+            (["--raw", "query", "deps", "R-01"], "gpd.core.query.query_deps", "query_deps"),
+            (["--raw", "query", "assumptions", "alpha", "beta"], "gpd.core.query.query_assumptions", "query_assumptions"),
+            (["--raw", "history-digest"], "gpd.core.commands.cmd_history_digest", "history_digest"),
+            (["--raw", "regression-check"], "gpd.core.commands.cmd_regression_check", "regression_check"),
+        ],
+    )
+    def test_project_scoped_read_only_commands_use_project_root(
+        self,
+        gpd_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        command_args: list[str],
+        patch_target: str,
+        kind: str,
+    ) -> None:
+        nested = gpd_project / "workspace" / "notes"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        project_root = gpd_project.resolve()
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr("gpd.cli._project_scoped_cwd", lambda cwd=None: project_root)
+
+        if kind == "health":
+            def _fake_run_health(cwd: Path, fix: bool = False):
+                seen["cwd"] = cwd
+                seen["fix"] = fix
+                return SimpleNamespace(
+                    overall="ok",
+                    model_dump=lambda mode="json", by_alias=True: {
+                        "cwd": str(cwd),
+                        "fix": fix,
+                        "overall": "ok",
+                    },
+                )
+
+            monkeypatch.setattr(patch_target, _fake_run_health)
+        elif kind == "query_search":
+            def _fake_query(cwd: Path, **kwargs: object):
+                seen["cwd"] = cwd
+                seen["kwargs"] = kwargs
+                return {"cwd": str(cwd), **kwargs}
+
+            monkeypatch.setattr(patch_target, _fake_query)
+        elif kind == "query_deps":
+            def _fake_query_deps(cwd: Path, identifier: str):
+                seen["cwd"] = cwd
+                seen["identifier"] = identifier
+                return {"cwd": str(cwd), "identifier": identifier}
+
+            monkeypatch.setattr(patch_target, _fake_query_deps)
+        elif kind == "query_assumptions":
+            def _fake_query_assumptions(cwd: Path, text: str):
+                seen["cwd"] = cwd
+                seen["text"] = text
+                return {"cwd": str(cwd), "text": text}
+
+            monkeypatch.setattr(patch_target, _fake_query_assumptions)
+        elif kind == "history_digest":
+            def _fake_history_digest(cwd: Path):
+                seen["cwd"] = cwd
+                return {"cwd": str(cwd)}
+
+            monkeypatch.setattr(patch_target, _fake_history_digest)
+        elif kind == "regression_check":
+            def _fake_regression_check(cwd: Path, phase: str | None = None, quick: bool = False):
+                seen["cwd"] = cwd
+                seen["phase"] = phase
+                seen["quick"] = quick
+                return SimpleNamespace(
+                    passed=True,
+                    model_dump=lambda mode="json", by_alias=True: {
+                        "cwd": str(cwd),
+                        "phase": phase,
+                        "quick": quick,
+                        "passed": True,
+                    },
+                )
+
+            monkeypatch.setattr(patch_target, _fake_regression_check)
+        else:  # pragma: no cover - guarded by parametrization
+            raise AssertionError(kind)
+
+        result = runner.invoke(app, ["--cwd", str(nested), *command_args], catch_exceptions=False)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["cwd"] == str(project_root)
+        assert seen["cwd"] == project_root
+        if kind == "health":
+            assert payload["fix"] is False
+            assert seen["fix"] is False
+        elif kind == "query_search":
+            assert payload["text"] == "alpha"
+            assert seen["kwargs"]["text"] == "alpha"
+        elif kind == "query_deps":
+            assert payload["identifier"] == "R-01"
+            assert seen["identifier"] == "R-01"
+        elif kind == "query_assumptions":
+            assert payload["text"] == "alpha beta"
+            assert seen["text"] == "alpha beta"
+        elif kind == "regression_check":
+            assert payload["passed"] is True
+            assert seen["quick"] is False
+
+
+class TestReadOnlyStateBackedLists:
+    @pytest.mark.parametrize(
+        ("command_args", "patch_target", "kind"),
+        [
+            (["--raw", "result", "list"], "gpd.core.results.result_list", "result_list"),
+            (["--raw", "approximation", "list"], "gpd.core.extras.approximation_list", "approximation_list"),
+            (["--raw", "uncertainty", "list"], "gpd.core.extras.uncertainty_list", "uncertainty_list"),
+            (["--raw", "question", "list"], "gpd.core.extras.question_list", "question_list"),
+            (["--raw", "calculation", "list"], "gpd.core.extras.calculation_list", "calculation_list"),
+        ],
+    )
+    def test_state_backed_read_only_lists_use_non_mutating_loader(
+        self,
+        gpd_project: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        command_args: list[str],
+        patch_target: str,
+        kind: str,
+    ) -> None:
+        nested = gpd_project / "workspace" / "notes"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+        project_root = gpd_project.resolve()
+        seen: dict[str, object] = {}
+
+        monkeypatch.setattr("gpd.cli._project_scoped_cwd", lambda cwd=None: project_root)
+
+        def _fake_peek_state_json(
+            cwd: Path,
+            *,
+            integrity_mode: str = "standard",
+            recover_intent: bool = True,
+            surface_blocked_project_contract: bool = False,
+            acquire_lock: bool = True,
+        ):
+            seen["peek_cwd"] = cwd
+            seen["acquire_lock"] = acquire_lock
+            seen["recover_intent"] = recover_intent
+            seen["surface_blocked_project_contract"] = surface_blocked_project_contract
+            return ({"loaded_cwd": str(cwd)}, [], "state.json")
+
+        monkeypatch.setattr("gpd.core.state.peek_state_json", _fake_peek_state_json)
+
+        def _fake_state_reader(state: dict, *args: object, **kwargs: object):
+            seen["state"] = state
+            seen["args"] = args
+            seen["kwargs"] = kwargs
+            return {"cwd": state["loaded_cwd"], "kind": kind, "args": list(args), "kwargs": kwargs}
+
+        monkeypatch.setattr(patch_target, _fake_state_reader)
+
+        result = runner.invoke(app, ["--cwd", str(nested), *command_args], catch_exceptions=False)
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["cwd"] == str(project_root)
+        assert payload["kind"] == kind
+        assert seen["peek_cwd"] == project_root
+        assert seen["acquire_lock"] is False
+        assert seen["recover_intent"] is False
+        assert seen["surface_blocked_project_contract"] is True
 
 
 class TestReviewValidationCommands:
@@ -1465,34 +1700,31 @@ class TestReviewValidationCommands:
 
     def test_command_context_recovery_surfaces_accept_partial_recoverable_workspace(
         self,
-        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        project = tmp_path / "recoverable-project"
-        nested = project / "workspace" / "notes"
-        gpd_dir = project / "GPD"
-        nested.mkdir(parents=True)
-        gpd_dir.mkdir()
-        (gpd_dir / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
-        (gpd_dir / "STATE.md").write_text("# Research State\n", encoding="utf-8")
-        monkeypatch.chdir(nested)
+        from tempfile import TemporaryDirectory
 
-        for command_name in ("progress", "resume-work"):
-            result = runner.invoke(
-                app,
-                ["--raw", "--cwd", str(nested), "validate", "command-context", command_name],
-                catch_exceptions=False,
-            )
+        with TemporaryDirectory() as temp_dir:
+            sandbox_root = Path(temp_dir)
+            project = sandbox_root / "recoverable-project"
+            nested = project / "workspace" / "notes"
+            gpd_dir = project / "GPD"
+            nested.mkdir(parents=True)
+            gpd_dir.mkdir()
+            (gpd_dir / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+            (gpd_dir / "STATE.md").write_text("# Research State\n", encoding="utf-8")
+            monkeypatch.setattr(cli_module, "_cwd", nested)
 
-            assert result.exit_code == (0 if command_name == "resume-work" else 1), result.output
-            payload = json.loads(result.output)
-            checks = {check["name"]: check for check in payload["checks"]}
-            assert payload["passed"] is (command_name == "resume-work")
-            assert payload["project_exists"] is False
-            assert checks["state_exists"]["passed"] is True
-            assert checks["roadmap_exists"]["passed"] is True
-            assert checks["project_exists"]["passed"] is False
-            assert checks["required_files"]["passed"] is (command_name == "resume-work")
+            for command_name in ("progress", "resume-work"):
+                preflight = cli_module._build_command_context_preflight(command_name)
+
+                checks = {check.name: check for check in preflight.checks}
+                assert preflight.passed is (command_name == "resume-work")
+                assert preflight.project_exists is False
+                assert checks["state_exists"].passed is True
+                assert checks["roadmap_exists"].passed is True
+                assert checks["project_exists"].passed is False
+                assert checks["required_files"].passed is (command_name == "resume-work")
 
     def test_command_context_plan_milestone_gaps_requires_globbed_files_in_project_root(
         self, gpd_project: Path

--- a/tests/test_cli_help_headline.py
+++ b/tests/test_cli_help_headline.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import re
+
+from typer.testing import CliRunner
+
+from gpd.cli import app
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+
+def _normalize_cli_output(text: str) -> str:
+    return " ".join(_ANSI_ESCAPE_RE.sub("", text).split())
+
+
+def test_top_level_help_headline_tracks_local_bridge_contract() -> None:
+    result = CliRunner().invoke(app, ["--help"], color=False)
+
+    assert result.exit_code == 0
+    assert (
+        "GPD local bridge: local install, readiness, validation, permissions, observability, recovery, cost, presets, diagnostics, and shared Wolfram integration CLI"
+        in _normalize_cli_output(result.output)
+    )

--- a/tests/test_runtime_cli_bridge_errors.py
+++ b/tests/test_runtime_cli_bridge_errors.py
@@ -256,6 +256,86 @@ def test_runtime_cli_repair_command_projection_respects_env_overridden_global_ta
 
 
 @pytest.mark.parametrize(
+    ("manifest_state", "artifact_override", "expected_kind", "expected_phrase"),
+    [
+        (
+            {"runtime": _BRIDGE_RUNTIME_DESCRIPTOR.runtime_name},
+            None,
+            runtime_cli._BridgeFailureKind.MISSING_INSTALL_SCOPE,
+            "The manifest must declare a non-empty `install_scope` field.",
+        ),
+        (
+            {
+                "runtime": next(
+                    item.runtime_name
+                    for item in iter_runtime_descriptors()
+                    if item.runtime_name != _BRIDGE_RUNTIME_DESCRIPTOR.runtime_name
+                ),
+                "install_scope": "local",
+            },
+            None,
+            runtime_cli._BridgeFailureKind.RUNTIME_MISMATCH,
+            "GPD runtime bridge mismatch",
+        ),
+        (
+            {"runtime": _BRIDGE_RUNTIME_DESCRIPTOR.runtime_name, "install_scope": "local"},
+            ("missing-artifact.txt",),
+            runtime_cli._BridgeFailureKind.MISSING_INSTALL_ARTIFACTS,
+            "Missing required install artifacts",
+        ),
+    ],
+)
+def test_runtime_cli_classifies_bridge_failures_with_stable_kinds(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    manifest_state: dict[str, object],
+    artifact_override: tuple[str, ...] | None,
+    expected_kind: runtime_cli._BridgeFailureKind,
+    expected_phrase: str,
+) -> None:
+    runtime_name = _BRIDGE_RUNTIME_DESCRIPTOR.runtime_name
+    adapter = runtime_cli.get_adapter(runtime_name)
+    config_dir = tmp_path / _BRIDGE_RUNTIME_DESCRIPTOR.config_dir_name
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / runtime_cli.get_shared_install_metadata().manifest_name).write_text(
+        json.dumps(manifest_state),
+        encoding="utf-8",
+    )
+
+    if artifact_override is not None:
+        monkeypatch.setattr(adapter, "missing_install_artifacts", lambda target_dir: artifact_override)
+    monkeypatch.setattr("gpd.runtime_cli._maybe_reexec_from_checkout", lambda *_args, **_kwargs: None)
+    monkeypatch.chdir(tmp_path)
+
+    manifest_status, _manifest_payload, manifest_runtime = runtime_cli.load_install_manifest_runtime_status(config_dir)
+    manifest_scope_status, manifest_scope_payload, manifest_install_scope = runtime_cli.load_install_manifest_scope_status(
+        config_dir
+    )
+    if manifest_scope_status == "ok":
+        manifest_install_scope = manifest_scope_payload.get("install_scope")
+        if not isinstance(manifest_install_scope, str):
+            manifest_install_scope = None
+
+    failure = runtime_cli._classify_bridge_failure(
+        runtime=runtime_name,
+        config_dir=config_dir,
+        install_scope="local",
+        explicit_target=False,
+        cli_cwd=tmp_path,
+        manifest_status=manifest_status,
+        manifest_runtime=manifest_runtime,
+        manifest_scope_status=manifest_scope_status,
+        manifest_install_scope=manifest_install_scope,
+        missing=artifact_override,
+        has_managed_install_markers=runtime_cli.config_dir_has_managed_install_markers(config_dir),
+    )
+
+    assert failure is not None
+    assert failure.kind is expected_kind
+    assert expected_phrase in failure.message
+
+
+@pytest.mark.parametrize(
     ("manifest_scope", "bridge_scope"),
     [("local", "global"), ("global", "local")],
 )

--- a/tests/test_runtime_wrapper_dry_run_contract.py
+++ b/tests/test_runtime_wrapper_dry_run_contract.py
@@ -1,0 +1,20 @@
+"""Regression test for runtime wrapper dry-run contract truthfulness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER_FILES = (
+    "src/gpd/commands/complete-milestone.md",
+    "src/gpd/commands/remove-phase.md",
+    "src/gpd/commands/merge-phases.md",
+    "src/gpd/commands/undo.md",
+)
+
+
+def test_runtime_wrapper_docs_do_not_claim_unsupported_dry_run_support() -> None:
+    for relative_path in WRAPPER_FILES:
+        text = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert "--dry-run" not in text, f"{relative_path} still claims dry-run support"
+        assert "runs the" in text and "workflow directly" in text, f"{relative_path} missing truthful contract note"


### PR DESCRIPTION
## Summary

This PR tightens the local GPD bridge and read-only project inspection paths so nested workspaces, stale state markdown, and broken runtime installs do not produce misleading output or mutate the project during probes.

### Runtime bridge and install readiness

- Adds structured runtime bridge failure classification for malformed invocations, unknown runtimes, missing/corrupt manifests, runtime or scope mismatches, and missing install artifacts.
- Keeps bridge error messages stable and repair-oriented while removing extra trailing newlines from generated repair messages.
- Makes runtime manifest readers tolerate invalid UTF-8 the same way they already tolerate missing or malformed JSON manifests.
- Adds typed runtime target readiness metadata to `gpd doctor`, including install state, manifest state, missing artifacts, and a user-facing readiness message.
- Defaults `gpd doctor --runtime <runtime>` to the local runtime target unless the caller explicitly asks for `--global` or a target directory.

### Read-only project/root handling

- Routes read-only local CLI commands through the resolved project root instead of the raw current directory, including health, consistency validation, query, history digest, regression check, roadmap inspection, and state-backed list commands.
- Adds a non-mutating `load_state_json_readonly` path and switches read-only callers to `peek_state_json(..., recover_intent=False, acquire_lock=False)` so probes do not create lockfiles, recovery writes, or nested stub `GPD/` directories.
- Improves root resolution so a durable ancestor project with real GPD markers wins over an empty nested `GPD/` stub, while still allowing a nearest bare `GPD/` when no stronger project root exists.
- Makes the statusline use a non-mutating state read and avoid being captured by unrelated empty ancestor `GPD/` directories.
- Adjusts project reentry so a verified current workspace wins normally, but a partial current workspace does not mask one strong recoverable recent project.

### State, query, phase, and observability behavior

- Extends `gpd query search`, `gpd query deps`, and `gpd query assumptions` to include the canonical intermediate-results registry, including direct/transitive dependency data and downstream consumers.
- Makes `gpd state get session|continuation|handoff` prefer canonical structured state JSON instead of stale markdown sections.
- Treats plain `not set` placeholders as unset in state parsing and convention checks, matching existing placeholder handling for em dash and `[not set]`.
- Fixes phase completeness and MCP phase summaries to count only matching plan/summary identities rather than any summary file in the phase directory.
- Lets roadmap analysis recover the current phase from `STATE.md` when no planned or partial phase is found, without reusing that same phase as the next phase.
- Adds degraded observability modes for malformed or partially missing live execution telemetry: `snapshot-only`, `trace-only`, and `degraded`, with safer follow-up suggestions.
- Preserves recent-project session provenance in runtime hints, including hostname, platform, last-session time, stopped-at, and missing handoff metadata.

### Command surface and prompt contracts

- Clarifies the top-level local CLI help headline to match the local bridge surface.
- Documents that runtime wrappers such as complete milestone, merge phases, remove phase, and undo run their workflows directly instead of claiming unsupported `--dry-run` behavior.
- Documents local export-log passthrough filters for command, phase, and category.
- Clarifies that `gpd:progress --brief|--full|--reconcile` are runtime-surface options and that local `gpd progress` remains a read-only `json|bar|table` renderer.
- Adds focused regression tests around the changed local CLI, state, query, root resolution, statusline, observability, runtime bridge, MCP, and command-doc behavior.

## Validation

- `uv run ruff check .`
- `git diff --check`
- `uv run pytest -q` (`7672 passed, 5 skipped`)

## Scope

- Final diff is limited to `src/` and `tests/`.
- This PR does not include workflow files, benchmarks, scripts, generated artifacts, fixture-bundle corpora, bug-ticket fixtures, or live-probe test fixtures.
