### PR TITLE
Fix peer-review proof-review messaging and model introspection

### DIFF
--- a/src/gpd/cli.py
+++ b/src/gpd/cli.py
@@ -210,6 +210,16 @@ def _output(data: object) -> None:
             console.print(str(data), highlight=False)
 
 
+def _stdout_is_interactive() -> bool:
+    stream = getattr(sys, "stdout", None)
+    if stream is None:
+        return False
+    try:
+        return bool(stream.isatty())
+    except Exception:
+        return False
+
+
 def _pretty_print(d: dict) -> None:
     """Render a dict as a rich table."""
     table = Table(show_header=True, header_style=f"bold {_INSTALL_ACCENT_COLOR}")
@@ -8787,13 +8797,21 @@ def resolve_model_cmd(
         "--runtime",
         help=_runtime_override_help(),
     ),
+    explain: bool = typer.Option(
+        False,
+        "--explain",
+        help="Explain the resolved tier/runtime and why the command may print nothing.",
+    ),
 ) -> None:
     """Resolve the runtime-specific model override for an agent.
 
     Prints nothing when no override is configured so callers can omit the
-    runtime model parameter and let the platform use its default model.
+    runtime model parameter and let the platform use its default model. Use
+    --explain for a human-readable explanation without changing shell-safe
+    default stdout behavior.
     """
-    from gpd.core.config import resolve_model, validate_agent_name
+    from gpd.core.config import resolve_model, resolve_tier, validate_agent_name
+    from gpd.core.context import _detect_platform as detect_context_runtime
     from gpd.core.context import _resolve_model as resolve_context_model
 
     supported_runtimes = _supported_runtime_names()
@@ -8814,6 +8832,44 @@ def resolve_model_cmd(
             if runtime is not None
             else resolve_context_model(_get_cwd(), agent_name)
         )
+        if explain:
+            effective_runtime = runtime if runtime is not None else normalize_runtime_name(detect_context_runtime(_get_cwd()))
+            tier = resolve_tier(_get_cwd(), agent_name).value
+            if resolved_model is not None:
+                detail = (
+                    f"Resolved explicit model override for runtime {effective_runtime!r} at {tier}; "
+                    f"the command emits {resolved_model!r}."
+                )
+            elif effective_runtime is None:
+                detail = (
+                    "No active runtime could be resolved, so no runtime-specific override can be selected. "
+                    "Omit the model parameter and let the platform use its default model."
+                )
+            else:
+                detail = (
+                    f"No explicit model override is configured for runtime {effective_runtime!r} at {tier}. "
+                    "The command stays silent by default so shell wrappers can omit the model parameter "
+                    "and use the platform default."
+                )
+            _output(
+                {
+                    "agent_name": agent_name,
+                    "tier": tier,
+                    "runtime": effective_runtime,
+                    "runtime_source": "explicit" if runtime is not None else "detected",
+                    "resolved_model": resolved_model,
+                    "override_configured": resolved_model is not None,
+                    "uses_runtime_default": resolved_model is None,
+                    "detail": detail,
+                }
+            )
+            return
+        if resolved_model is None and _stdout_is_interactive():
+            console.print(
+                "[dim]No explicit model override is configured. Use `gpd resolve-model "
+                f"{agent_name} --explain` for details.[/dim]"
+            )
+            return
         _output(resolved_model)
     except ConfigError as exc:
         _error(str(exc))

--- a/src/gpd/core/proof_review.py
+++ b/src/gpd/core/proof_review.py
@@ -692,6 +692,7 @@ def _latest_matching_math_review_anchor(project_root: Path, manuscript_entrypoin
                     artifact_path=path,
                     claim_index=claim_index,
                     expected_manuscript_path=expected_manuscript_path,
+                    expected_manuscript_label="active manuscript",
                 )
             )
             if theorem_claim_ids:

--- a/src/gpd/core/referee_policy.py
+++ b/src/gpd/core/referee_policy.py
@@ -201,6 +201,7 @@ def validate_stage_review_artifact_alignment(
     artifact_path: Path,
     claim_index: ClaimIndex | None,
     expected_manuscript_path: str | None = None,
+    expected_manuscript_label: str = "expected manuscript",
     expected_manuscript_sha256: str | None = None,
     require_claim_index_error: bool = True,
 ) -> list[str]:
