### PR TITLE
fix: recognize bare arXiv IDs and bare DOIs as concrete reference locators (FULL-020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- Recognize bare arXiv IDs (`1304.4926`, `hep-th/0603001`) and bare DOIs (`10.1103/PhysRevD.100.026003`) as concrete reference locators for `must_surface` anchor validation. Fix casefold mismatch in `_is_project_artifact_path` that misclassified mixed-case archive names (e.g., `math.DG/0211159`) as project artifact paths.
 - Fix `gpd suggest` ignoring actual project state: use `_project_scoped_cwd()` so root-level PROJECT.md is auto-migrated before `suggest_next()` runs, matching the pattern used by `progress`, `state`, and `status` commands.
 - Fix `phase_add` and `phase_insert` heading consistency: detect heading level, number padding, and separator style (colon vs em-dash) from existing ROADMAP phases instead of hardcoding `### Phase {N}:`. Defaults to `### Phase N: ` (unpadded, colon) for empty ROADMAPs, matching the `new-project` template.
 - Fix LaTeX special character escaping in user-provided metadata fields: `~`, `#`, `%`, and `&` in title, abstract, author fields, and acknowledgments are now escaped before rendering, preventing compilation errors and silent data loss. Agent-generated LaTeX content (section bodies, figure captions, appendix content) is deliberately unaffected.

--- a/src/gpd/contracts.py
+++ b/src/gpd/contracts.py
@@ -385,6 +385,13 @@ _PLAN_REFERENCE_LOCATOR_PLACEHOLDER_PATTERNS: tuple[re.Pattern[str], ...] = (
 _PLAN_CITATION_LOCATOR_YEAR_PATTERN = re.compile(r"\b(?:18|19|20)\d{2}\b")
 _PLAN_REFERENCE_LOCATOR_CONCRETE_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b(?:doi\s*[:/]|https?://(?:doi\.org/|arxiv\.org/abs/)|arxiv\s*:)\S+"),
+    re.compile(r"^\d{2}(?:0[1-9]|1[0-2])\.\d{4,5}(?:v\d+)?$"),
+    # Old-style arXiv ID: archive/YYMMNNN. Bare archives (math, physics, cs,
+    # nlin, stat) are whitelisted explicitly; all other archives require a
+    # separator (hep-th, cond-mat, math.DG, etc.). econ and eess are included
+    # defensively (created post-2007, never had old-style IDs).
+    re.compile(r"^(?:(?:math|physics|cs|nlin|stat|econ|eess)|[a-z][a-z0-9]*(?:[-.][a-z][a-z0-9]*)+)/\d{2}(?:0[1-9]|1[0-2])\d{3}(?:v\d+)?$"),
+    re.compile(r"^10\.\d{4,9}/\S+$"),
 )
 _PLAN_GROUNDING_TEXT_DIRECT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^\s*(?:need(?:s)? grounding|grounding needed)\s*$"),
@@ -467,7 +474,7 @@ def _is_project_artifact_path(value: str, *, project_root: Path | None = None) -
         return False
 
     if project_root is None:
-        if any(pattern.search(candidate) for pattern in _PLAN_REFERENCE_LOCATOR_CONCRETE_PATTERNS):
+        if any(pattern.search(candidate.casefold()) for pattern in _PLAN_REFERENCE_LOCATOR_CONCRETE_PATTERNS):
             return False
         return _looks_like_project_artifact_path(candidate)
 

--- a/tests/core/test_contract_validation.py
+++ b/tests/core/test_contract_validation.py
@@ -3186,7 +3186,20 @@ def test_collect_plan_contract_integrity_errors_requires_concrete_grounding_not_
     assert "missing references or explicit grounding context" in errors
 
 
-@pytest.mark.parametrize("locator", ["TBD", "Section 4"])
+@pytest.mark.parametrize("locator", [
+    "TBD",
+    "Section 4",
+    "12345",
+    "data/1304.4926",
+    "1334.4926",
+    "1300.4926",
+    "hep-th/0600123",
+    "hep-th/0613123",
+    "data/2401001",
+    "results/0612001",
+    "output/0301001",
+    "logs/0501001",
+])
 def test_collect_plan_contract_integrity_errors_rejects_placeholder_must_surface_reference_locators(
     locator: str,
 ) -> None:
@@ -3219,6 +3232,22 @@ def test_collect_plan_contract_integrity_errors_rejects_placeholder_must_surface
         ("paper", "Author et al., Journal, 2024"),
         ("other", "Einstein, Annalen der Physik, 1905"),
         ("spec", "https://example.org/missing-data-benchmark.csv"),
+        ("paper", "1304.4926"),
+        ("paper", "1905.08255v2"),
+        ("paper", "hep-th/0603001"),
+        ("paper", "gr-qc/9711053v1"),
+        ("paper", "math.DG/0211159"),
+        ("paper", "cs.SE/0303020"),
+        ("paper", "q-bio.PE/0501001"),
+        ("paper", "hep-th/0601001"),
+        ("paper", "hep-th/0612001"),
+        ("paper", "math/0301234"),
+        ("paper", "physics/0601001"),
+        ("paper", "cs/0303020"),
+        ("paper", "nlin/0101001"),
+        ("paper", "stat/0501001"),
+        ("paper", "10.1103/PhysRevD.100.026003"),
+        ("paper", "10.1007/JHEP12(2020)155"),
     ],
 )
 def test_collect_plan_contract_integrity_errors_accepts_concrete_must_surface_reference_locator(
@@ -3340,6 +3369,9 @@ def test_collect_plan_contract_integrity_errors_accepts_non_reference_grounding_
     [
         ("paper", "Author et al., Journal, 2024"),
         ("other", "Einstein, Annalen der Physik, 1905"),
+        ("paper", "hep-th/0603001"),
+        ("paper", "10.1103/PhysRevD.100.026003"),
+        ("paper", "math/0301234"),
     ],
 )
 def test_validate_project_contract_approved_mode_accepts_concrete_must_surface_reference_locator(


### PR DESCRIPTION
## Summary

- `must_surface=true` references with bare locators (e.g. `1304.4926`, `hep-th/0603001`, `math.DG/0211159`, `10.1103/PhysRevD.100.026003`) were rejected because `_PLAN_REFERENCE_LOCATOR_CONCRETE_PATTERNS` only matched prefixed forms (`doi:`, `arxiv:`, `https://`)
- Found by 6 stress-test researchers across 18 PLAN files
- Adds three anchored regex patterns: bare new-style arXiv (YYMM-validated), bare old-style arXiv (separator-required + bare-archive whitelist), and bare DOI
- Fixes secondary bug: casefolds candidate in `_is_project_artifact_path` exclusion check so mixed-case archives like `math.DG/0211159` are not misclassified as project artifact paths

## Changes

- `src/gpd/contracts.py`: 3 new patterns in `_PLAN_REFERENCE_LOCATOR_CONCRETE_PATTERNS`, casefold fix at line 474
- `tests/core/test_contract_validation.py`: 29 new test cases across 3 parametrize blocks (acceptance + rejection + approved-mode)
- `CHANGELOG.md`: entry under `## vNEXT`

## False-positive prevention

- New-style: YYMM month validation (01-12) rejects `1334.4926`; no optional prefix rejects `data/1304.4926`
- Old-style: prefix must contain a hyphen/dot OR be in whitelist (`math|physics|cs|nlin|stat|econ|eess`); rejects `data/2401001`, `results/0612001`
- DOI: anchored to `^10\.` — no common paths start with `10.`

## Test plan

- [x] 38 targeted tests pass (29 new + 9 existing)
- [x] Full suite: 7611 passed, 0 failed, 43 skipped
- [x] Branch verified before and after test run
- [x] 3 rounds of planner-reviewer adversarial loops (APPROVED 0/0/0/2, APPROVED 0/0/0/2)
- [x] 4 rounds of Codex review (R1: 2xP2 fixed, R2: P1 fixed + P3 false positive, R3: P2 fixed, R4: P2 dismissed as pre-existing design)