### PR TITLE
[codex] relax artifact-first and publication workflows

### DIFF
--- a/src/gpd/agents/gpd-referee.md
+++ b/src/gpd/agents/gpd-referee.md
@@ -234,7 +234,7 @@ ls GPD/review/REFEREE_RESPONSE*.md 2>/dev/null
 <step name="load_research">
 **Load all research outputs to be reviewed (initial review only).**
 
-1. Read the manuscript first: title, abstract, introduction, results, conclusion, and nearby `.tex` sections
+1. Read the review target first: title, abstract, introduction, results, conclusion, and the supplied primary review surface. When the workflow supplies nearby manuscript section files, use them as companions; when the target is a standalone `.txt` or `.pdf`, treat that artifact as the primary review surface.
 2. Extract claims from the manuscript before consulting project-internal summaries
 3. Read key derivation files, numerical code, and results only as evidence sources
 4. Read ROADMAP.md, SUMMARY.md, and VERIFICATION.md only after the manuscript-first claim map exists

--- a/src/gpd/agents/gpd-review-reader.md
+++ b/src/gpd/agents/gpd-review-reader.md
@@ -25,7 +25,7 @@ You are not the final referee. Do not issue the panel's final recommendation for
 </references>
 
 <process>
-1. Read the manuscript main file and all section files in order.
+1. Read the resolved review target end-to-end. If the workflow supplies companion section files from the same manuscript root, read them in order; otherwise treat the supplied artifact as the full review text.
 2. State the main claim in one sentence.
 3. Extract the supporting subclaims, promised deliverables, and main evidence chain.
 4. Flag any place where the title, abstract, introduction, or conclusion appears stronger than the actual evidence.

--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -23,7 +23,7 @@ import os
 import re
 import shlex
 import sys
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, NoReturn
@@ -3330,7 +3330,7 @@ def doctor(
     live_executable_probes: bool = typer.Option(
         False,
         "--live-executable-probes",
-        help="Run cheap local executable probes such as `pdflatex --version` or `wolframscript -version`",
+        help="Run cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`",
     ),
 ) -> None:
     """Check GPD installation and environment health, or inspect runtime readiness."""
@@ -5536,11 +5536,32 @@ def _resolve_review_preflight_manuscript(
     allow_markdown: bool = True,
     restrict_to_supported_roots: bool = False,
     workspace_cwd: Path | None = None,
+    allowed_suffixes: Collection[str] | None = None,
 ) -> tuple[Path | None, str]:
     """Resolve a review-preflight manuscript target from an explicit subject or defaults."""
 
     project_root = cwd.resolve(strict=False)
     subject_base = (workspace_cwd or cwd).resolve(strict=False)
+    normalized_allowed_suffixes = {
+        suffix.lower()
+        for suffix in (
+            allowed_suffixes
+            if allowed_suffixes is not None
+            else ({".tex", ".md"} if allow_markdown else {".tex"})
+        )
+    }
+    if not normalized_allowed_suffixes:
+        normalized_allowed_suffixes = {".tex"}
+
+    def _allowed_suffix_message() -> str:
+        ordered_suffixes = [suffix for suffix in (".tex", ".md", ".txt", ".pdf") if suffix in normalized_allowed_suffixes]
+        extras = sorted(suffix for suffix in normalized_allowed_suffixes if suffix not in {".tex", ".md", ".txt", ".pdf"})
+        ordered_suffixes.extend(extras)
+        if ordered_suffixes == [".tex"]:
+            return ".tex file"
+        if len(ordered_suffixes) == 2:
+            return f"{ordered_suffixes[0]} or {ordered_suffixes[1]} file"
+        return ", ".join(ordered_suffixes[:-1]) + f", or {ordered_suffixes[-1]} file"
 
     def _supported_explicit_manuscript_target(target: Path) -> bool:
         try:
