### PR TITLE
fix: gpd suggest uses _project_scoped_cwd() for root PROJECT.md migration (FULL-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- Fix `gpd suggest` ignoring actual project state: use `_project_scoped_cwd()` so root-level PROJECT.md is auto-migrated before `suggest_next()` runs, matching the pattern used by `progress`, `state`, and `status` commands.
 - Fix `phase_add` and `phase_insert` heading consistency: detect heading level, number padding, and separator style (colon vs em-dash) from existing ROADMAP phases instead of hardcoding `### Phase {N}:`. Defaults to `### Phase N: ` (unpadded, colon) for empty ROADMAPs, matching the `new-project` template.
 - Fix LaTeX special character escaping in user-provided metadata fields: `~`, `#`, `%`, and `&` in title, abstract, author fields, and acknowledgments are now escaped before rendering, preventing compilation errors and silent data loss. Agent-generated LaTeX content (section bodies, figure captions, appendix content) is deliberately unaffected.
 - **Breaking (raw output only):** `gpd question resolve` and `gpd calculation complete` now return structured results (resolved/completed text, search text, remaining count) instead of a bare `1`. Raw JSON output changes from `{"result": "1"}` to a model with `resolved`/`completed`, `search_text`, and `remaining` fields. The prior `{"result": "1"}` output was a bug (unhelpful) and is not considered a stable contract.

--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -3423,6 +3423,10 @@ def suggest(
     kwargs: dict[str, int] = {}
     if limit is not None:
         kwargs["limit"] = limit
+    # NOTE: _project_scoped_cwd() runs migration before resolution. If run
+    # from a subfolder that has its own PROJECT.md, migration may create a
+    # spurious GPD/ there and resolve to the wrong project root. This is a
+    # known limitation shared with progress/state/status commands.
     suggest_cwd = _project_scoped_cwd()
     _output(suggest_next(suggest_cwd, **kwargs))
 

--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -3418,14 +3418,12 @@ def suggest(
     limit: int | None = typer.Option(None, "--limit", help="Max suggestions to return"),
 ) -> None:
     """Suggest what to do next based on project state."""
-    from gpd.core.root_resolution import resolve_project_root
     from gpd.core.suggest import suggest_next
 
     kwargs: dict[str, int] = {}
     if limit is not None:
         kwargs["limit"] = limit
-    workspace_cwd = _get_cwd().expanduser().resolve(strict=False)
-    suggest_cwd = resolve_project_root(workspace_cwd, require_layout=True) or workspace_cwd
+    suggest_cwd = _project_scoped_cwd()
     _output(suggest_next(suggest_cwd, **kwargs))
 
 


### PR DESCRIPTION
## Summary

- `gpd suggest` returned "No PROJECT.md found" with 0% progress when PROJECT.md was at workspace root
- Root cause: suggest command resolved cwd inline, bypassing `_migrate_planning_files()` that copies root PROJECT.md into GPD/
- Fix: replace inline resolution with `_project_scoped_cwd()`, matching the pattern used by `progress`, `state`, and `status` commands
- Net change: 2 lines replaced, 1 unused import removed, 1 code comment added

## Known limitation

`_project_scoped_cwd()` runs migration before ancestor resolution. If `gpd suggest` is run from a subfolder that contains its own `PROJECT.md` (e.g., `docs/PROJECT.md`), migration may create a spurious `GPD/` directory there and `resolve_project_root()` will stop at that level instead of walking up to the real project root. This is a pre-existing limitation shared with `progress`, `state`, and `status` commands that use the same function. A code comment has been added noting this.

## Test plan

- [x] Full test suite: 7582 passed, 0 failed
- [x] Branch verified before and after test run
- [x] Codex review completed (P2 edge case noted above)
- [x] CHANGELOG.md updated