### PR TITLE
feat: add --skip-readiness-check flag to install command

### DIFF
--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -9229,6 +9229,7 @@ def install(
     global_install: bool = typer.Option(False, "--global", help="Install into the global runtime config dir"),
     target_dir: str | None = typer.Option(None, "--target-dir", help="Override target config directory"),
     force_statusline: bool = typer.Option(False, "--force-statusline", help="Overwrite existing statusline config"),
+    skip_readiness_check: bool = typer.Option(False, "--skip-readiness-check", help="Skip runtime readiness preflight (for embedded/sidecar use)"),
 ) -> None:
     """Install GPD skills, agents, and hooks into runtime config directories."""
     from rich.progress import Progress, SpinnerColumn, TextColumn
@@ -9283,11 +9284,14 @@ def install(
     install_scope = "global" if is_global else "local"
     resolved_target_override = _resolve_cli_target_dir(target_dir) if target_dir else None
 
-    preflight_failures, preflight_advisories = _run_install_readiness_preflight(
-        selected,
-        install_scope=install_scope,
-        target_dir=resolved_target_override,
-    )
+    preflight_failures: list[tuple[str, list[str]]] = []
+    preflight_advisories: dict[str, list[str]] = {}
+    if not skip_readiness_check:
+        preflight_failures, preflight_advisories = _run_install_readiness_preflight(
+            selected,
+            install_scope=install_scope,
+            target_dir=resolved_target_override,
+        )
     if preflight_failures:
         if _raw:
             _output(


### PR DESCRIPTION
## Summary

- Adds `--skip-readiness-check` flag to `gpd install` that skips the `_run_install_readiness_preflight()` call
- Default behavior unchanged — preflight still runs unless the flag is explicitly passed
- The install pipeline's own safety guards (`_validate_target_runtime`, `_pre_cleanup`, `_verify`) still run regardless

## Why

The GPD desktop app runs `gpd-sidecar install opencode --global` from a Tauri subprocess during first-run setup. The readiness preflight hard-blocks this because:

1. **`shutil.which("opencode")` fails** — Tauri subprocesses inherit a minimal GUI PATH (no `/opt/homebrew/bin`), and the bundled binary is `opencode-cli` not `opencode`
2. **Stale manifest detection** — `OPENCODE_CONFIG_DIR=~/.config/gpd` may point to a directory with a manifest from a previous partial install

The preflight protects interactive CLI users from broken environments. The desktop app bundles Python, GPD, and the runtime — it controls the entire environment, so the preflight adds no safety value and creates a false negative.

## Safety analysis

9 adversarial investigation agents confirmed:
- The sole blocking check is "Runtime Launcher" (`CheckStatus.FAIL` from `shutil.which("opencode")`)
- All other 12 checks pass or warn (never FAIL) in the desktop app context
- The install pipeline has independent guards: `_validate_target_runtime()` catches ownership violations, `_pre_cleanup()` ensures clean slate, `_verify()` confirms post-install integrity
- No Tauri-only fix exists that isn't a hack (symlinks, PATH manipulation, config dir wiping)

## Test plan

- [ ] `gpd install opencode --global` still works as before (preflight runs)
- [ ] `gpd install opencode --global --skip-readiness-check` skips preflight, install succeeds
- [ ] `gpd install --help` shows the new flag with description