@@ -5577,27 +5598,32 @@ def _resolve_review_preflight_manuscript(
         if not target.exists():
             return None, f"missing explicit manuscript target {_format_display_path(target)}"
         if target.is_file():
-            if target.suffix == ".tex" or (allow_markdown and target.suffix == ".md"):
-                manuscript_root, root_resolution = _supported_root_resolution_for_target(target)
-                if manuscript_root is not None and root_resolution is not None:
-                    if root_resolution.status != "resolved" or root_resolution.manuscript_entrypoint is None:
-                        return (
-                            None,
-                            f"{_format_display_path(manuscript_root)} is ambiguous or inconsistent: {root_resolution.detail}",
-                        )
-                    if root_resolution.manuscript_entrypoint.resolve(strict=False) != target.resolve(strict=False):
-                        return (
-                            None,
-                            (
-                                f"{_format_display_path(target)} does not match the resolved manuscript entrypoint "
-                                f"{_format_display_path(root_resolution.manuscript_entrypoint)} under "
-                                f"{_format_display_path(manuscript_root)}"
-                            ),
-                        )
+            target_suffix = target.suffix.lower()
+            if target_suffix in normalized_allowed_suffixes:
+                if target_suffix in {".tex", ".md"}:
+                    manuscript_root, root_resolution = _supported_root_resolution_for_target(target)
+                    if manuscript_root is not None and root_resolution is not None:
+                        if root_resolution.status != "resolved" or root_resolution.manuscript_entrypoint is None:
+                            return (
+                                None,
+                                f"{_format_display_path(manuscript_root)} is ambiguous or inconsistent: {root_resolution.detail}",
+                            )
+                        if root_resolution.manuscript_entrypoint.resolve(strict=False) != target.resolve(strict=False):
+                            return (
+                                None,
+                                (
+                                    f"{_format_display_path(target)} does not match the resolved manuscript entrypoint "
+                                    f"{_format_display_path(root_resolution.manuscript_entrypoint)} under "
+                                    f"{_format_display_path(manuscript_root)}"
+                                ),
+                            )
                 return target, f"{_format_display_path(target)} present"
-            if target.suffix == ".md":
+            if target_suffix == ".md" and normalized_allowed_suffixes == {".tex"}:
                 return None, f"explicit manuscript target must be a .tex file: {_format_display_path(target)}"
-            return None, f"explicit manuscript target must be a .tex or .md file: {_format_display_path(target)}"
+            return (
+                None,
+                f"explicit manuscript target must be a {_allowed_suffix_message()}: {_format_display_path(target)}",
+            )
 
         if target.is_dir():
             manuscript_root, root_resolution = _supported_root_resolution_for_target(target)
@@ -6368,6 +6394,7 @@ _PROJECT_AWARE_EXPLICIT_INPUTS: dict[str, tuple[list[str], Callable[[str | None]
         ["knowledge file path, source file path, arXiv ID, or topic"],
         _has_digest_knowledge_explicit_inputs,
     ),
+    "gpd:peer-review": (["paper directory, manuscript path, or external artifact path"], _has_simple_positional_inputs),
     "gpd:review-knowledge": (
         ["knowledge document path or canonical K-* knowledge id"],
         _has_review_knowledge_explicit_inputs,
@@ -6520,6 +6547,7 @@ def _command_required_files_override_detail(
         allow_markdown=not _command_requires_compiled_manuscript(command),
         restrict_to_supported_roots=_command_explicit_manuscript_subject_uses_supported_roots(command),
         workspace_cwd=workspace_cwd,
+        allowed_suffixes=_command_explicit_manuscript_suffixes(command),
     )
     if manuscript is None:
         return None
@@ -6539,9 +6567,31 @@ def _command_requires_compiled_manuscript(command: object) -> bool:
     return _review_contract_requests_check(contract, "compiled_manuscript")
 
 
+def _command_explicit_manuscript_suffixes(command: object) -> frozenset[str]:
+    """Return the allowed explicit manuscript suffixes for one command."""
+    allowed_suffixes = {".tex"}
+    if not _command_requires_compiled_manuscript(command):
+        allowed_suffixes.add(".md")
+    if getattr(command, "name", "") == "gpd:peer-review":
+        allowed_suffixes.update({".txt", ".pdf"})
+    return frozenset(allowed_suffixes)
+
+
+def _command_allows_external_manuscript_targets(command: object) -> bool:
+    """Return whether a command may accept explicit manuscript targets outside supported roots."""
+    return getattr(command, "name", "") == "gpd:peer-review"
+
+
+def _command_allows_interactive_standalone_intake(command: object) -> bool:
+    """Return whether a project-aware command may prompt for standalone inputs after launch."""
+    return getattr(command, "name", "") == "gpd:peer-review"
+
+
 def _command_explicit_manuscript_subject_uses_supported_roots(command: object) -> bool:
     """Return whether explicit manuscript arguments must stay under supported manuscript roots."""
     if not _command_supports_explicit_manuscript_subject(command):
+        return False
+    if _command_allows_external_manuscript_targets(command):
         return False
 
     supported_roots = {"paper", "manuscript", "draft"}
@@ -6589,6 +6639,7 @@ def _command_context_manuscript_check(
             allow_markdown=allow_markdown,
             restrict_to_supported_roots=_command_explicit_manuscript_subject_uses_supported_roots(command),
             workspace_cwd=workspace_cwd,
+            allowed_suffixes=_command_explicit_manuscript_suffixes(command),
         )
         return manuscript is not None, detail
 
@@ -6662,6 +6713,51 @@ def _resolve_registry_command(command_name: str) -> tuple[object, str]:
 
     command = content_registry.get_command(command_name)
     return command, _canonical_command_name(command_name)
+
+
+def _path_is_within_supported_manuscript_root(project_root: Path, target: Path) -> bool:
+    """Return whether *target* lives under a canonical manuscript root in *project_root*."""
+    try:
+        relative = target.resolve(strict=False).relative_to(project_root.resolve(strict=False))
+    except ValueError:
+        return False
+    return bool(relative.parts) and relative.parts[0] in {"paper", "manuscript", "draft"}
+
+
+def _peer_review_external_mode_requested(
+    project_root: Path,
+    subject: str | None,
+    *,
+    workspace_cwd: Path | None = None,
+) -> bool:
+    """Return whether peer-review should treat the current request as external-artifact mode."""
+    from gpd.core.constants import ProjectLayout
+
+    layout = ProjectLayout(project_root)
+    if not layout.project_md.exists():
+        return True
+    if not isinstance(subject, str) or not subject.strip():
+        return False
+
+    target = Path(subject)
+    if not target.is_absolute():
+        target = (workspace_cwd or project_root) / target
+    return not _path_is_within_supported_manuscript_root(project_root, target.resolve(strict=False))
+
+
+def _peer_review_pdf_intake_ready(manuscript: Path) -> tuple[bool, str]:
+    """Return whether a PDF manuscript target can be converted into review text."""
+    companion_text = manuscript.with_suffix(".txt")
+    if companion_text.exists():
+        return True, f"PDF intake can use companion text file {_format_display_path(companion_text)}"
+
+    from gpd.mcp.paper.compiler import find_latex_compiler
+
+    pdftotext_path = find_latex_compiler("pdftotext")
+    if pdftotext_path is not None:
+        return True, f"pdftotext available at {_format_display_path(pdftotext_path)} for PDF review intake"
+
+    return False, "PDF review target requires `pdftotext` on PATH or a same-directory `.txt` companion file"
 
 
 def _build_command_context_preflight(
@@ -6970,6 +7066,11 @@ def _build_command_context_preflight(
         ),
     )
     explicit_inputs_ok = predicate(arguments)
+    interactive_intake_allowed = (
+        _command_allows_interactive_standalone_intake(command)
+        and not explicit_inputs_ok
+        and not _has_simple_positional_inputs(arguments)
+    )
     add_check(
         "project_exists",
         project_exists,
@@ -6982,15 +7083,20 @@ def _build_command_context_preflight(
     )
     add_check(
         "explicit_inputs",
-        explicit_inputs_ok,
+        explicit_inputs_ok or interactive_intake_allowed,
         (
             "explicit standalone inputs detected"
             if explicit_inputs_ok
-            else f"missing explicit standalone inputs ({', '.join(explicit_inputs)})"
+            else (
+                "no explicit review target supplied; interactive intake can prompt for a specific artifact path "
+                "or use the current GPD project when available"
+                if interactive_intake_allowed
+                else f"missing explicit standalone inputs ({', '.join(explicit_inputs)})"
+            )
         ),
-        blocking=not project_exists,
+        blocking=not project_exists and not interactive_intake_allowed,
     )
-    passed = project_exists or explicit_inputs_ok
+    passed = project_exists or explicit_inputs_ok or interactive_intake_allowed
     guidance = "" if passed else _build_project_aware_guidance(explicit_inputs, init_command=init_command)
     return CommandContextPreflightResult(
         command=public_command_name,
@@ -7024,6 +7130,7 @@ def _build_review_preflight(
     contract = command.review_contract
     if contract is None:
         raise GPDError(f"Command {public_command_name} does not expose a review contract")
+    external_peer_review_mode = _peer_review_external_mode_requested(project_cwd, subject, workspace_cwd=cwd)
 
     checks: list[ReviewPreflightCheck] = []
     phase_subject = subject
@@ -7069,79 +7176,108 @@ def _build_review_preflight(
     )
 
     if "project_state" in contract.preflight_checks:
-        state_ok = layout.state_json.exists() and layout.state_md.exists()
-        add_check(
-            "project_state",
-            state_ok,
-            (
-                f"state.json={layout.state_json.exists()}, STATE.md={layout.state_md.exists()}"
-                if not state_ok
-                else f"{_format_display_path(layout.state_json)} and {_format_display_path(layout.state_md)} present"
-            ),
-        )
-        if strict:
-            validation = state_validate(project_cwd, integrity_mode="review")
-            detail = f"integrity_status={validation.integrity_status}"
-            if validation.issues:
-                detail = f"{detail}; {'; '.join(validation.issues)}"
-            add_check("state_integrity", validation.valid, detail, blocking=True)
+        if external_peer_review_mode:
+            add_check(
+                "project_state",
+                True,
+                "external artifact review: project state is optional and is not required to start review",
+                blocking=False,
+            )
+        else:
+            state_ok = layout.state_json.exists() and layout.state_md.exists()
+            add_check(
+                "project_state",
+                state_ok,
+                (
+                    f"state.json={layout.state_json.exists()}, STATE.md={layout.state_md.exists()}"
+                    if not state_ok
+                    else f"{_format_display_path(layout.state_json)} and {_format_display_path(layout.state_md)} present"
+                ),
+            )
+            if strict:
+                validation = state_validate(project_cwd, integrity_mode="review")
+                detail = f"integrity_status={validation.integrity_status}"
+                if validation.issues:
+                    detail = f"{detail}; {'; '.join(validation.issues)}"
+                add_check("state_integrity", validation.valid, detail, blocking=True)
 
     if "roadmap" in contract.preflight_checks:
-        add_check(
-            "roadmap",
-            layout.roadmap.exists(),
-            (
-                f"{_format_display_path(layout.roadmap)} present"
-                if layout.roadmap.exists()
-                else f"missing {_format_display_path(layout.roadmap)}"
-            ),
-        )
+        if external_peer_review_mode:
+            add_check("roadmap", True, "external artifact review: roadmap is optional", blocking=False)
+        else:
+            add_check(
+                "roadmap",
+                layout.roadmap.exists(),
+                (
+                    f"{_format_display_path(layout.roadmap)} present"
+                    if layout.roadmap.exists()
+                    else f"missing {_format_display_path(layout.roadmap)}"
+                ),
+            )
 
     if "conventions" in contract.preflight_checks:
-        add_check(
-            "conventions",
-            layout.conventions_md.exists(),
-            (
-                f"{_format_display_path(layout.conventions_md)} present"
-                if layout.conventions_md.exists()
-                else f"missing {_format_display_path(layout.conventions_md)}"
-            ),
-        )
+        if external_peer_review_mode:
+            add_check("conventions", True, "external artifact review: project conventions are optional", blocking=False)
+        else:
+            add_check(
+                "conventions",
+                layout.conventions_md.exists(),
+                (
+                    f"{_format_display_path(layout.conventions_md)} present"
+                    if layout.conventions_md.exists()
+                    else f"missing {_format_display_path(layout.conventions_md)}"
+                ),
+            )
 
     if "research_artifacts" in contract.preflight_checks:
-        digest_exists = layout.milestones_dir.exists() and any(layout.milestones_dir.rglob("RESEARCH-DIGEST.md"))
-        summary_exists = _has_any_phase_summary(layout.phases_dir)
-        passed = digest_exists or summary_exists
-        detail = "milestone digest or phase summaries present" if passed else "no digest or phase summaries found"
-        add_check("research_artifacts", passed, detail)
-        if strict and summary_exists:
-            summary_failures = _validate_phase_artifacts(layout.phases_dir, "summary")
+        if external_peer_review_mode:
             add_check(
-                "summary_frontmatter",
-                not summary_failures,
-                "all phase summaries satisfy the summary schema"
-                if not summary_failures
-                else "; ".join(summary_failures[:3]),
-                blocking=True,
+                "research_artifacts",
+                True,
+                "external artifact review: phase summaries or milestone digests are optional",
+                blocking=False,
             )
-        verification_reports_requested = _review_contract_requests_check(contract, "verification_reports")
-        if verification_reports_requested:
-            verification_exists = layout.phases_dir.exists() and any(layout.phases_dir.rglob("*VERIFICATION.md"))
-            add_check(
-                "verification_reports",
-                verification_exists,
-                "verification reports present" if verification_exists else "no verification reports found",
-            )
-            if strict and verification_exists:
-                verification_failures = _validate_phase_artifacts(layout.phases_dir, "verification")
+            if _review_contract_requests_check(contract, "verification_reports"):
                 add_check(
-                    "verification_frontmatter",
-                    not verification_failures,
-                    "all verification reports satisfy the verification schema"
-                    if not verification_failures
-                    else "; ".join(verification_failures[:3]),
+                    "verification_reports",
+                    True,
+                    "external artifact review: verification reports are optional",
+                    blocking=False,
+                )
+        else:
+            digest_exists = layout.milestones_dir.exists() and any(layout.milestones_dir.rglob("RESEARCH-DIGEST.md"))
+            summary_exists = _has_any_phase_summary(layout.phases_dir)
+            passed = digest_exists or summary_exists
+            detail = "milestone digest or phase summaries present" if passed else "no digest or phase summaries found"
+            add_check("research_artifacts", passed, detail)
+            if strict and summary_exists:
+                summary_failures = _validate_phase_artifacts(layout.phases_dir, "summary")
+                add_check(
+                    "summary_frontmatter",
+                    not summary_failures,
+                    "all phase summaries satisfy the summary schema"
+                    if not summary_failures
+                    else "; ".join(summary_failures[:3]),
                     blocking=True,
                 )
+            verification_reports_requested = _review_contract_requests_check(contract, "verification_reports")
+            if verification_reports_requested:
+                verification_exists = layout.phases_dir.exists() and any(layout.phases_dir.rglob("*VERIFICATION.md"))
+                add_check(
+                    "verification_reports",
+                    verification_exists,
+                    "verification reports present" if verification_exists else "no verification reports found",
+                )
+                if strict and verification_exists:
+                    verification_failures = _validate_phase_artifacts(layout.phases_dir, "verification")
+                    add_check(
+                        "verification_frontmatter",
+                        not verification_failures,
+                        "all verification reports satisfy the verification schema"
+                        if not verification_failures
+                        else "; ".join(verification_failures[:3]),
+                        blocking=True,
+                    )
 
     if "manuscript" in contract.preflight_checks:
         allow_markdown = not _command_requires_compiled_manuscript(command)
@@ -7151,6 +7287,7 @@ def _build_review_preflight(
                 project_cwd,
                 subject,
                 allow_markdown=allow_markdown,
+                allowed_suffixes=_command_explicit_manuscript_suffixes(command),
                 restrict_to_supported_roots=_command_explicit_manuscript_subject_uses_supported_roots(command),
                 workspace_cwd=cwd,
             )
@@ -7159,6 +7296,7 @@ def _build_review_preflight(
                 project_cwd,
                 None,
                 allow_markdown=allow_markdown,
+                allowed_suffixes=_command_explicit_manuscript_suffixes(command),
             )
         resolution = resolve_current_manuscript_resolution(project_cwd, allow_markdown=allow_markdown)
         if _command_allows_manuscript_bootstrap(command) and subject is None and resolution.status == "missing":
@@ -7173,6 +7311,13 @@ def _build_review_preflight(
             manuscript_passed = resolution.status == "resolved"
         else:
             manuscript_passed = manuscript is not None
+        if manuscript is not None and command.name == "gpd:peer-review" and manuscript.suffix.lower() == ".pdf":
+            pdf_ready, pdf_detail = _peer_review_pdf_intake_ready(manuscript)
+            manuscript_passed = manuscript_passed and pdf_ready
+            if pdf_ready:
+                manuscript_detail = f"{_format_display_path(manuscript)} present; {pdf_detail}"
+            else:
+                manuscript_detail = pdf_detail
         add_check(
             "manuscript",
             manuscript_passed,
@@ -7231,8 +7376,12 @@ def _build_review_preflight(
                 reproducibility_manifest = publication_artifacts.reproducibility_manifest
 
                 if "artifact_manifest" in requested_publication_checks:
-                    artifact_manifest_detail = "no ARTIFACT-MANIFEST.json found near the manuscript"
-                    artifact_manifest_passed = artifact_manifest is not None
+                    artifact_manifest_detail = (
+                        "no ARTIFACT-MANIFEST.json found near the manuscript"
+                        if not external_peer_review_mode
+                        else "no ARTIFACT-MANIFEST.json found near the manuscript; external artifact review can proceed without it"
+                    )
+                    artifact_manifest_passed = artifact_manifest is not None or external_peer_review_mode
                     if artifact_manifest is not None:
                         artifact_manifest_detail = f"{_format_display_path(artifact_manifest)} present"
                         from gpd.mcp.paper.models import ArtifactManifest
@@ -7252,17 +7401,27 @@ def _build_review_preflight(
                                 _format_pydantic_schema_error(error, root_label="artifact_manifest")
                                 for error in exc.errors()[:3]
                             )
-                    add_check("artifact_manifest", artifact_manifest_passed, artifact_manifest_detail)
+                    add_check(
+                        "artifact_manifest",
+                        artifact_manifest_passed,
+                        artifact_manifest_detail,
+                        blocking=not external_peer_review_mode,
+                    )
 
                 if "bibliography_audit" in requested_publication_checks:
                     add_check(
                         "bibliography_audit",
-                        bibliography_audit is not None,
+                        bibliography_audit is not None or external_peer_review_mode,
                         (
                             f"{_format_display_path(bibliography_audit)} present"
                             if bibliography_audit is not None
-                            else "no BIBLIOGRAPHY-AUDIT.json found near the manuscript"
+                            else (
+                                "no BIBLIOGRAPHY-AUDIT.json found near the manuscript"
+                                if not external_peer_review_mode
+                                else "no BIBLIOGRAPHY-AUDIT.json found near the manuscript; external artifact review can proceed without it"
+                            )
                         ),
+                        blocking=not external_peer_review_mode,
                     )
 
                 if "compiled_manuscript" in requested_publication_checks:
@@ -7488,44 +7647,56 @@ def _build_review_preflight(
                 if "reproducibility_manifest" in requested_publication_checks:
                     add_check(
                         "reproducibility_manifest",
-                        reproducibility_manifest is not None,
+                        reproducibility_manifest is not None or external_peer_review_mode,
                         (
                             f"{_format_display_path(reproducibility_manifest)} present"
                             if reproducibility_manifest is not None
-                            else "no reproducibility manifest found near the manuscript"
+                            else (
+                                "no reproducibility manifest found near the manuscript"
+                                if not external_peer_review_mode
+                                else "no reproducibility manifest found near the manuscript; external artifact review can proceed without it"
+                            )
                         ),
+                        blocking=not external_peer_review_mode,
                     )
 
                 if "manuscript_proof_review" in requested_publication_checks:
-                    manuscript_proof_review = resolve_manuscript_proof_review_status(
-                        project_cwd,
-                        manuscript,
-                        persist_manifest=True,
-                    )
-                    theorem_bearing_review_required = _requires_theorem_bearing_manuscript_review(
-                        project_cwd, manuscript
-                    )
-                    manuscript_proof_review_passed = (
-                        manuscript_proof_review.can_rely_on_prior_review
-                        or manuscript_proof_review.state == "not_reviewed"
-                    )
-                    manuscript_proof_review_blocking = False
-                    manuscript_proof_review_detail = manuscript_proof_review.detail
-                    if _command_requires_compiled_manuscript(command):
-                        if "manuscript_proof_review" in conditional_blocking_preflight_checks:
-                            manuscript_proof_review_passed = manuscript_proof_review.can_rely_on_prior_review
-                            manuscript_proof_review_blocking = True
-                        else:
-                            manuscript_proof_review_passed = True
-                            manuscript_proof_review_detail = (
-                                "no theorem-bearing claims were detected in the latest matching staged claim inventory "
-                                "or staged math review; manuscript proof review is not required for submission"
-                            )
-                    elif _command_allows_manuscript_bootstrap(command):
-                        manuscript_proof_review_passed = manuscript_proof_review.can_rely_on_prior_review
+                    if external_peer_review_mode:
+                        manuscript_proof_review_passed = True
                         manuscript_proof_review_blocking = False
-                        if theorem_bearing_review_required:
-                            if not manuscript_proof_review_passed:
+                        manuscript_proof_review_detail = (
+                            "prior staged manuscript proof review is optional in external artifact mode; "
+                            "theorem-bearing claims will be audited in this review round if detected"
+                        )
+                    else:
+                        manuscript_proof_review = resolve_manuscript_proof_review_status(
+                            project_cwd,
+                            manuscript,
+                            persist_manifest=True,
+                        )
+                        theorem_bearing_review_required = _requires_theorem_bearing_manuscript_review(
+                            project_cwd, manuscript
+                        )
+                        manuscript_proof_review_passed = (
+                            manuscript_proof_review.can_rely_on_prior_review
+                            or manuscript_proof_review.state == "not_reviewed"
+                        )
+                        manuscript_proof_review_blocking = False
+                        manuscript_proof_review_detail = manuscript_proof_review.detail
+                        if _command_requires_compiled_manuscript(command):
+                            if "manuscript_proof_review" in conditional_blocking_preflight_checks:
+                                manuscript_proof_review_passed = manuscript_proof_review.can_rely_on_prior_review
+                                manuscript_proof_review_blocking = True
+                            else:
+                                manuscript_proof_review_passed = True
+                                manuscript_proof_review_detail = (
+                                    "no theorem-bearing claims were detected in the latest matching staged claim inventory "
+                                    "or staged math review; manuscript proof review is not required for submission"
+                                )
+                        elif _command_allows_manuscript_bootstrap(command):
+                            manuscript_proof_review_passed = manuscript_proof_review.can_rely_on_prior_review
+                            manuscript_proof_review_blocking = False
+                            if theorem_bearing_review_required and not manuscript_proof_review_passed:
                                 manuscript_proof_review_detail = (
                                     manuscript_proof_review.detail
                                     + "; write-paper will run its own staged proof-review loop"
@@ -7539,7 +7710,12 @@ def _build_review_preflight(
 
                 if strict and bibliography_audit is not None and "bibliography_audit" in requested_publication_checks:
                     clean, detail = _validate_bibliography_audit_semantics(bibliography_audit)
-                    add_check("bibliography_audit_clean", clean, detail, blocking=True)
+                    add_check(
+                        "bibliography_audit_clean",
+                        clean,
+                        detail,
+                        blocking=not external_peer_review_mode,
+                    )
                 if (
                     strict
                     and reproducibility_manifest is not None
@@ -7551,7 +7727,12 @@ def _build_review_preflight(
                         repro_payload = json.loads(reproducibility_manifest.read_text(encoding="utf-8"))
                         repro_validation = validate_reproducibility_manifest(repro_payload)
                     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-                        add_check("reproducibility_ready", False, f"could not validate reproducibility manifest: {exc}")
+                        add_check(
+                            "reproducibility_ready",
+                            False,
+                            f"could not validate reproducibility manifest: {exc}",
+                            blocking=not external_peer_review_mode,
+                        )
                     else:
                         ready = (
                             repro_validation.valid
@@ -7566,7 +7747,12 @@ def _build_review_preflight(
                                 f"warnings={len(repro_validation.warnings)}, issues={len(repro_validation.issues)}"
                             )
                         )
-                        add_check("reproducibility_ready", ready, detail)
+                        add_check(
+                            "reproducibility_ready",
+                            ready,
+                            detail,
+                            blocking=not external_peer_review_mode,
+                        )
 
     if "phase_artifacts" in contract.preflight_checks:
         if subject:
@@ -7686,7 +7872,7 @@ def validate_unattended_readiness_cmd(
     live_executable_probes: bool = typer.Option(
         False,
         "--live-executable-probes",
-        help="Run cheap local executable probes such as `pdflatex --version` or `wolframscript -version`",
+        help="Run cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`",
     ),
 ) -> None:
     """Check whether one runtime surface is ready for unattended use."""

--- a/src/gpd/commands/peer-review.md
+++ b/src/gpd/commands/peer-review.md
@@ -1,8 +1,8 @@
 ---
 name: gpd:peer-review
-description: Conduct a staged six-pass peer review of a manuscript and supporting research artifacts in the current GPD project
-argument-hint: "[paper directory or manuscript path]"
-context_mode: project-required
+description: Conduct a staged six-pass peer review of a manuscript and supporting research artifacts from the current GPD project or an explicit external artifact
+argument-hint: "[paper directory or manuscript/artifact path]"
+context_mode: project-aware
 requires:
   files: ["paper/*.tex", "paper/*.md", "manuscript/*.tex", "manuscript/*.md", "draft/*.tex", "draft/*.md"]
 review-contract:
@@ -90,14 +90,13 @@ Keep the wrapper focused on the manuscript target, review prerequisites, and fin
 </execution_context>
 
 <context>
-Review target: $ARGUMENTS (optional paper directory or manuscript path)
+Review target: $ARGUMENTS (optional paper directory, manuscript path, or explicit artifact path). If no argument is provided, first ask whether to review an explicit artifact or the current GPD project's active manuscript when available.
 
-@GPD/STATE.md
-@GPD/ROADMAP.md
+If the current folder is a GPD project, treat `GPD/STATE.md` and `GPD/ROADMAP.md` as optional project context. Do not require them for standalone external artifact review.
 
-The default manuscript family is limited to `paper/`, `manuscript/`, and `draft/`.
-Let centralized preflight resolve the active manuscript entrypoint from the explicit argument when provided, otherwise from the manuscript-root `ARTIFACT-MANIFEST.json`, then `PAPER-CONFIG.json`, then the canonical current manuscript entrypoint rules for those roots. Do not use ad hoc wildcard discovery.
-If none of those roots exist, pass an explicit manuscript path or paper directory and let centralized preflight reject anything outside the supported target family.
+The default in-project manuscript family is limited to `paper/`, `manuscript/`, and `draft/`.
+Let centralized preflight resolve the active manuscript entrypoint from the explicit argument when provided, otherwise from the manuscript-root `ARTIFACT-MANIFEST.json`, then `PAPER-CONFIG.json`, then the canonical current manuscript entrypoint rules for those roots. Explicit external artifact intake may also target `.tex`, `.md`, `.txt`, or `.pdf`. Do not use ad hoc wildcard discovery.
+If no explicit target is supplied, the workflow may either use the current GPD project manuscript when available or ask the user to point at a specific artifact path.
 
 ```bash
 # Regression guardrail wording retained for test alignment:

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -1647,7 +1647,7 @@ def _doctor_check_package_imports() -> HealthCheck:
 
 
 _DOCTOR_LIVE_EXECUTABLE_PROBE_TIMEOUT_SECONDS = 5
-_DOCTOR_LIVE_EXECUTABLE_OPTIONAL_COMMANDS = ("pdflatex", "bibtex", "latexmk", "kpsewhich", "wolframscript")
+_DOCTOR_LIVE_EXECUTABLE_OPTIONAL_COMMANDS = ("pdflatex", "bibtex", "latexmk", "kpsewhich", "pdftotext", "wolframscript")
 
 
 def _doctor_run_executable_probe(argv: list[str], *, timeout_seconds: int) -> dict[str, object]:
@@ -1729,10 +1729,11 @@ def _doctor_check_live_executable_probes() -> HealthCheck:
         resolved = _doctor_which(executable)
         if resolved is None:
             skipped.append(executable)
+            skipped_command = [executable, "-v"] if executable == "pdftotext" else [executable, "--version"]
             probe_results.append(
                 {
                     "label": executable,
-                    "command": [executable, "--version"],
+                    "command": skipped_command,
                     "status": "skipped",
                     "reason": "not found on PATH",
                 }
@@ -1740,7 +1741,8 @@ def _doctor_check_live_executable_probes() -> HealthCheck:
             warnings.append(f"{executable} not found on PATH")
             continue
 
-        probe = _doctor_run_executable_probe([resolved, "--version"], timeout_seconds=_DOCTOR_LIVE_EXECUTABLE_PROBE_TIMEOUT_SECONDS)
+        probe_args = [resolved, "-v"] if executable == "pdftotext" else [resolved, "--version"]
+        probe = _doctor_run_executable_probe(probe_args, timeout_seconds=_DOCTOR_LIVE_EXECUTABLE_PROBE_TIMEOUT_SECONDS)
         probe["label"] = executable
         probe["resolved_path"] = resolved
         probe_results.append(probe)
@@ -1968,11 +1970,13 @@ def _doctor_check_latex_toolchain() -> HealthCheck:
                 "bibtex_available": None,
                 "bibliography_support_available": False,
                 "kpsewhich_available": None,
+                "pdftotext_available": None,
                 "readiness_state": "blocked",
                 "message": "Could not load LaTeX detection helpers.",
                 "warnings": [f"Could not load LaTeX detection helpers: {exc}"],
                 "paper_build_ready": False,
                 "arxiv_submission_ready": False,
+                "pdf_review_ready": False,
                 "missing_components": [],
             },
             warnings=[f"Could not load LaTeX detection helpers: {exc}"],
@@ -1984,6 +1988,7 @@ def _doctor_check_latex_toolchain() -> HealthCheck:
     latexmk_available = bool(capability_details["latexmk_available"])
     bibtex_available = bool(capability_details["bibtex_available"])
     kpsewhich_available = bool(capability_details["kpsewhich_available"])
+    pdftotext_available = bool(capability_details["pdftotext_available"])
     full_toolchain_available = bool(capability_details["full_toolchain_available"])
     missing_components: list[str] = []
     if not compiler_available:
@@ -1994,6 +1999,8 @@ def _doctor_check_latex_toolchain() -> HealthCheck:
         missing_components.append("bibtex")
     if compiler_available and not kpsewhich_available:
         missing_components.append("kpsewhich")
+    if compiler_available and not pdftotext_available:
+        missing_components.append("pdftotext")
 
     warnings = list(capability_details.get("warnings", [])) if isinstance(capability_details.get("warnings"), list) else []
     if compiler_available and missing_components:
@@ -2052,6 +2059,12 @@ def _doctor_check_workflow_presets(*, latex_check: HealthCheck, base_ready: bool
         warnings.append(
             "Publication / manuscript and full research presets are degraded without arxiv-submission support: "
             "`paper-build` remains usable, but `arxiv-submission` stays blocked until TeX resource checks pass."
+        )
+    elif not bool(capability_details.get("pdf_review_ready", False)):
+        warnings.append(
+            "Publication / manuscript and full research presets are degraded without pdftotext: "
+            "`write-paper`, `paper-build`, and `arxiv-submission` remain usable, but PDF-backed `peer-review` intake "
+            "requires `pdftotext` or a nearby `.txt` companion file."
         )
 
     status = CheckStatus.OK if details["degraded"] == 0 and details["blocked"] == 0 else CheckStatus.WARN

--- a/src/gpd/core/workflow_presets.py
+++ b/src/gpd/core/workflow_presets.py
@@ -42,11 +42,13 @@ _LATEX_CAPABILITY_DEFAULTS: dict[str, object] = {
     "bibliography_support_available": False,
     "latexmk_available": None,
     "kpsewhich_available": None,
+    "pdftotext_available": None,
     "readiness_state": "blocked",
     "message": "",
     "warnings": [],
     "paper_build_ready": False,
     "arxiv_submission_ready": False,
+    "pdf_review_ready": False,
 }
 
 
@@ -140,6 +142,7 @@ def _normalize_latex_capability(
 
     latexmk_value = _capability_value(latex_capability, "latexmk_available", "latexmk")
     kpsewhich_value = _capability_value(latex_capability, "kpsewhich_available", "kpsewhich")
+    pdftotext_value = _capability_value(latex_capability, "pdftotext_available", "pdftotext")
     full_toolchain_value = _capability_value(latex_capability, "full_toolchain_available", "full_toolchain_ready")
     full_toolchain_available = _strict_bool_value(full_toolchain_value)
     compiler_path = _capability_value(latex_capability, "compiler_path")
@@ -155,6 +158,7 @@ def _normalize_latex_capability(
         warnings = []
 
     bibtex_ready = bibtex_available is True
+    pdftotext_ready = _strict_bool_value(pdftotext_value) is not False
     bibliography_support_available = compiler_available and bibtex_ready
     paper_build_ready = compiler_available
     arxiv_submission_ready = bibliography_support_available and kpsewhich_value is True
@@ -191,11 +195,13 @@ def _normalize_latex_capability(
         "bibliography_support_available": bibliography_support_available,
         "latexmk_available": _strict_bool_value(latexmk_value),
         "kpsewhich_available": _strict_bool_value(kpsewhich_value),
+        "pdftotext_available": _strict_bool_value(pdftotext_value),
         "readiness_state": readiness_state,
         "message": message,
         "warnings": warnings,
         "paper_build_ready": paper_build_ready,
         "arxiv_submission_ready": arxiv_submission_ready,
+        "pdf_review_ready": pdftotext_ready,
     }
     return normalized
 
@@ -448,6 +454,7 @@ def resolve_workflow_preset_readiness(
     bibliography_support_ready = capability.get("bibliography_support_available") is True
     latexmk_available = capability.get("latexmk_available")
     kpsewhich_available = capability.get("kpsewhich_available")
+    pdf_review_ready = capability.get("pdf_review_ready") is True
     paper_build_ready = capability["paper_build_ready"] is True
     arxiv_submission_ready = capability["arxiv_submission_ready"] is True
 
@@ -473,23 +480,40 @@ def resolve_workflow_preset_readiness(
             ready_workflows = []
             degraded_workflows = list(preset.degraded_workflows)
             blocked_workflows = list(preset.blocked_workflows)
-        elif preset.requires_extra_tooling and not bibliography_support_ready:
-            status = "degraded"
+        elif preset.requires_extra_tooling:
+            status = "ready"
             usable = True
-            summary = (
-                "degraded without bibliography tooling: draft/review remain usable, while paper-build and "
-                "arxiv-submission may fail for manuscripts that require bibliography processing"
-            )
-            ready_workflows = list(preset.degraded_workflows)
-            degraded_workflows = ["paper-build", "arxiv-submission"]
-            blocked_workflows = []
-        elif preset.requires_extra_tooling and not arxiv_submission_ready:
-            status = "degraded"
-            usable = True
-            summary = "degraded without arxiv-submission support: paper-build remains usable, but arxiv-submission stays blocked"
-            ready_workflows = [workflow for workflow in preset.ready_workflows if workflow != "arxiv-submission"]
+            summary = "ready"
+            ready_workflows = list(preset.ready_workflows)
             degraded_workflows = []
-            blocked_workflows = ["arxiv-submission"]
+            blocked_workflows = []
+
+            if not bibliography_support_ready:
+                summary = (
+                    "degraded without bibliography tooling: draft/review remain usable, while paper-build and "
+                    "arxiv-submission may fail for manuscripts that require bibliography processing"
+                )
+                status = "degraded"
+                ready_workflows = [workflow for workflow in ready_workflows if workflow not in {"paper-build", "arxiv-submission"}]
+                degraded_workflows.extend(["paper-build", "arxiv-submission"])
+            elif not arxiv_submission_ready:
+                summary = (
+                    "degraded without arxiv-submission support: paper-build remains usable, but arxiv-submission stays blocked"
+                )
+                status = "degraded"
+                ready_workflows = [workflow for workflow in ready_workflows if workflow != "arxiv-submission"]
+                blocked_workflows.append("arxiv-submission")
+
+            if not pdf_review_ready:
+                if status == "ready":
+                    summary = (
+                        "degraded without pdftotext: TeX/Markdown/TXT review remains usable, "
+                        "but PDF intake for peer-review requires pdftotext or a companion text file"
+                    )
+                status = "degraded"
+                ready_workflows = [workflow for workflow in ready_workflows if workflow != "peer-review"]
+                if "peer-review" not in degraded_workflows:
+                    degraded_workflows.append("peer-review")
         else:
             status = "ready"
             usable = True
@@ -519,10 +543,21 @@ def resolve_workflow_preset_readiness(
                 warnings.append(
                     "kpsewhich is missing: paper-build remains usable, but arxiv-submission stays blocked."
                 )
+            elif not pdf_review_ready:
+                warnings.append(
+                    "pdftotext is missing: TeX/Markdown/TXT review remains usable, but PDF-backed peer-review intake "
+                    "requires pdftotext or a nearby `.txt` companion file."
+                )
             if latexmk_available is False:
                 warnings.append("latexmk is missing: paper builds will fall back to manual multipass compilation.")
             if kpsewhich_available is False:
                 warnings.append("kpsewhich is missing: TeX resource checks are best-effort only.")
+            if capability.get("pdftotext_available") is False and not any(
+                "pdftotext is missing:" in warning for warning in warnings
+            ):
+                warnings.append(
+                    "pdftotext is missing: PDF-backed peer-review intake requires pdftotext or a nearby `.txt` companion file."
+                )
 
         entries.append(
             {

--- a/src/gpd/mcp/paper/compiler.py
+++ b/src/gpd/mcp/paper/compiler.py
@@ -115,11 +115,13 @@ def detect_latex_toolchain(compiler: str = "pdflatex") -> LatexToolchainStatus:
     bibtex_path = find_latex_compiler("bibtex")
     latexmk_path = find_latex_compiler("latexmk")
     kpsewhich_path = find_latex_compiler("kpsewhich")
+    pdftotext_path = find_latex_compiler("pdftotext")
 
     compiler_available = path is not None
     bibtex_available = bibtex_path is not None
     latexmk_available = latexmk_path is not None
     kpsewhich_available = kpsewhich_path is not None
+    pdftotext_available = pdftotext_path is not None
     warnings: list[str] = []
 
     if compiler_available:
@@ -132,7 +134,9 @@ def detect_latex_toolchain(compiler: str = "pdflatex") -> LatexToolchainStatus:
             warnings.append("latexmk not found; multi-pass compilation will fall back to manual passes.")
         if not kpsewhich_available:
             warnings.append("kpsewhich not found; TeX resource checks will assume installed resources.")
-    else:
+    if not pdftotext_available:
+        warnings.append("pdftotext not found; PDF peer-review intake will require a nearby `.txt` companion file.")
+    if not compiler_available:
         warnings.append("Install a LaTeX distribution to enable paper compilation.")
 
     # Heuristic distribution name
@@ -159,6 +163,7 @@ def detect_latex_toolchain(compiler: str = "pdflatex") -> LatexToolchainStatus:
             bibtex_available=bibtex_available,
             latexmk_available=latexmk_available,
             kpsewhich_available=kpsewhich_available,
+            pdftotext_available=pdftotext_available,
             readiness_state="blocked",
             message=get_latex_install_guidance(),
             warnings=warnings,
@@ -179,6 +184,10 @@ def detect_latex_toolchain(compiler: str = "pdflatex") -> LatexToolchainStatus:
         summary += "; kpsewhich available"
     else:
         summary += "; kpsewhich unavailable"
+    if pdftotext_available:
+        summary += "; pdftotext available"
+    else:
+        summary += "; pdftotext unavailable"
     summary += f"; readiness={readiness_state}"
 
     return LatexToolchainStatus(
@@ -189,6 +198,7 @@ def detect_latex_toolchain(compiler: str = "pdflatex") -> LatexToolchainStatus:
         bibtex_available=bibtex_available,
         latexmk_available=latexmk_available,
         kpsewhich_available=kpsewhich_available,
+        pdftotext_available=pdftotext_available,
         readiness_state=readiness_state,
         message=summary,
         warnings=warnings,

--- a/src/gpd/mcp/paper/models.py
+++ b/src/gpd/mcp/paper/models.py
@@ -459,10 +459,12 @@ class PaperToolchainCapability(BaseModel):
     bibliography_support_available: bool = False
     latexmk_available: bool | None = None
     kpsewhich_available: bool | None = None
+    pdftotext_available: bool | None = None
     available: bool = False
     full_toolchain_available: bool = False
     paper_build_ready: bool = False
     arxiv_submission_ready: bool = False
+    pdf_review_ready: bool = False
     readiness_state: Literal["blocked", "degraded", "ready"] = "blocked"
     message: str = ""
     warnings: list[str] = Field(default_factory=list)
@@ -473,14 +475,16 @@ class PaperToolchainCapability(BaseModel):
         bibtex_available = self.bibtex_available is True
         latexmk_available = self.latexmk_available is True
         kpsewhich_available = self.kpsewhich_available is True
+        pdftotext_available = self.pdftotext_available is True
 
         self.available = compiler_available
         self.bibliography_support_available = compiler_available and bibtex_available
         self.paper_build_ready = compiler_available
         self.full_toolchain_available = (
-            compiler_available and bibtex_available and latexmk_available and kpsewhich_available
+            compiler_available and bibtex_available and latexmk_available and kpsewhich_available and pdftotext_available
         )
         self.arxiv_submission_ready = self.bibliography_support_available and kpsewhich_available
+        self.pdf_review_ready = pdftotext_available
         if not compiler_available:
             self.readiness_state = "blocked"
         elif bibtex_available:

--- a/src/gpd/specs/references/publication/peer-review-reliability.md
+++ b/src/gpd/specs/references/publication/peer-review-reliability.md
@@ -26,11 +26,11 @@ The peer review phase activates **after a complete manuscript draft exists** and
 
 ### Precondition Checklist
 
-- Manuscript main file exists under `paper/`, `manuscript/`, or `draft/`
-- `GPD/STATE.md` and `GPD/ROADMAP.md` are present
-- Phase summaries and verification reports are available under `GPD/phases/`
-- `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and reproducibility manifest are present (strict mode)
-- Strict preflight semantic gates pass: `bibliography_audit_clean` and `reproducibility_ready`
+- Either the active manuscript exists under `paper/`, `manuscript/`, or `draft/`, or the user supplies one explicit `.tex`, `.md`, `.txt`, or `.pdf` review target
+- `GPD/STATE.md` and `GPD/ROADMAP.md` are present when reviewing the current GPD project manuscript
+- Phase summaries and verification reports are available under `GPD/phases/` when reviewing the current GPD project manuscript
+- `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and reproducibility manifest are required in strict project-backed mode and additive when present for explicit external artifact review
+- Strict preflight semantic gates pass for any manuscript-root publication artifacts that are present
 
 If any precondition fails, the review preflight blocks entry and reports the missing items.
 
@@ -58,7 +58,7 @@ All of the following must hold before the review phase begins:
 1. **Manuscript completeness.** All sections referenced in the paper structure are drafted. No placeholder or stub sections remain.
 2. **Artifact readiness.** `ARTIFACT-MANIFEST.json` and `BIBLIOGRAPHY-AUDIT.json` exist and pass validation. In strict mode the bibliography audit must also clear `bibliography_audit_clean`, and the reproducibility manifest must clear `reproducibility_ready`.
 3. **Verification coverage.** At least one verification report exists under `GPD/phases/`.
-4. **Preflight pass.** `gpd validate review-preflight peer-review "$ARGUMENTS" --strict` exits zero.
+4. **Preflight pass.** `gpd validate review-preflight peer-review "$REVIEW_TARGET" --strict` exits zero.
 
 ### Exit Criteria
 

--- a/src/gpd/specs/templates/paper/publication-manuscript-root-preflight.md
+++ b/src/gpd/specs/templates/paper/publication-manuscript-root-preflight.md
@@ -1,7 +1,9 @@
 Canonical manuscript-root publication preflight.
 
 Resolve exactly one active manuscript root from the canonical manuscript family: `paper/`, `manuscript/`, or `draft/`.
+In explicit-artifact mode, allow one `.tex`, `.md`, `.txt`, or `.pdf` review target outside those roots.
 
 For a resumed manuscript, strict preflight reads `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and `reproducibility-manifest.json` from the resolved manuscript directory itself. Use `ARTIFACT-MANIFEST.json` first and `PAPER-CONFIG.json` second when selecting the active manuscript entry point. Do not use ad hoc wildcard discovery or first-match filename scans.
+For explicit-artifact mode, nearby `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and `reproducibility-manifest.json` are additive when present rather than blocking prerequisites.
 
 Keep all manuscript-local support artifacts rooted at the same explicit manuscript directory, and do not satisfy strict review or packaging with artifacts copied from another manuscript root. Treat `gpd paper-build` as the authoritative step that regenerates the resolved manuscript-root `ARTIFACT-MANIFEST.json` and `BIBLIOGRAPHY-AUDIT.json`. In strict mode, `bibliography_audit_clean` and `reproducibility_ready` must pass before review or packaging proceeds.

--- a/src/gpd/specs/workflows/help.md
+++ b/src/gpd/specs/workflows/help.md
@@ -58,9 +58,9 @@ Phase {N} complete:
 **Manuscript exists, no referee report yet:**
 ```
 Publication workflow:
-  gpd:peer-review         — Run manuscript peer review inside the current project
+  gpd:peer-review         — Run manuscript peer review on the current project manuscript or an explicit artifact
   gpd:arxiv-submission    — Package only after review passes and the paper-build contract succeeds
-  gpd doctor --runtime <runtime> --local|--global — Check runtime-local paper-toolchain readiness for the paper/manuscript workflow preset. Add `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version` or `wolframscript -version`. Inspect the preset with `gpd presets list`, preview it with `gpd presets show <preset>`, and apply it from your normal terminal with `gpd presets apply <preset>` or through your runtime-specific settings command; failed preset rows degrade `write-paper`, but `paper-build` remains the build contract and `arxiv-submission` requires the built manuscript
+  gpd doctor --runtime <runtime> --local|--global — Check runtime-local paper-toolchain readiness for the paper/manuscript workflow preset. Add `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`. Inspect the preset with `gpd presets list`, preview it with `gpd presets show <preset>`, and apply it from your normal terminal with `gpd presets apply <preset>` or through your runtime-specific settings command; failed preset rows degrade `write-paper`, but `paper-build` remains the build contract and `arxiv-submission` requires the built manuscript
   gpd integrations status wolfram — Inspect the shared optional Wolfram integration config only; this does not prove local Mathematica availability or plan readiness, and optional doctor probes do not change that
 ```
 
@@ -96,7 +96,7 @@ Project ─── the overall research goal
 5. `gpd:verify-work` — Verify physics correctness
 6. Repeat 2-5 for each phase (or `gpd:autonomous` to run all phases hands-off)
 7. `gpd:write-paper` — Generate publication from results
-8. `gpd:peer-review` — Run manuscript review before submission inside the current project
+8. `gpd:peer-review` — Run manuscript review before submission on the current project manuscript or an explicit artifact
 9. `gpd:respond-to-referees` — Address reviewer comments if needed
 10. `gpd:arxiv-submission` — Package the approved manuscript
 
@@ -136,7 +136,7 @@ Depending on the runtime, those names may be rendered with slash prefixes, dolla
 - Use these names inside the installed agent/runtime command surface.
 - Use `gpd --help` to inspect the executable local install/readiness/permissions/diagnostics surface directly.
 - Use `gpd permissions status --runtime <runtime> --autonomy balanced` when you want the read-only runtime-owned approval/alignment snapshot from your normal terminal.
-- Use `gpd doctor` to check the selected install target and runtime-local readiness signals. Use `gpd validate unattended-readiness --runtime <runtime> --autonomy balanced` for the unattended or overnight verdict, `gpd permissions sync --runtime <runtime> --autonomy balanced` when runtime-owned permissions need realignment, and `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version` or `wolframscript -version`.
+- Use `gpd doctor` to check the selected install target and runtime-local readiness signals. Use `gpd validate unattended-readiness --runtime <runtime> --autonomy balanced` for the unattended or overnight verdict, `gpd permissions sync --runtime <runtime> --autonomy balanced` when runtime-owned permissions need realignment, and `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`.
 - If you need to validate whether a public runtime command can run in the current workspace, use `gpd validate command-context gpd:<name>`.
 - If a plan declares specialized `tool_requirements`, use `gpd validate plan-preflight <PLAN.md>` from your normal terminal before execution.
 - For a normal-terminal, current-workspace read-only recovery snapshot without launching the runtime, use `gpd resume`.
@@ -241,7 +241,7 @@ This is the compact grouped list of runtime commands. For normal-terminal instal
 
 - `gpd:literature-review [topic]` - Create a structured literature review
 - `gpd:write-paper [title or topic] [--from-phases 1,2,3]` - Draft a paper from project results
-- `gpd:peer-review [paper directory or manuscript path]` - Run the staged review workflow
+- `gpd:peer-review [paper directory | manuscript path | .pdf/.txt artifact path]` - Run the staged review workflow
 - `gpd:respond-to-referees` - Draft referee responses and revise the paper
 - `gpd:arxiv-submission` - Package a built manuscript for arXiv
 - `gpd:slides [topic, audience, or source path]` - Create presentation slides
@@ -781,18 +781,21 @@ Structure and write a physics paper from research results.
 Usage: `gpd:write-paper "Critical exponents via RG"`
 Usage: `gpd:write-paper --from-phases 1,3,5` (subset of phases)
 
-**`gpd:peer-review [paper directory or manuscript path]`**
-Run skeptical peer review on an existing manuscript within the current GPD project.
+**`gpd:peer-review [paper directory | manuscript path | .pdf/.txt artifact path]`**
+Run skeptical peer review on an existing manuscript or explicit review artifact.
 
-- Runs strict review preflight checks against project state, manuscript, artifacts, and reproducibility support
-- Loads manuscript files, phase summaries, verification reports, bibliography audit, and artifact manifest
+- Runs strict review preflight checks against the resolved review target and available supporting artifacts
+- Loads manuscript files or explicit artifact text, plus project summaries and verification context when present
+- Bare PDF intake requires either `pdftotext` on PATH or a same-directory `.txt` companion file
 - Spawns a six-agent review panel plus the auxiliary `gpd-check-proof` critic when theorem-bearing claims are present
 - Produces stage artifacts under `GPD/review/` plus `GPD/REFEREE-REPORT{round_suffix}.md` and `GPD/REFEREE-REPORT{round_suffix}.tex`
 - Routes the result to `gpd:respond-to-referees` or `gpd:arxiv-submission`
-- Requires an initialized `GPD/PROJECT.md` workspace; manuscript paths do not bypass project preflight
+- If no argument is supplied, the command asks whether to review an explicit artifact or the current GPD project's active manuscript when available
 
 Usage: `gpd:peer-review`
 Usage: `gpd:peer-review paper/`
+Usage: `gpd:peer-review draft.pdf`
+Usage: `gpd:peer-review notes.txt`
 
 **`gpd:respond-to-referees`**
 Structure point-by-point response to referee reports and revise the manuscript.
@@ -888,7 +891,7 @@ Usage: `gpd:review-knowledge GPD/knowledge/K-renormalization-group-fixed-points.
 **Workflow presets**
 
 - `Paper/manuscript workflows` - First supported workflow preset for `write-paper`, `paper-build`, `peer-review`, and `arxiv-submission`; inspect it with `gpd presets list`, preview it with `gpd presets show <preset>`, and apply it from your normal terminal with `gpd presets apply <preset>` or through your runtime-specific `settings` command
-- `gpd doctor --runtime <runtime> --local` / `gpd doctor --runtime <runtime> --global` - Check the local or global runtime target from your normal terminal before using that preset. Add `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version` or `wolframscript -version`. Failed preset rows degrade `write-paper`, but `paper-build` remains the build contract and `arxiv-submission` still requires the built manuscript
+- `gpd doctor --runtime <runtime> --local` / `gpd doctor --runtime <runtime> --global` - Check the local or global runtime target from your normal terminal before using that preset. Add `--live-executable-probes` if you also want cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`. Failed preset rows degrade `write-paper`, but `paper-build` remains the build contract and `arxiv-submission` still requires the built manuscript
 - `gpd presets list` - Inspect the local preset catalog; presets resolve to the existing config keys and do not add a separate persisted preset block
 - `gpd presets show <preset>` - Preview one preset's bundle before applying it
 - `gpd presets apply <preset> [--dry-run]` - Apply or preview one preset from your normal terminal without inventing a separate preset schema

--- a/src/gpd/specs/workflows/new-project.md
+++ b/src/gpd/specs/workflows/new-project.md
@@ -288,7 +288,7 @@ See `GPD/CONVENTIONS.md`. Add `GPD/NOTATION_GLOSSARY.md` later only if the proje
 
 [Inferred from input, or "To be determined from conventions setup"]
 
-If the project may rely on Wolfram capability, distinguish a local Mathematica / Wolfram Language install from the shared optional Wolfram integration config. Add `--live-executable-probes` to `gpd doctor` if you also want cheap local executable probes such as `pdflatex --version` or `wolframscript -version`, but that stays separate from the shared path enabled with `gpd integrations enable wolfram`, and it is still separate from `gpd validate plan-preflight <PLAN.md>` and from local install checks.
+If the project may rely on Wolfram capability, distinguish a local Mathematica / Wolfram Language install from the shared optional Wolfram integration config. Add `--live-executable-probes` to `gpd doctor` if you also want cheap local executable probes such as `pdflatex --version`, `pdftotext -v`, or `wolframscript -version`, but that stays separate from the shared path enabled with `gpd integrations enable wolfram`, and it is still separate from `gpd validate plan-preflight <PLAN.md>` and from local install checks.
 
 ## Requirements
 

--- a/src/gpd/specs/workflows/peer-review.md
+++ b/src/gpd/specs/workflows/peer-review.md
@@ -42,10 +42,28 @@ If `derived_manuscript_reference_status` is present, use it as a first-pass manu
 If `derived_manuscript_proof_review_status` is present, use it as the first-pass manuscript-local summary of theorem/proof freshness and keep the manuscript-root proof-redteam artifacts authoritative for strict decisions.
 The shared manuscript-root bootstrap contract is applied in preflight. The local steps below add only peer-review-specific routing, proof-review, and adjudication rules.
 
+Set `REVIEW_TARGET="$ARGUMENTS"` unless interactive intake overrides it.
+
+If `REVIEW_TARGET` is empty and `project_exists` is true, ask the user which mode they want:
+
+> **Platform note:** If `ask_user` is not available, present the same choices in plain text and wait for the user's freeform response.
+
+Use ask_user:
+
+- header: `Peer Review`
+- question: `Review the current GPD project manuscript, or point at a specific manuscript artifact?`
+- options:
+  - `Use current project` -- Review the active manuscript resolved from the current GPD project. Recommended when the folder is already a GPD project.
+  - `Pick artifact path` -- Review a specific `.tex`, `.md`, `.txt`, `.pdf`, or manuscript directory path instead.
+
+If the user chooses `Pick artifact path`, ask for one explicit path and store it in `REVIEW_TARGET`.
+
+If `REVIEW_TARGET` is empty and `project_exists` is false, ask the user for one explicit manuscript path or directory. Accept `.tex`, `.md`, `.txt`, `.pdf`, or a manuscript directory path. If the answer is still empty, STOP and ask again for a concrete artifact path.
+
 Run centralized context preflight before continuing:
 
 ```bash
-CONTEXT=$(gpd --raw validate command-context peer-review "$ARGUMENTS")
+CONTEXT=$(gpd --raw validate command-context peer-review "$REVIEW_TARGET")
 if [ $? -ne 0 ]; then
   echo "$CONTEXT"
   exit 1
@@ -54,8 +72,8 @@ fi
 
 **Resolve manuscript target:**
 
-1. If `$ARGUMENTS` names a directory, use it as the candidate paper directory.
-2. If `$ARGUMENTS` names a `.tex` or `.md` file, use that file and its parent directory as the review root.
+1. If `$REVIEW_TARGET` names a directory, use it as the candidate paper directory.
+2. If `$REVIEW_TARGET` names a `.tex`, `.md`, `.txt`, or `.pdf` file, use that file and its parent directory as the review root.
 3. Otherwise search, in order:
    - the resolved manuscript entrypoint under `paper/`
    - the resolved manuscript entrypoint under `manuscript/`
@@ -63,7 +81,7 @@ fi
 
 After resolution, keep all manuscript-local support artifacts rooted at the same explicit manuscript directory:
 
-- `RESOLVED_MANUSCRIPT` = resolved `.tex` or `.md` entry point
+- `RESOLVED_MANUSCRIPT` = resolved manuscript entry point or explicit artifact file
 - `MANUSCRIPT_ROOT` = parent directory of `RESOLVED_MANUSCRIPT`
 - `ARTIFACT_MANIFEST_PATH` = `${MANUSCRIPT_ROOT}/ARTIFACT-MANIFEST.json`
 - `BIBLIOGRAPHY_AUDIT_PATH` = `${MANUSCRIPT_ROOT}/BIBLIOGRAPHY-AUDIT.json`
@@ -71,12 +89,20 @@ After resolution, keep all manuscript-local support artifacts rooted at the same
 - `PAPER_CONFIG_PATH` = `${MANUSCRIPT_ROOT}/PAPER-CONFIG.json`
 - `LOCAL_BIB_FILES` = all `*.bib` files under `${MANUSCRIPT_ROOT}`
 
+Prepare a reader-friendly manuscript surface for the staged reviewers:
+
+- For `.tex` or `.md`, keep the resolved main file plus any nearby section `.tex` / `.md` files under the same manuscript root.
+- For `.txt`, use the `.txt` file directly as the manuscript review surface.
+- For `.pdf`, first look for a nearby text companion such as the same basename with `.txt`. If none exists and `pdftotext` is available, create `GPD/review/` if needed, extract a text copy to `GPD/review/MANUSCRIPT-TEXT.txt`, and use that extracted file as the manuscript review surface while keeping the original PDF as the canonical `RESOLVED_MANUSCRIPT`. If neither a nearby text companion nor `pdftotext` is available, STOP and ask the user to point at a `.txt`, `.md`, `.tex`, or a PDF with an extractable text companion.
+
+Store the reviewer-visible inputs as `MANUSCRIPT_STAGE_FILES`.
+
 **If no manuscript found:**
 
 ```
 No manuscript found. Searched: paper/, manuscript/, draft/
 
-Run gpd:write-paper first, or provide a manuscript path to gpd:peer-review.
+Run gpd:write-paper first, or provide a `.tex`, `.md`, `.txt`, `.pdf`, or manuscript directory path to gpd:peer-review.
 ```
 
 Exit.
@@ -111,13 +137,13 @@ Apply the shared manuscript-root bootstrap contract exactly:
 @{GPD_INSTALL_DIR}/templates/paper/publication-manuscript-root-preflight.md
 
 ```bash
-gpd validate review-preflight peer-review "$ARGUMENTS" --strict
+gpd validate review-preflight peer-review "$REVIEW_TARGET" --strict
 ```
 
 If preflight exits nonzero because of missing project state, missing manuscript, degraded review integrity, or missing review-grade paper artifacts, STOP and show the blocking issues.
 If preflight reports blocked contract/state integrity, surface `project_contract_gate`, `project_contract_load_info`, and `project_contract_validation` details in the stop message and repair the blocked contract before retrying.
 
-In strict peer-review mode, `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and a reproducibility manifest are required inputs. `gpd paper-build` is the step that regenerates `BIBLIOGRAPHY-AUDIT.json` for the current bibliography; rerun it before proceeding whenever the manuscript bibliography or citation set has changed. Strict preflight also enforces the semantic gates `bibliography_audit_clean` and `reproducibility_ready`; those artifacts must be review-ready, not merely present. If `derived_manuscript_reference_status` is available from init, use it as a quick read on what is likely stale or complete, but do not let it override the manuscript-root publication artifacts. Peer review is expected to fail closed when those review-support artifacts are absent, stale, or not review-ready.
+In strict project-backed peer-review mode, `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and a reproducibility manifest are required inputs. `gpd paper-build` is the step that regenerates `BIBLIOGRAPHY-AUDIT.json` for the current bibliography; rerun it before proceeding whenever the manuscript bibliography or citation set has changed. Strict preflight also enforces the semantic gates `bibliography_audit_clean` and `reproducibility_ready`; those artifacts must be review-ready, not merely present. If `derived_manuscript_reference_status` is available from init, use it as a quick read on what is likely stale or complete, but do not let it override the manuscript-root publication artifacts. For explicit external artifact review, these manuscript-root publication artifacts become optional supporting context when present and must not block intake by themselves.
 Passing preflight still does not establish scientific support. Complete manifests and audits cannot rescue missing decisive comparisons, overclaimed conclusions, or absent contract-backed evidence.
 </step>
 
@@ -126,11 +152,11 @@ Passing preflight still does not establish scientific support. Complete manifest
 
 Load the following files:
 
-- The resolved manuscript entrypoint and any nearby manuscript `*.tex` or `*.md` files that belong to the same manuscript root
-- `GPD/STATE.md`
-- `GPD/ROADMAP.md`
-- All summary artifacts matching `GPD/phases/*/*SUMMARY.md`
-- All `GPD/phases/*/*-VERIFICATION.md` files
+- `MANUSCRIPT_STAGE_FILES`
+- `GPD/STATE.md` if present
+- `GPD/ROADMAP.md` if present
+- All summary artifacts matching `GPD/phases/*/*SUMMARY.md` if present
+- All `GPD/phases/*/*-VERIFICATION.md` files if present
 - `GPD/comparisons/*-COMPARISON.md` if present
 - `${MANUSCRIPT_ROOT}/FIGURE_TRACKER.md` if present
 - `${ARTIFACT_MANIFEST_PATH}` if present
@@ -247,7 +273,7 @@ Output paths:
 - `GPD/review/STAGE-reader{round_suffix}.json`
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 
 Focus on:
 1. Read the whole manuscript end-to-end before consulting project-internal summaries.
@@ -313,7 +339,7 @@ Carry-forward context: protocol bundle guidance {protocol_bundle_context}; proje
 Output path: `GPD/review/STAGE-literature{round_suffix}.json`
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 - `GPD/review/STAGE-reader{round_suffix}.json`
 - `GPD/comparisons/*-COMPARISON.md` if present
@@ -345,11 +371,11 @@ Carry-forward context: project contract {project_contract}; project contract gat
 Output path: `GPD/review/STAGE-math{round_suffix}.json`
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 - `GPD/review/STAGE-reader{round_suffix}.json`
-- Summary artifacts matching `GPD/phases/*/*SUMMARY.md`
-- `GPD/phases/*/*-VERIFICATION.md`
+- Summary artifacts matching `GPD/phases/*/*SUMMARY.md` if present
+- `GPD/phases/*/*-VERIFICATION.md` if present
 - `${ARTIFACT_MANIFEST_PATH}` if present
 - `${REPRODUCIBILITY_MANIFEST_PATH}` if present
 
@@ -386,11 +412,11 @@ Before writing frontmatter, bind these fields exactly from the active round arti
 - `proof_artifact_paths`: copy exactly the theorem-bearing proof artifact paths under review, plus the manuscript entrypoint if it is not already listed
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 - `GPD/review/STAGE-reader{round_suffix}.json`
-- Summary artifacts matching `GPD/phases/*/*SUMMARY.md`
-- `GPD/phases/*/*-VERIFICATION.md`
+- Summary artifacts matching `GPD/phases/*/*SUMMARY.md` if present
+- `GPD/phases/*/*-VERIFICATION.md` if present
 - `${ARTIFACT_MANIFEST_PATH}` if present
 - `${REPRODUCIBILITY_MANIFEST_PATH}` if present
 
@@ -461,14 +487,14 @@ Carry-forward context: project contract {project_contract}; project contract gat
 Output path: `GPD/review/STAGE-physics{round_suffix}.json`
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 - `GPD/review/STAGE-reader{round_suffix}.json`
 - `GPD/review/STAGE-math{round_suffix}.json`
 - `GPD/review/PROOF-REDTEAM{round_suffix}.md` if proof-bearing review is active
 - `GPD/review/STAGE-literature{round_suffix}.json`
-- Summary artifacts matching `GPD/phases/*/*SUMMARY.md`
-- `GPD/phases/*/*-VERIFICATION.md`
+- Summary artifacts matching `GPD/phases/*/*SUMMARY.md` if present
+- `GPD/phases/*/*-VERIFICATION.md` if present
 - `GPD/comparisons/*-COMPARISON.md` if present
 - `${MANUSCRIPT_ROOT}/FIGURE_TRACKER.md` if present
 
@@ -530,7 +556,7 @@ Carry-forward context: project contract {project_contract}; project contract gat
 Output path: `GPD/review/STAGE-interestingness{round_suffix}.json`
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 	- `GPD/review/STAGE-reader{round_suffix}.json`
 	- `GPD/review/STAGE-literature{round_suffix}.json`
@@ -596,7 +622,7 @@ Additive specialized guidance: {protocol_bundle_context}
 Carry-forward context: project contract {project_contract}; project contract gate {project_contract_gate}; project contract load info {project_contract_load_info}; project contract validation {project_contract_validation}; active references {active_reference_context}; derived manuscript reference status {derived_manuscript_reference_status}; contract intake {contract_intake}; effective reference intake {effective_reference_intake}; reference artifacts content {reference_artifacts_content}
 
 Files to read:
-- Resolved manuscript main file and all nearby section .tex files
+- `MANUSCRIPT_STAGE_FILES`
 - `GPD/review/CLAIMS{round_suffix}.json`
 - `GPD/review/STAGE-reader{round_suffix}.json`
 - `GPD/review/STAGE-literature{round_suffix}.json`
@@ -609,12 +635,12 @@ Files to read:
 - `${ARTIFACT_MANIFEST_PATH}` if present
 - `${BIBLIOGRAPHY_AUDIT_PATH}` if present
 - `${REPRODUCIBILITY_MANIFEST_PATH}` if present
-- `GPD/STATE.md`
-- `GPD/ROADMAP.md`
-- Summary artifacts matching `GPD/phases/*/*SUMMARY.md`
-- `GPD/phases/*/*-VERIFICATION.md`
+- `GPD/STATE.md` if present
+- `GPD/ROADMAP.md` if present
+- Summary artifacts matching `GPD/phases/*/*SUMMARY.md` if present
+- `GPD/phases/*/*-VERIFICATION.md` if present
 
-If this is a revision round, also read the latest `REFEREE-REPORT*.md` and matching `AUTHOR-RESPONSE*.md`.
+If this is a revision round, also read the latest `REFEREE-REPORT*.md` and matching `AUTHOR-RESPONSE*.md` when present.
 
 If any required staged-review artifact is missing, malformed, or uses the wrong round suffix, STOP and report that failure instead of falling back to standalone review.
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -5825,10 +5825,12 @@ def test_paper_build_uses_default_config_surface(tmp_path: Path):
         "bibtex_available": True,
         "bibliography_support_available": True,
         "kpsewhich_available": True,
+        "pdftotext_available": True,
         "readiness_state": "ready",
         "message": "pdflatex found (TeX Live): /usr/bin/pdflatex",
         "paper_build_ready": True,
         "arxiv_submission_ready": True,
+        "pdf_review_ready": True,
         "warnings": [],
     }
     assert len(payload["warnings"]) == 1

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -572,8 +572,10 @@ class TestDoctorCheckLatexToolchain:
         assert result.details["latexmk_available"] is True
         assert result.details["bibtex_available"] is True
         assert result.details["kpsewhich_available"] is True
+        assert result.details["pdftotext_available"] is True
         assert result.details["paper_build_ready"] is True
         assert result.details["arxiv_submission_ready"] is True
+        assert result.details["pdf_review_ready"] is True
         assert result.details["missing_components"] == []
         assert result.warnings == []
 
@@ -599,6 +601,7 @@ class TestDoctorCheckLatexToolchain:
         assert result.details["latexmk_available"] is False
         assert result.details["bibtex_available"] is True
         assert result.details["kpsewhich_available"] is False
+        assert result.details["pdftotext_available"] is True
         assert result.details["paper_build_ready"] is True
         assert result.details["arxiv_submission_ready"] is False
         assert result.details["missing_components"] == ["latexmk", "kpsewhich"]
@@ -657,6 +660,7 @@ class TestDoctorCheckLatexToolchain:
         assert result.details["latexmk_available"] is None
         assert result.details["bibtex_available"] is None
         assert result.details["kpsewhich_available"] is None
+        assert result.details["pdftotext_available"] is None
         assert result.details["readiness_state"] == "blocked"
         assert result.details["message"] == "Could not load LaTeX detection helpers."
         assert any("Could not load LaTeX detection helpers" in warning for warning in result.details["warnings"])
@@ -1715,6 +1719,7 @@ trigger:
             return {
                 "pdflatex": "/usr/bin/pdflatex",
                 "bibtex": "/usr/bin/bibtex",
+                "pdftotext": None,
                 "wolframscript": None,
             }.get(binary)
 
@@ -1746,13 +1751,14 @@ trigger:
         assert probe_check.details["enabled"] is True
         assert probe_check.details["timeout_seconds"] == 5
         assert probe_check.details["mandatory_probe"] == "python -m gpd.cli --help"
-        assert probe_check.details["skipped"] == ["latexmk", "kpsewhich", "wolframscript"]
+        assert probe_check.details["skipped"] == ["latexmk", "kpsewhich", "pdftotext", "wolframscript"]
         assert [probe["label"] for probe in probe_check.details["probed"]] == [
             "gpd-cli",
             "pdflatex",
             "bibtex",
             "latexmk",
             "kpsewhich",
+            "pdftotext",
             "wolframscript",
         ]
         assert probe_check.details["probed"][0]["status"] == "ok"
@@ -1761,8 +1767,10 @@ trigger:
         assert probe_check.details["probed"][3]["status"] == "skipped"
         assert probe_check.details["probed"][4]["status"] == "skipped"
         assert probe_check.details["probed"][5]["status"] == "skipped"
+        assert probe_check.details["probed"][6]["status"] == "skipped"
         assert "latexmk not found on PATH" in probe_check.warnings
         assert "kpsewhich not found on PATH" in probe_check.warnings
+        assert "pdftotext not found on PATH" in probe_check.warnings
         assert "wolframscript not found on PATH" in probe_check.warnings
 
     def test_runtime_mode_records_virtualenv_state_without_blocking(self, tmp_path: Path):

--- a/tests/core/test_prompt_wiring.py
+++ b/tests/core/test_prompt_wiring.py
@@ -728,7 +728,7 @@ def test_representative_commands_expose_expected_context_modes() -> None:
     assert registry.get_command("discover").context_mode == "project-aware"
     assert registry.get_command("explain").context_mode == "project-aware"
     assert registry.get_command("suggest-next").context_mode == "projectless"
-    assert registry.get_command("peer-review").context_mode == "project-required"
+    assert registry.get_command("peer-review").context_mode == "project-aware"
 
 
 def test_slides_workflow_references_templates_and_existing_output_policy() -> None:
@@ -2688,12 +2688,13 @@ def test_peer_review_prompt_includes_concise_stage_map_for_users() -> None:
 def test_peer_review_command_limits_default_manuscript_targets_to_canonical_roots() -> None:
     peer_review_command = (COMMANDS_DIR / "peer-review.md").read_text(encoding="utf-8")
 
-    assert "The default manuscript family is limited to `paper/`, `manuscript/`, and `draft/`." in peer_review_command
+    assert "The default in-project manuscript family is limited to `paper/`, `manuscript/`, and `draft/`." in peer_review_command
     assert "then `PAPER-CONFIG.json`, then the canonical current manuscript entrypoint rules" in peer_review_command
+    assert "Explicit external artifact intake may also target `.tex`, `.md`, `.txt`, or `.pdf`." in peer_review_command
     assert "Do not use ad hoc wildcard discovery." in peer_review_command
     assert "find paper manuscript draft" not in peer_review_command
     assert "find . -maxdepth 3" not in peer_review_command
-    assert "pass an explicit manuscript path or paper directory" in peer_review_command
+    assert "ask the user to point at a specific artifact path" in peer_review_command
 
 
 def test_peer_review_referee_surface_fail_closed_stage6_contract() -> None:
@@ -2770,6 +2771,12 @@ def test_publication_prompts_surface_strict_semantic_manuscript_gates() -> None:
     )
     assert (
         "Resolve exactly one active manuscript root from the canonical manuscript family: `paper/`, `manuscript/`, or `draft/`."
+        in shared_preflight
+    )
+    assert "In explicit-artifact mode, allow one `.tex`, `.md`, `.txt`, or `.pdf` review target outside those roots." in shared_preflight
+    assert (
+        "For explicit-artifact mode, nearby `ARTIFACT-MANIFEST.json`, `BIBLIOGRAPHY-AUDIT.json`, and "
+        "`reproducibility-manifest.json` are additive when present rather than blocking prerequisites."
         in shared_preflight
     )
     assert (
@@ -3855,7 +3862,7 @@ def test_publication_workflows_refresh_bibliography_audit_after_bibliography_cha
     assert "references/publication/publication-review-round-artifacts.md" in peer_review_staging.stage(
         "artifact_discovery"
     ).loaded_authorities
-    assert "absent, stale, or not review-ready" in peer_review
+    assert "must be review-ready, not merely present" in peer_review
     assert "bibliography_audit_clean" in peer_review
     assert "reproducibility_ready" in peer_review
     assert (

--- a/tests/core/test_review_workflow_preflight_wiring.py
+++ b/tests/core/test_review_workflow_preflight_wiring.py
@@ -101,7 +101,7 @@ def test_arxiv_submission_workflow_runs_centralized_review_preflight() -> None:
 def test_peer_review_workflow_runs_centralized_review_preflight_with_explicit_arguments() -> None:
     workflow = _workflow_text("peer-review.md")
 
-    assert 'gpd validate review-preflight peer-review "$ARGUMENTS" --strict' in workflow
+    assert 'gpd validate review-preflight peer-review "$REVIEW_TARGET" --strict' in workflow
     assert "gpd validate review-preflight peer-review --strict" not in workflow
     assert "If any spawned reviewer or proof auditor needs user input, it must return `status: checkpoint` and stop." in workflow
     assert "Do not keep the same spawned run alive waiting for confirmation." in workflow

--- a/tests/core/test_runtime_hints.py
+++ b/tests/core/test_runtime_hints.py
@@ -295,6 +295,7 @@ def test_build_runtime_hint_payload_merges_source_sections_and_actions(tmp_path:
     assert payload.source_meta["latex_capability"]["bibtex_available"] is True
     assert payload.source_meta["latex_capability"]["latexmk_available"] is False
     assert payload.source_meta["latex_capability"]["kpsewhich_available"] is False
+    assert payload.source_meta["latex_capability"]["pdftotext_available"] is True
     assert payload.source_meta["latex_capability"]["readiness_state"] == "ready"
     assert payload.source_meta["latex_capability"]["message"] == "pdflatex found (TeX Live): /usr/bin/pdflatex"
     assert "latex_available" not in payload.source_meta

--- a/tests/core/test_workflow_contract_visibility_regressions.py
+++ b/tests/core/test_workflow_contract_visibility_regressions.py
@@ -86,7 +86,7 @@ def test_peer_review_reliability_reference_matches_peer_review_workflow_invocati
         REPO_ROOT / "src/gpd/specs/references/publication/peer-review-reliability.md"
     ).read_text(encoding="utf-8")
 
-    expected = 'gpd validate review-preflight peer-review "$ARGUMENTS" --strict'
+    expected = 'gpd validate review-preflight peer-review "$REVIEW_TARGET" --strict'
 
     assert expected in workflow
     assert expected in reliability

--- a/tests/core/test_workflow_presets.py
+++ b/tests/core/test_workflow_presets.py
@@ -240,6 +240,29 @@ def test_workflow_preset_readiness_degrades_publication_family_when_bibtex_is_mi
     assert any("BibTeX support is missing" in warning for warning in publication["warnings"])
 
 
+def test_workflow_preset_readiness_degrades_peer_review_pdf_intake_when_pdftotext_is_missing() -> None:
+    readiness = resolve_workflow_preset_readiness(
+        base_ready=True,
+        latex_capability=_latex_capability(pdftotext_available=False),
+    )
+    statuses = {preset["id"]: preset["status"] for preset in readiness["presets"]}
+    publication = next(preset for preset in readiness["presets"] if preset["id"] == "publication-manuscript")
+
+    assert readiness["ready"] == 3
+    assert readiness["degraded"] == 2
+    assert readiness["blocked"] == 0
+    assert readiness["latex_capability"]["paper_build_ready"] is True
+    assert readiness["latex_capability"]["arxiv_submission_ready"] is True
+    assert readiness["latex_capability"]["pdf_review_ready"] is False
+    assert readiness["latex_capability"]["full_toolchain_available"] is False
+    assert statuses["publication-manuscript"] == "degraded"
+    assert statuses["full-research"] == "degraded"
+    assert publication["ready_workflows"] == ["write-paper", "paper-build", "arxiv-submission"]
+    assert publication["degraded_workflows"] == ["peer-review"]
+    assert publication["blocked_workflows"] == []
+    assert any("pdftotext is missing" in warning for warning in publication["warnings"])
+
+
 def test_workflow_preset_readiness_does_not_backfill_legacy_paper_build_flag_to_ready() -> None:
     readiness = resolve_workflow_preset_readiness(base_ready=True, latex_capability={"paper_build_ready": True})
     publication = next(preset for preset in readiness["presets"] if preset["id"] == "publication-manuscript")

--- a/tests/latex_test_support.py
+++ b/tests/latex_test_support.py
@@ -12,6 +12,7 @@ def latex_capability_payload(**overrides: object) -> dict[str, object]:
         "bibtex_available": True,
         "latexmk_available": True,
         "kpsewhich_available": True,
+        "pdftotext_available": True,
         "readiness_state": "ready",
         "message": "pdflatex found (TeX Live): /usr/bin/pdflatex",
         "warnings": [],
@@ -27,7 +28,10 @@ def latex_capability_payload(**overrides: object) -> dict[str, object]:
             and bool(capability.get("bibtex_available"))
             and bool(capability.get("latexmk_available"))
             and bool(capability.get("kpsewhich_available"))
+            and bool(capability.get("pdftotext_available"))
         )
+    if "pdf_review_ready" not in capability:
+        capability["pdf_review_ready"] = bool(capability.get("pdftotext_available"))
     return capability
 
 

--- a/tests/mcp/test_servers_integration.py
+++ b/tests/mcp/test_servers_integration.py
@@ -544,7 +544,7 @@ class TestSkillsServerIntegration:
                 "stage_artifacts": ["GPD/review/PROOF-REDTEAM{round_suffix}.md"],
             }
         ]
-        assert result["context_mode"] == "project-required"
+        assert result["context_mode"] == "project-aware"
         assert result["project_reentry_capable"] is False
         assert "## Review Contract" in result["content"]
         assert "review_contract:" in result["content"]

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -18,6 +18,7 @@ import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from typer.testing import CliRunner
@@ -1472,7 +1473,7 @@ class TestReviewValidationCommands:
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert payload["command"] == "gpd:peer-review"
-        assert payload["context_mode"] == "project-required"
+        assert payload["context_mode"] == "project-aware"
         assert payload["review_contract"]["review_mode"] == "publication"
         assert "GPD/REFEREE-REPORT{round_suffix}.md" in payload["review_contract"]["required_outputs"]
         assert "GPD/REFEREE-REPORT{round_suffix}.tex" in payload["review_contract"]["required_outputs"]
@@ -3453,7 +3454,7 @@ class TestReviewValidationCommands:
         assert "artifact manifest is invalid" in checks["artifact_manifest"]["detail"]
         assert "artifact_manifest.paper_title" in checks["artifact_manifest"]["detail"]
 
-    def test_review_preflight_peer_review_rejects_explicit_manuscript_path_outside_supported_roots(
+    def test_review_preflight_peer_review_accepts_explicit_manuscript_path_outside_supported_roots(
         self,
         gpd_project: Path,
     ) -> None:
@@ -3487,15 +3488,16 @@ class TestReviewValidationCommands:
             catch_exceptions=False,
         )
 
-        assert result.exit_code == 1, result.output
+        assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         assert payload["command"] == "gpd:peer-review"
-        assert payload["passed"] is False
+        assert payload["passed"] is True
         checks = {check["name"]: check for check in payload["checks"]}
-        assert checks["manuscript"]["passed"] is False
-        assert checks["manuscript"]["detail"] == (
-            "explicit manuscript target must stay under `paper/`, `manuscript/`, or `draft/` inside the current project"
-        )
+        assert checks["manuscript"]["passed"] is True
+        assert checks["manuscript"]["detail"] == f"./submission/{_CANONICAL_MANUSCRIPT_BASENAME} present"
+        assert checks["artifact_manifest"]["detail"] == "./submission/ARTIFACT-MANIFEST.json present"
+        assert checks["bibliography_audit"]["detail"] == "./submission/BIBLIOGRAPHY-AUDIT.json present"
+        assert checks["reproducibility_manifest"]["detail"] == "./submission/reproducibility-manifest.json present"
 
     def test_review_preflight_peer_review_strict_does_not_fall_back_to_gpd_paper_for_explicit_manuscript(
         self,
@@ -3521,12 +3523,19 @@ class TestReviewValidationCommands:
             catch_exceptions=False,
         )
 
-        assert result.exit_code == 1, result.output
+        assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
+        assert payload["passed"] is True
         checks = {check["name"]: check for check in payload["checks"]}
-        assert checks["manuscript"]["passed"] is False
-        assert checks["manuscript"]["detail"] == (
-            "explicit manuscript target must stay under `paper/`, `manuscript/`, or `draft/` inside the current project"
+        assert checks["manuscript"]["passed"] is True
+        assert checks["artifact_manifest"]["detail"] == (
+            "no ARTIFACT-MANIFEST.json found near the manuscript; external artifact review can proceed without it"
+        )
+        assert checks["bibliography_audit"]["detail"] == (
+            "no BIBLIOGRAPHY-AUDIT.json found near the manuscript; external artifact review can proceed without it"
+        )
+        assert checks["reproducibility_manifest"]["detail"] == (
+            "no reproducibility manifest found near the manuscript; external artifact review can proceed without it"
         )
 
     def test_review_preflight_peer_review_accepts_explicit_manuscript_directory(self, gpd_project: Path) -> None:
@@ -4248,11 +4257,11 @@ class TestReviewValidationCommands:
         assert result.exit_code == 0, result.output
         payload = json.loads(result.output)
         checks = {check["name"]: check for check in payload["checks"]}
-        assert checks["manuscript"]["passed"] is True
-        assert checks["required_files"]["passed"] is True
-        assert "../paper/" not in checks["manuscript"]["detail"]
+        assert payload["passed"] is True
+        assert checks["project_exists"]["passed"] is True
+        assert checks["explicit_inputs"]["passed"] is True
 
-    def test_command_context_peer_review_rejects_explicit_manuscript_outside_supported_roots(
+    def test_command_context_peer_review_accepts_explicit_manuscript_outside_supported_roots(
         self,
         gpd_project: Path,
     ) -> None:
@@ -4275,13 +4284,118 @@ class TestReviewValidationCommands:
             catch_exceptions=False,
         )
 
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is True
+        assert checks["project_exists"]["passed"] is True
+        assert checks["explicit_inputs"]["passed"] is True
+
+    def test_command_context_peer_review_without_arguments_allows_interactive_intake(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        workspace = tmp_path / "standalone-review"
+        workspace.mkdir()
+
+        result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(workspace), "validate", "command-context", "peer-review"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is True
+        assert checks["project_exists"]["blocking"] is False
+        assert checks["explicit_inputs"]["passed"] is True
+        assert checks["explicit_inputs"]["detail"] == (
+            "no explicit review target supplied; interactive intake can prompt for a specific artifact path "
+            "or use the current GPD project when available"
+        )
+
+    def test_review_preflight_peer_review_accepts_external_txt_artifact(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "standalone-review"
+        workspace.mkdir()
+        artifact = workspace / "notes.txt"
+        artifact.write_text("Standalone manuscript notes.\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(workspace), "validate", "review-preflight", "peer-review", "notes.txt", "--strict"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is True
+        assert checks["project_state"]["blocking"] is False
+        assert checks["manuscript"]["passed"] is True
+        assert checks["manuscript"]["detail"] == "./notes.txt present"
+
+    def test_review_preflight_peer_review_accepts_external_pdf_artifact_with_companion_text(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "standalone-review"
+        workspace.mkdir()
+        artifact = workspace / "draft.pdf"
+        artifact.write_bytes(b"%PDF-1.4\n% standalone draft\n")
+        (workspace / "draft.txt").write_text("Extracted PDF text.\n", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(workspace), "validate", "review-preflight", "peer-review", "draft.pdf", "--strict"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is True
+        assert checks["manuscript"]["passed"] is True
+        assert checks["manuscript"]["detail"] == "./draft.pdf present; PDF intake can use companion text file ./draft.txt"
+
+    def test_review_preflight_peer_review_rejects_external_pdf_without_text_support(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "standalone-review"
+        workspace.mkdir()
+        artifact = workspace / "draft.pdf"
+        artifact.write_bytes(b"%PDF-1.4\n% standalone draft\n")
+
+        with patch("gpd.mcp.paper.compiler.find_latex_compiler", return_value=None):
+            result = runner.invoke(
+                app,
+                ["--raw", "--cwd", str(workspace), "validate", "review-preflight", "peer-review", "draft.pdf", "--strict"],
+                catch_exceptions=False,
+            )
+
         assert result.exit_code == 1, result.output
         payload = json.loads(result.output)
         checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is False
         assert checks["manuscript"]["passed"] is False
         assert checks["manuscript"]["detail"] == (
-            "explicit manuscript target must stay under `paper/`, `manuscript/`, or `draft/` inside the current project"
+            "PDF review target requires `pdftotext` on PATH or a same-directory `.txt` companion file"
         )
+
+    def test_review_preflight_peer_review_accepts_external_pdf_with_pdftotext(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "standalone-review"
+        workspace.mkdir()
+        artifact = workspace / "draft.pdf"
+        artifact.write_bytes(b"%PDF-1.4\n% standalone draft\n")
+
+        with patch("gpd.mcp.paper.compiler.find_latex_compiler", return_value="/usr/bin/pdftotext"):
+            result = runner.invoke(
+                app,
+                ["--raw", "--cwd", str(workspace), "validate", "review-preflight", "peer-review", "draft.pdf", "--strict"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        checks = {check["name"]: check for check in payload["checks"]}
+        assert payload["passed"] is True
+        assert checks["manuscript"]["passed"] is True
+        assert checks["manuscript"]["detail"] == "./draft.pdf present; pdftotext available at /usr/bin/pdftotext for PDF review intake"
 
     def test_review_preflight_arxiv_submission_strict_does_not_fall_back_to_legacy_gpd_paper_artifacts(
         self,

--- a/tests/test_latex_detection.py
+++ b/tests/test_latex_detection.py
@@ -91,6 +91,7 @@ class TestDetectLatexToolchain:
                 "bibtex": "/usr/bin/bibtex",
                 "latexmk": "/usr/bin/latexmk",
                 "kpsewhich": "/usr/bin/kpsewhich",
+                "pdftotext": "/usr/bin/pdftotext",
             }
             return mapping.get(binary)
 
@@ -104,9 +105,11 @@ class TestDetectLatexToolchain:
         assert status.bibliography_support_available is True
         assert status.latexmk_available is True
         assert status.kpsewhich_available is True
+        assert status.pdftotext_available is True
         assert status.readiness_state == "ready"
         assert status.paper_build_ready is True
         assert status.arxiv_submission_ready is True
+        assert status.pdf_review_ready is True
         assert "readiness=ready" in status.message
 
     def test_degrades_when_bibtex_is_missing_but_compiler_is_present(
@@ -132,12 +135,15 @@ class TestDetectLatexToolchain:
         assert status.bibliography_support_available is False
         assert status.latexmk_available is False
         assert status.kpsewhich_available is False
+        assert status.pdftotext_available is False
         assert status.readiness_state == "degraded"
         assert status.paper_build_ready is True
         assert status.arxiv_submission_ready is False
+        assert status.pdf_review_ready is False
         assert "BibTeX missing" in status.message
         assert status.warnings
         assert any("citation-bearing builds" in warning for warning in status.warnings)
+        assert any("pdftotext not found" in warning for warning in status.warnings)
 
 
 class TestPaperToolchainCapability:
@@ -174,6 +180,7 @@ class TestPaperToolchainCapability:
                 "bibtex": "/usr/bin/bibtex",
                 "latexmk": "/usr/bin/latexmk",
                 "kpsewhich": "/usr/bin/kpsewhich",
+                "pdftotext": "/usr/bin/pdftotext",
             }
             return mapping.get(binary)
 
@@ -188,9 +195,11 @@ class TestPaperToolchainCapability:
         assert status.bibliography_support_available is False
         assert status.latexmk_available is True
         assert status.kpsewhich_available is True
+        assert status.pdftotext_available is True
         assert status.readiness_state == "blocked"
         assert status.paper_build_ready is False
         assert status.arxiv_submission_ready is False
+        assert status.pdf_review_ready is True
         assert "No LaTeX compiler found" in status.message
 
     def test_detects_miktex_distribution(self, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What changed
- make GPD's relaxed command path coherent around typed subject/context/output policy instead of one-off command-name exceptions
- broaden `gpd:peer-review` to support explicit external manuscript artifacts, including `.txt` and `.pdf` intake with `pdftotext` readiness checks
- align artifact-first/current-workspace analysis commands so they keep GPD-authored durable outputs under `GPD/` while staying fail-closed about authoritative project lineage
- unify publication substrate handling around `GPD/publication/{subject_slug}/...` for managed publication lanes and external-subject continuation
- add a bounded external-authoring lane to `gpd:write-paper` via explicit `--intake path/to/paper-authoring-input.json`
- refresh prompt surfaces, workflow docs, contracts, graph inventory, and regression tests to match the final behavior

## Why
GPD had drifted into an inconsistent state where some commands claimed to be project-aware but still walked into ancestor projects or blocked on missing GPD state even when the user had supplied an explicit artifact. Publication and manuscript flows were especially inconsistent: `peer-review` was too strict, `write-paper` could not materialize a bounded external-authoring lane, and the docs/tests no longer matched the real behavior.

## Impact
GPD now works more cleanly in both modes it needs to support:
- full end-to-end GPD project workflows
- artifact-first / workspace-first use on explicit user research artifacts

Users can review externally produced manuscripts, use current-workspace analysis commands without accidental recent/ancestor-project capture, and materialize bounded GPD-managed publication state under `GPD/publication/{subject_slug}/...` while keeping all GPD-authored durable outputs under `GPD/`.

## Root cause
The repo had accumulated project-only assumptions in CLI preflight logic, publication/runtime path handling, and command/workflow/test surfaces. Root-resolution policy, review-contract scope semantics, and storage/output rules were not being enforced consistently across commands, which left the public contract and the actual runtime behavior out of sync.

## Validation
- `uv run pytest` -> `7908 passed, 5 skipped`
- `uv run ruff check src/gpd/cli.py src/gpd/commands/write-paper.md tests/test_cli_commands.py tests/core/test_prompt_wiring.py tests/core/test_review_contract_prompt_visibility.py tests/core/test_write_paper_prompt_budget.py tests/mcp/test_servers_integration.py`