@@ -228,7 +229,7 @@ def validate_stage_review_artifact_alignment(
     if expected_manuscript_path and normalize_review_path_label(
         stage_report.manuscript_path
     ) != normalize_review_path_label(expected_manuscript_path):
-        errors.append(f"{artifact_path.name} manuscript_path does not match the referee decision manuscript_path")
+        errors.append(f"{artifact_path.name} manuscript_path does not match the {expected_manuscript_label}")
     if expected_manuscript_sha256 and stage_report.manuscript_sha256 != expected_manuscript_sha256:
         errors.append(f"{artifact_path.name} manuscript_sha256 does not match the active manuscript snapshot")
 
@@ -521,6 +522,7 @@ def _strict_stage_artifact_consistency_errors(
             validate_stage_review_artifact_file(
                 artifact_path,
                 expected_manuscript_path=expected_manuscript_path,
+                expected_manuscript_label="referee decision manuscript_path",
                 expected_manuscript_sha256=expected_manuscript_sha256,
             )
         )
@@ -635,6 +637,7 @@ def validate_stage_review_artifact_file(
     artifact_path: Path,
     *,
     expected_manuscript_path: str | None = None,
+    expected_manuscript_label: str = "expected manuscript",
     expected_manuscript_sha256: str | None = None,
 ) -> list[str]:
     """Return semantic validation errors for a stage-review file."""
@@ -654,6 +657,7 @@ def validate_stage_review_artifact_file(
         stage_report,
         artifact_path=artifact_path,
         expected_manuscript_path=expected_manuscript_path,
+        expected_manuscript_label=expected_manuscript_label,
         expected_manuscript_sha256=expected_manuscript_sha256,
     )
 
@@ -663,6 +667,7 @@ def validate_stage_review_artifact_payload(
     *,
     artifact_path: Path,
     expected_manuscript_path: str | None = None,
+    expected_manuscript_label: str = "expected manuscript",
     expected_manuscript_sha256: str | None = None,
 ) -> list[str]:
     """Return semantic validation errors for one typed stage-review artifact."""
@@ -687,6 +692,7 @@ def validate_stage_review_artifact_payload(
             artifact_path=artifact_path,
             claim_index=claim_index,
             expected_manuscript_path=expected_manuscript_path,
+            expected_manuscript_label=expected_manuscript_label,
             expected_manuscript_sha256=expected_manuscript_sha256,
             require_claim_index_error=not claim_index_errors,
         )

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -2707,6 +2707,7 @@ def test_validate_plan_preflight_blocks_on_missing_knowledge_dependency(
 def test_resolve_model_help_lists_supported_runtime_ids():
     result = runner.invoke(app, ["resolve-model", "--help"])
     assert result.exit_code == 0
+    assert "--explain" in result.output
     for runtime_name in list_runtimes():
         assert runtime_name in result.output
 

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -2707,9 +2707,10 @@ def test_validate_plan_preflight_blocks_on_missing_knowledge_dependency(
 def test_resolve_model_help_lists_supported_runtime_ids():
     result = runner.invoke(app, ["resolve-model", "--help"])
     assert result.exit_code == 0
-    assert "--explain" in result.output
+    normalized_output = _normalize_cli_output(result.output)
+    assert "--explain" in normalized_output
     for runtime_name in list_runtimes():
-        assert runtime_name in result.output
+        assert runtime_name in normalized_output
 
 
 def test_state_help():

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -2457,6 +2457,32 @@ class TestReviewValidationCommands:
         assert payload["resolved_review_root"] == str(gpd_project)
         assert payload["staged_loading"]["stage_id"] == "bootstrap"
 
+    def test_init_peer_review_proof_review_detail_uses_active_manuscript_wording_without_final_review_artifacts(
+        self,
+        gpd_project: Path,
+    ) -> None:
+        package = write_proof_review_package(gpd_project, theorem_bearing=True, review_report=False)
+        review_dir = gpd_project / "GPD" / "review"
+        (review_dir / "REVIEW-LEDGER.json").unlink()
+        (review_dir / "REFEREE-DECISION.json").unlink()
+        math_stage_path = review_dir / "STAGE-math.json"
+        math_stage_payload = json.loads(math_stage_path.read_text(encoding="utf-8"))
+        math_stage_payload["manuscript_path"] = "paper/other.tex"
+        math_stage_path.write_text(json.dumps(math_stage_payload), encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["--raw", "--cwd", str(gpd_project), "init", "peer-review", str(package.manuscript_path)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        detail = payload["derived_manuscript_proof_review_status"]["detail"]
+        assert payload["latest_review_artifacts"] is None
+        assert "active manuscript" in detail
+        assert "referee decision manuscript_path" not in detail
+
     def test_review_preflight_peer_review_project_backed_mode_surfaces_effective_contract_fields(
         self,
         gpd_project: Path,
@@ -6776,6 +6802,59 @@ def test_cli_uninstall_and_resolution_paths(monkeypatch: pytest.MonkeyPatch, gpd
         )
         is True
     )
+
+
+def test_resolve_model_explain_surfaces_runtime_default_reason(
+    monkeypatch: pytest.MonkeyPatch,
+    gpd_project: Path,
+) -> None:
+    import gpd.core.config as config_module
+    import gpd.core.context as context_module
+
+    monkeypatch.setattr(config_module, "validate_agent_name", lambda agent_name: None)
+    monkeypatch.setattr(config_module, "resolve_tier", lambda cwd, agent_name: config_module.ModelTier.TIER_1)
+    monkeypatch.setattr(context_module, "_resolve_model", lambda cwd, agent_name: None)
+    monkeypatch.setattr(context_module, "_detect_platform", lambda cwd=None: _PRIMARY_RAW_RUNTIME_DESCRIPTOR.runtime_name)
+
+    result = runner.invoke(
+        app,
+        ["--raw", "--cwd", str(gpd_project), "resolve-model", "gpd-referee", "--explain"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["agent_name"] == "gpd-referee"
+    assert payload["tier"] == "tier-1"
+    assert payload["runtime"] == _PRIMARY_RAW_RUNTIME_DESCRIPTOR.runtime_name
+    assert payload["runtime_source"] == "detected"
+    assert payload["resolved_model"] is None
+    assert payload["override_configured"] is False
+    assert payload["uses_runtime_default"] is True
+    assert "No explicit model override is configured" in payload["detail"]
+
+
+def test_resolve_model_keeps_blank_stdout_by_default_when_no_override(
+    monkeypatch: pytest.MonkeyPatch,
+    gpd_project: Path,
+) -> None:
+    import gpd.cli as cli_module
+    import gpd.core.config as config_module
+    import gpd.core.context as context_module
+
+    monkeypatch.setattr(cli_module, "_stdout_is_interactive", lambda: False)
+    monkeypatch.setattr(config_module, "validate_agent_name", lambda agent_name: None)
+    monkeypatch.setattr(context_module, "_resolve_model", lambda cwd, agent_name: None)
+    monkeypatch.setattr(context_module, "_detect_platform", lambda cwd=None: _PRIMARY_RAW_RUNTIME_DESCRIPTOR.runtime_name)
+
+    result = runner.invoke(
+        app,
+        ["--cwd", str(gpd_project), "resolve-model", "gpd-referee"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert result.output == ""
 
 
 def test_init_new_project_help_surfaces_stage_option() -> None:


### PR DESCRIPTION
## Summary
- fix misleading manuscript proof-review status text so standalone `init peer-review` no longer mentions a referee decision when only `STAGE-math` alignment is being checked
- add `gpd resolve-model --explain` so blank stdout can be diagnosed without breaking the shell-safe default behavior
- add CLI regressions for both cases and keep default non-interactive `resolve-model` output blank when no override is configured

## Root cause
- the shared stage-review alignment helper hard-coded referee-decision wording and that leaked into manuscript proof-review freshness checks
- `resolve-model` intentionally returned blank output when no runtime override existed, but there was no human-readable introspection path

## Testing
- `uv run pytest -q`
