### PR TITLE
Require concrete GPD next-up guidance

### DIFF
--- a/src/gpd/agents/gpd-bibliographer.md
+++ b/src/gpd/agents/gpd-bibliographer.md
@@ -117,7 +117,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [references/references.bib, GPD/references-status.json]
   issues: [list of citation problems, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   entries_added: N
 ```
 

--- a/src/gpd/agents/gpd-consistency-checker.md
+++ b/src/gpd/agents/gpd-consistency-checker.md
@@ -50,7 +50,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/phases/{scope}/CONSISTENCY-CHECK.md]
   issues: [list of issues, including warnings]
-  next_actions: [recommended follow-up]
+  next_actions: [concrete commands such as "gpd:validate-conventions", "gpd:resume-work", or "gpd:suggest-next"]
   phase_checked: [phase or milestone scope]
   checks_performed: [count]
   issues_found: [count]

--- a/src/gpd/agents/gpd-debugger.md
+++ b/src/gpd/agents/gpd-debugger.md
@@ -145,7 +145,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/debug/{slug}.md, ...]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   session_file: GPD/debug/{slug}.md
 ```
 

--- a/src/gpd/agents/gpd-executor.md
+++ b/src/gpd/agents/gpd-executor.md
@@ -1076,7 +1076,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [list of file paths created or modified]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands such as "gpd:execute-phase {phase}", "gpd:verify-work {phase}", "gpd:resume-work", or "gpd:suggest-next"]
   phase: "{phase}"
   plan: "{plan}"
   tasks_completed: N

--- a/src/gpd/agents/gpd-experiment-designer.md
+++ b/src/gpd/agents/gpd-experiment-designer.md
@@ -976,7 +976,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [path to EXPERIMENT-DESIGN.md]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   design_file: [path to EXPERIMENT-DESIGN.md]
 ```
 

--- a/src/gpd/agents/gpd-literature-reviewer.md
+++ b/src/gpd/agents/gpd-literature-reviewer.md
@@ -335,7 +335,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/literature/{slug}-REVIEW.md]
   issues: [most important unresolved issues or empty list]
-  next_actions: [recommended follow-up actions or reading path]
+  next_actions: [concrete commands or exact reading/review path]
   papers_reviewed: {count}
   field_assessment: settled | active_research | active_debate | speculative
 ```
@@ -370,7 +370,7 @@ gpd_return:
   status: checkpoint
   files_written: [GPD/literature/{slug}-REVIEW.md]
   issues: [checkpoint question or ambiguity]
-  next_actions: [resume after user response]
+  next_actions: ["gpd:resume-work" or exact user-response handoff action]
   papers_reviewed: {count}
   field_assessment: settled | active_research | active_debate | speculative
 ```

--- a/src/gpd/agents/gpd-notation-coordinator.md
+++ b/src/gpd/agents/gpd-notation-coordinator.md
@@ -693,7 +693,7 @@ gpd_return:
   # Mapping: established → completed, updated → completed, conflict → failed
   files_written: [GPD/CONVENTIONS.md, ...]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands such as "gpd:validate-conventions", "gpd:resume-work", "gpd convention set <key> <value>", or "gpd:suggest-next"]
   conventions_file: GPD/CONVENTIONS.md
 ```
 

--- a/src/gpd/agents/gpd-paper-writer.md
+++ b/src/gpd/agents/gpd-paper-writer.md
@@ -1023,7 +1023,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [{resolved_manuscript_root}/{section_file}.tex]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   section_name: "{section drafted}"
   equations_added: N
   figures_added: N

--- a/src/gpd/agents/gpd-phase-researcher.md
+++ b/src/gpd/agents/gpd-phase-researcher.md
@@ -531,7 +531,7 @@ gpd_return:
   # Headings above are presentation only; route on gpd_return.status.
   files_written: [$PHASE_DIR/$PADDED_PHASE-RESEARCH.md]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   confidence: HIGH | MEDIUM | LOW
 ```
 

--- a/src/gpd/agents/gpd-plan-checker.md
+++ b/src/gpd/agents/gpd-plan-checker.md
@@ -1421,7 +1421,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: []
   issues: [issue objects from Issue Format above]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   approved_plans: [list of plan IDs that passed]
   blocked_plans: [list of plan IDs needing revision or escalation]
   dimensions_checked: [list of dimensions evaluated]

--- a/src/gpd/agents/gpd-project-researcher.md
+++ b/src/gpd/agents/gpd-project-researcher.md
@@ -690,7 +690,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/literature/SUMMARY.md, GPD/literature/METHODS.md, ...]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   confidence: HIGH | MEDIUM | LOW
 ```
 

--- a/src/gpd/agents/gpd-referee.md
+++ b/src/gpd/agents/gpd-referee.md
@@ -1059,7 +1059,7 @@ gpd_return:
     - GPD/review/REVIEW-LEDGER{round_suffix}.json
     - GPD/CONSISTENCY-REPORT.md  # only when applicable
   issues: [list of blocking or unresolved review issues, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   recommendation: "{accept | minor_revision | major_revision | reject}"
   confidence: "{high | medium | low}"
   major_issues: N

--- a/src/gpd/agents/gpd-research-mapper.md
+++ b/src/gpd/agents/gpd-research-mapper.md
@@ -753,7 +753,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/research-map/{focus}.md, ...]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   focus: "theory | computation | methodology | status"
 ```
 

--- a/src/gpd/agents/gpd-research-synthesizer.md
+++ b/src/gpd/agents/gpd-research-synthesizer.md
@@ -1056,7 +1056,7 @@ gpd_return:
   # Mapping: SYNTHESIS COMPLETE → completed, SYNTHESIS BLOCKED → blocked
   files_written: [GPD/literature/SUMMARY.md]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
 ```
 
 </structured_returns>

--- a/src/gpd/agents/gpd-roadmapper.md
+++ b/src/gpd/agents/gpd-roadmapper.md
@@ -878,7 +878,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [ROADMAP.md, STATE.md]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   phases_created: {count}
 ```
 

--- a/src/gpd/agents/gpd-verifier.md
+++ b/src/gpd/agents/gpd-verifier.md
@@ -510,7 +510,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [list only files that actually landed on disk; use [] when no file was written]
   issues: [list of gaps or issues found, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands such as "gpd:plan-phase {phase} --gaps", "gpd:verify-work {phase}", "gpd:show-phase {phase}", or "gpd:suggest-next"]
   verification_status: passed | gaps_found | expert_needed | human_needed
   score: "{N}/{M}"
   confidence: HIGH | MEDIUM | LOW | UNRELIABLE

--- a/src/gpd/commands/new-milestone.md
+++ b/src/gpd/commands/new-milestone.md
@@ -25,7 +25,7 @@ Continuation equivalent of new-project. Research project exists, PROJECT.md has 
 - `GPD/ROADMAP.md` — phase structure (continues numbering)
 - `GPD/STATE.md` — reset for new milestone
 
-**After:** `gpd:plan-phase [N]` to start execution.
+**After:** `gpd:discuss-phase [N]` to clarify the first new phase before planning. Use `gpd:plan-phase [N]` only when the phase context is already clear.
 </objective>
 
 <execution_context>

--- a/src/gpd/commands/respond-to-referees.md
+++ b/src/gpd/commands/respond-to-referees.md
@@ -1,10 +1,10 @@
 ---
 name: gpd:respond-to-referees
-description: Structure a point-by-point response to referee reports for the current GPD manuscript or an explicit manuscript target
-argument-hint: "[path to referee report or 'paste']"
+description: Structure a point-by-point response to referee reports for an explicit manuscript target or the current GPD manuscript
+argument-hint: "[--manuscript PATH] (--report PATH [--report PATH...] | paste)"
 context_mode: project-aware
 requires:
-  files: ["paper/*.tex", "paper/*.md", "manuscript/*.tex", "manuscript/*.md", "draft/*.tex", "draft/*.md"]
+  files: ["paper/*.tex", "paper/*.md", "manuscript/*.tex", "manuscript/*.md", "draft/*.tex", "draft/*.md", "GPD/publication/*/manuscript/*.tex", "GPD/publication/*/manuscript/*.md"]
 command-policy:
   schema_version: 1
   subject_policy:

--- a/src/gpd/contracts.py
+++ b/src/gpd/contracts.py
@@ -2477,6 +2477,28 @@ def _has_contract_grounding_context(
     )
 
 
+def _split_missing_must_surface_anchor_findings(
+    contract: ResearchContract,
+    *,
+    project_root: Path | None = None,
+    mode: Literal["draft", "approved"] = "draft",
+) -> tuple[list[str], list[str]]:
+    """Return errors and warnings for contracts that lack a must-surface reference anchor."""
+
+    if not contract.references or any(reference.must_surface for reference in contract.references):
+        return [], []
+
+    finding = "references must include at least one must_surface=true anchor"
+    has_non_reference_grounding = _has_contract_grounding_context(
+        contract,
+        project_root=project_root,
+        require_existing_project_artifacts=True,
+    )
+    if mode == "approved" and not has_non_reference_grounding:
+        return [finding], []
+    return [], [finding]
+
+
 def contract_has_explicit_context_intake(
     contract: ResearchContract,
     *,

--- a/src/gpd/core/contract_validation.py
+++ b/src/gpd/core/contract_validation.py
@@ -42,6 +42,7 @@ from gpd.contracts import (
     _is_concrete_reference_locator,
     _is_context_intake_locator_grounding,
     _is_project_artifact_path,
+    _split_missing_must_surface_anchor_findings,
     collect_contract_integrity_errors,
     collect_proof_bearing_claim_integrity_errors,
     is_placeholder_only_guidance_text,
@@ -1372,14 +1373,13 @@ def validate_project_contract(
     else:
         warnings.extend(_must_surface_locator_warnings(parsed, project_root=project_root))
 
-    has_non_reference_grounding = _has_non_reference_grounding_signal(parsed, project_root=project_root)
-
-    if parsed.references and not any(reference.must_surface for reference in parsed.references):
-        finding = "references must include at least one must_surface=true anchor"
-        if mode == "approved" and not has_non_reference_grounding:
-            errors.append(finding)
-        else:
-            warnings.append(finding)
+    reference_anchor_errors, reference_anchor_warnings = _split_missing_must_surface_anchor_findings(
+        parsed,
+        project_root=project_root,
+        mode=mode,
+    )
+    errors.extend(reference_anchor_errors)
+    warnings.extend(reference_anchor_warnings)
 
     if (
         mode == "approved"

--- a/src/gpd/core/health.py
+++ b/src/gpd/core/health.py
@@ -435,7 +435,7 @@ def check_compaction_needed(cwd: Path) -> HealthCheck:
             details={"reason": "no_state_file"},
         )
 
-    line_count = len(content.split("\n"))
+    line_count = len(content.splitlines())
 
     # Count decisions
     dec_match = re.search(
@@ -696,7 +696,7 @@ def _latest_summary_file(cwd: Path) -> tuple[Path, str] | None:
 
     for phase_dir in sorted(
         (entry for entry in phases_dir.iterdir() if entry.is_dir()),
-        key=lambda entry: phase_sort_key(entry.name),
+        key=lambda entry: (phase_sort_key(entry.name), entry.name),
     ):
         for summary in sorted(
             (entry for entry in phase_dir.iterdir() if entry.is_file() and layout.is_summary_file(entry.name)),
@@ -707,13 +707,13 @@ def _latest_summary_file(cwd: Path) -> tuple[Path, str] | None:
             except OSError:
                 continue
             mtime_ns = getattr(stat, "st_mtime_ns", int(stat.st_mtime * 1_000_000_000))
-            candidates.append((mtime_ns, f"{phase_dir.name}/{summary.name}", summary))
+            candidates.append((mtime_ns, tuple(phase_sort_key(phase_dir.name)), phase_dir.name, summary.name, summary))
 
     if not candidates:
         return None
 
-    _mtime_ns, summary_name, summary_path = max(candidates, key=lambda item: (item[0], item[1]))
-    return summary_path, summary_name
+    _mtime_ns, _phase_key, phase_name, summary_filename, summary_path = max(candidates, key=lambda item: item[:4])
+    return summary_path, f"{phase_name}/{summary_filename}"
 
 
 def check_latest_return(cwd: Path) -> HealthCheck:

--- a/src/gpd/core/model_visible_text.py
+++ b/src/gpd/core/model_visible_text.py
@@ -153,6 +153,10 @@ def command_visibility_note() -> str:
         agent_clause,
         "`project_reentry_capable` must be `true` or `false` and may be `true` only when `context_mode` is `project-required`.",
         "Missing required files or other decisive evidence are blocking for strong claims; do not treat omissions or proxies as success.",
+        "Any user-visible completion, checkpoint, blocked return, failed return, retry gate, or stop that expects later "
+        "action must end with a concrete `## > Next Up` or `## >> Next Up` section. Include copy-pasteable GPD "
+        "commands when they exist; otherwise name the exact artifact or review action. Use `gpd:suggest-next` as the "
+        "recovery/confirmation command for project-backed states.",
         *_EPISTEMIC_GUARDRAIL_CLAUSES,
     )
 

--- a/src/gpd/core/state.py
+++ b/src/gpd/core/state.py
@@ -1288,6 +1288,24 @@ VALID_TRANSITIONS: dict[str, list[str] | None] = {
     "blocked": None,
 }
 
+# Keep in sync with generate_state_markdown() Session Continuity fields.
+_SESSION_CONTINUITY_MIRROR_FIELDS = frozenset({
+    "last session",
+    "stopped at",
+    "resume file",
+    "last result id",
+    "hostname",
+    "platform",
+})
+
+
+def _session_continuity_mirror_field_reason(field_norm: str) -> str:
+    return (
+        f'Field "{field_norm}" is a Session Continuity mirror field '
+        "that is regenerated from state.json on save. "
+        "Use the continuation API to update session state."
+    )
+
 
 def is_valid_status(value: str) -> bool:
     """Check if a status value is recognized (case-insensitive exact match)."""
@@ -1369,6 +1387,38 @@ def state_has_field(content: str, field_name: str) -> bool:
     """Check if a **Field:** exists in STATE.md content."""
     escaped = re.escape(field_name)
     return bool(re.search(rf"\*\*{escaped}:\*\*", content, re.IGNORECASE))
+
+
+def _resolve_state_md_field_name(content: str, field: str) -> tuple[str, list[str], bool]:
+    """Resolve a STATE.md field name using patch/update lookup semantics."""
+    field_norm = field
+    also_tried: list[str] = []
+
+    found = state_has_field(content, field_norm)
+
+    if not found:
+        underscore_form = field.replace("_", " ")
+        if underscore_form != field:
+            also_tried.append(underscore_form)
+            found = state_has_field(content, underscore_form)
+            if found:
+                field_norm = underscore_form
+
+    if not found and "." in field:
+        stripped_raw = field.rsplit(".", 1)[-1]
+        also_tried.append(stripped_raw)
+        found = state_has_field(content, stripped_raw)
+        if found:
+            field_norm = stripped_raw
+        else:
+            stripped_norm = field.replace("_", " ").rsplit(".", 1)[-1]
+            if stripped_norm != stripped_raw:
+                also_tried.append(stripped_norm)
+                found = state_has_field(content, stripped_norm)
+                if found:
+                    field_norm = stripped_norm
+
+    return field_norm, also_tried, found
 
 
 # ─── STATE.md Parser ──────────────────────────────────────────────────────────
@@ -3898,7 +3948,19 @@ def state_update(cwd: Path, field: str, value: str) -> StateUpdateResult:
         content = _load_or_rebuild_state_markdown_locked(cwd)
         if content is None:
             return StateUpdateResult(updated=False, reason="STATE.md not found")
-        field_norm = field.replace("_", " ")  # TODO(FULL-017): Apply dot-notation stripping here too
+        field_norm, _also_tried, found = _resolve_state_md_field_name(content, field)
+
+        if found and field_norm.lower() in _SESSION_CONTINUITY_MIRROR_FIELDS:
+            return StateUpdateResult(
+                updated=False,
+                reason=_session_continuity_mirror_field_reason(field_norm),
+            )
+
+        if field_norm.lower() == "status" and not is_valid_status(value):
+            return StateUpdateResult(
+                updated=False,
+                reason=f'Invalid status: "{value}". Valid: {", ".join(VALID_STATUSES)}',
+            )
 
         # Validate state transitions
         if field_norm.lower() == "status":
@@ -3908,7 +3970,7 @@ def state_update(cwd: Path, field: str, value: str) -> StateUpdateResult:
                 if err:
                     return StateUpdateResult(updated=False, reason=err)
 
-        if not state_has_field(content, field_norm):
+        if not found:
             return StateUpdateResult(updated=False, reason=f'Field "{field}" not found in STATE.md')
 
         new_content = state_replace_field(content, field_norm, value)
@@ -3935,57 +3997,14 @@ def state_patch(cwd: Path, patches: dict[str, str]) -> StatePatchResult:
         failed: list[str] = []
         failure_reasons: dict[str, str] = {}
 
-        # Session Continuity fields are non-authoritative mirrors in STATE.md —
-        # save_state_markdown_locked() regenerates this section from state.json,
-        # so patching these fields via markdown replacement is silently a no-op.
-        # Keep in sync with generate_state_markdown() L2716-2724.
-        _session_mirror = frozenset({
-            "last session", "stopped at", "resume file",
-            "last result id", "hostname", "platform",
-        })
-
         for field, value in patches.items():
-            # --- Three-phase field resolution ---
-            # Phase 1: try the raw input exactly as given
-            field_norm = field
-            found = state_has_field(content, field_norm)
-            also_tried: list[str] = []
-
-            # Phase 2: try underscore → space normalization
-            if not found:
-                underscore_form = field.replace("_", " ")
-                if underscore_form != field:
-                    also_tried.append(underscore_form)
-                    found = state_has_field(content, underscore_form)
-                    if found:
-                        field_norm = underscore_form
-
-            # Phase 3: dot-prefix stripping (on the best candidate so far)
-            if not found and "." in field:
-                # Strip from the raw field first (preserves underscores)
-                stripped_raw = field.rsplit(".", 1)[-1]
-                also_tried.append(stripped_raw)
-                found = state_has_field(content, stripped_raw)
-                if found:
-                    field_norm = stripped_raw
-                else:
-                    # Also try underscore-replaced + stripped
-                    stripped_norm = field.replace("_", " ").rsplit(".", 1)[-1]
-                    if stripped_norm != stripped_raw:
-                        also_tried.append(stripped_norm)
-                        found = state_has_field(content, stripped_norm)
-                        if found:
-                            field_norm = stripped_norm
+            field_norm, also_tried, found = _resolve_state_md_field_name(content, field)
 
             # Guard: reject Session Continuity mirror fields — they are
             # regenerated from state.json on save, so markdown patches are no-ops.
-            if found and field_norm.lower() in _session_mirror:
+            if found and field_norm.lower() in _SESSION_CONTINUITY_MIRROR_FIELDS:
                 failed.append(field)
-                failure_reasons[field] = (
-                    f'Field "{field_norm}" is a Session Continuity mirror field '
-                    f"that is regenerated from state.json on save. "
-                    f"Use the continuation API to update session state."
-                )
+                failure_reasons[field] = _session_continuity_mirror_field_reason(field_norm)
                 continue
 
             if field_norm.lower() == "status" and not is_valid_status(value):

--- a/src/gpd/hooks/install_metadata.py
+++ b/src/gpd/hooks/install_metadata.py
@@ -207,6 +207,22 @@ def load_install_manifest_scope_status(config_dir: Path) -> tuple[str, dict[str,
     return "ok", payload, normalized_scope
 
 
+def load_install_manifest_explicit_target_status(config_dir: Path) -> tuple[str, dict[str, object], bool | None]:
+    """Return the manifest parse state, payload, and explicit-target flag when available."""
+
+    state, payload = load_install_manifest_state(config_dir)
+    if state != "ok":
+        return state, payload, None
+
+    if "explicit_target" not in payload:
+        return "missing_explicit_target", payload, None
+
+    explicit_target = payload.get("explicit_target")
+    if not isinstance(explicit_target, bool):
+        return "malformed_explicit_target", payload, None
+    return "ok", payload, explicit_target
+
+
 def assess_install_target(
     config_dir: Path,
     *,
@@ -309,8 +325,10 @@ def installed_update_command(config_dir: Path) -> str | None:
     except KeyError:
         return None
 
-    explicit_target = manifest.get("explicit_target")
-    if not isinstance(explicit_target, bool):
+    explicit_target_state, _explicit_target_manifest, explicit_target = load_install_manifest_explicit_target_status(
+        config_dir
+    )
+    if explicit_target_state != "ok" or explicit_target is None:
         # Fail closed for legacy manifests that do not prove whether the
         # install was explicitly targeted. Update-command synthesis is only
         # trusted when the manifest carries the authoritative flag.

--- a/src/gpd/mcp/servers/__init__.py
+++ b/src/gpd/mcp/servers/__init__.py
@@ -89,12 +89,9 @@ def configure_mcp_logging(logger_name: str) -> logging.Logger:
 def resolve_absolute_project_dir(project_dir: str) -> Path | None:
     """Return an absolute project root path or ``None`` when the contract is violated."""
 
-    from gpd.core.project_files import migrate_root_planning_files
-
     cwd = Path(project_dir)
     if not cwd.is_absolute():
         return None
-    migrate_root_planning_files(cwd)
     return cwd
 
 

--- a/src/gpd/mcp/servers/skills_server.py
+++ b/src/gpd/mcp/servers/skills_server.py
@@ -16,7 +16,7 @@ import re
 from collections.abc import Callable
 from functools import cache, lru_cache
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, NamedTuple
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -72,28 +72,47 @@ _SPEC_ROOT = content_registry.SPECS_DIR.resolve()
 _AGENT_ROOT = content_registry.AGENTS_DIR.resolve()
 _COMMAND_ROOT = content_registry.COMMANDS_DIR.resolve()
 _REPO_ROOT = _SPEC_ROOT.parents[2]
-_SPEC_RELATIVE_REFERENCE_PREFIXES = (
-    "references/",
-    "workflows/",
-    "templates/",
-    "bundles/",
-    "shared/",
-    "domains/",
-    "execution/",
-    "verification/",
-    "conventions/",
-    "research/",
-    "publication/",
-    "protocols/",
-    "subfields/",
-    "orchestration/",
+
+
+class _ReferencePrefixSpec(NamedTuple):
+    raw_prefix: str
+    portable_prefix: str
+    root: Path
+    kind: str
+    allow_missing: bool = False
+
+
+_REFERENCE_PREFIX_SPECS: tuple[_ReferencePrefixSpec, ...] = (
+    _ReferencePrefixSpec("references/", "@{GPD_INSTALL_DIR}/references/", _SPEC_ROOT / "references", "reference"),
+    _ReferencePrefixSpec("workflows/", "@{GPD_INSTALL_DIR}/workflows/", _SPEC_ROOT / "workflows", "workflow"),
+    _ReferencePrefixSpec("templates/", "@{GPD_INSTALL_DIR}/templates/", _SPEC_ROOT / "templates", "template"),
+    _ReferencePrefixSpec("bundles/", "@{GPD_INSTALL_DIR}/bundles/", _SPEC_ROOT / "bundles", "bundle"),
+    _ReferencePrefixSpec("shared/", "@{GPD_INSTALL_DIR}/shared/", _SPEC_ROOT / "shared", "reference"),
+    _ReferencePrefixSpec("domains/", "@{GPD_INSTALL_DIR}/domains/", _SPEC_ROOT / "domains", "reference"),
+    _ReferencePrefixSpec("execution/", "@{GPD_INSTALL_DIR}/execution/", _SPEC_ROOT / "execution", "reference"),
+    _ReferencePrefixSpec("verification/", "@{GPD_INSTALL_DIR}/verification/", _SPEC_ROOT / "verification", "reference"),
+    _ReferencePrefixSpec("conventions/", "@{GPD_INSTALL_DIR}/conventions/", _SPEC_ROOT / "conventions", "reference"),
+    _ReferencePrefixSpec("research/", "@{GPD_INSTALL_DIR}/research/", _SPEC_ROOT / "research", "reference"),
+    _ReferencePrefixSpec("publication/", "@{GPD_INSTALL_DIR}/publication/", _SPEC_ROOT / "publication", "reference"),
+    _ReferencePrefixSpec("protocols/", "@{GPD_INSTALL_DIR}/protocols/", _SPEC_ROOT / "protocols", "reference"),
+    _ReferencePrefixSpec("subfields/", "@{GPD_INSTALL_DIR}/subfields/", _SPEC_ROOT / "subfields", "reference"),
+    _ReferencePrefixSpec("orchestration/", "@{GPD_INSTALL_DIR}/orchestration/", _SPEC_ROOT / "orchestration", "reference"),
+    _ReferencePrefixSpec("commands/", "@{GPD_INSTALL_DIR}/commands/", _COMMAND_ROOT, "command"),
+    _ReferencePrefixSpec("agents/", "@{GPD_AGENTS_DIR}/", _AGENT_ROOT, "agent"),
+    _ReferencePrefixSpec("docs/", "@GPD/docs/", _REPO_ROOT / "docs", "docs", allow_missing=True),
 )
 _SKILL_COMMAND_PREFIX = "gpd-"
-_MARKDOWN_REFERENCE_RE = re.compile(
-    r"(?P<path>(?:@?\{GPD_(?:INSTALL|AGENTS)_DIR\}/|(?:\.\./|\.\/)?"
-    r"(?:references|workflows|templates|agents|commands|bundles|shared|domains|execution|verification|conventions|research|publication|protocols|subfields|orchestration|GPD|src/gpd)/)"
-    r"[^\s`\"')]+?\.md)"
-)
+
+
+@lru_cache(maxsize=1)
+def _markdown_reference_re() -> re.Pattern[str]:
+    """Return the matcher for direct markdown references."""
+
+    relative_prefixes = "|".join(re.escape(spec.raw_prefix) for spec in _REFERENCE_PREFIX_SPECS)
+    return re.compile(
+        r"(?P<path>(?:@?\{GPD_(?:INSTALL|AGENTS)_DIR\}/|(?:\.\./|\.\/)?"
+        rf"(?:{relative_prefixes}|GPD/|src/gpd/))[^\s`\"')]+?\.md)"
+    )
 _SKILL_BEHAVIORAL_GUARDRAIL_HINT = (
     "Use scientific skepticism and critical thinking without treating the user as an adversary. Treat missing "
     "evidence or artifacts as missing, blocked, failed, or inconclusive, and never fabricate references, results, "
@@ -360,26 +379,36 @@ def _portable_reference_path(raw_path: str, *, base_path: Path | None = None) ->
         resolved = resolved.resolve()
         if not resolved.is_file():
             return None
-        try:
-            rel = resolved.relative_to(_SPEC_ROOT)
-        except ValueError:
-            pass
-        else:
-            portable = f"@{{GPD_INSTALL_DIR}}/{rel.as_posix()}"
+        for spec in _REFERENCE_PREFIX_SPECS:
+            try:
+                rel = resolved.relative_to(spec.root)
+            except ValueError:
+                continue
+            portable = f"{spec.portable_prefix}{rel.as_posix()}"
             return portable, resolved
-        try:
-            rel = resolved.relative_to(_AGENT_ROOT)
-        except ValueError:
-            pass
-        else:
-            portable = f"@{{GPD_AGENTS_DIR}}/{rel.as_posix()}"
-            return portable, resolved
-        try:
-            rel = resolved.relative_to(_COMMAND_ROOT)
-        except ValueError:
+        return None
+
+    def _safe_missing_reference_suffix(relative: str) -> str | None:
+        normalized = relative.replace("\\", "/")
+        if not normalized or normalized.startswith("/"):
             return None
-        portable = f"@{{GPD_INSTALL_DIR}}/commands/{rel.as_posix()}"
-        return portable, resolved
+        parts = normalized.split("/")
+        if any(part in {"", ".", ".."} for part in parts):
+            return None
+        return normalized
+
+    def _missing_portable_path(spec: _ReferencePrefixSpec, relative: str) -> tuple[str, Path | None] | None:
+        safe_relative = _safe_missing_reference_suffix(relative)
+        if safe_relative is None:
+            return None
+        portable = f"{spec.portable_prefix}{safe_relative}"
+        return portable, None
+
+    def _reference_spec_for(candidate_path: str) -> _ReferencePrefixSpec | None:
+        for spec in _REFERENCE_PREFIX_SPECS:
+            if candidate_path.startswith(spec.raw_prefix):
+                return spec
+        return None
 
     if candidate.startswith("@{GPD_INSTALL_DIR}/") or candidate.startswith("{GPD_INSTALL_DIR}/"):
         relative = candidate.split("}/", 1)[1]
@@ -393,29 +422,23 @@ def _portable_reference_path(raw_path: str, *, base_path: Path | None = None) ->
         normalized = _normalize_resolved_path(resolved)
         return normalized
 
+    spec = _reference_spec_for(candidate)
+    if spec is not None:
+        relative = candidate.removeprefix(spec.raw_prefix)
+        resolved = spec.root / relative
+        normalized = _normalize_resolved_path(resolved)
+        if normalized is not None:
+            return normalized
+        if spec.allow_missing:
+            return _missing_portable_path(spec, relative)
+        return None
+
     raw_path_obj = Path(candidate)
     if raw_path_obj.is_absolute():
         normalized = _normalize_resolved_path(raw_path_obj)
         if normalized is not None:
             return normalized
         return None
-
-    if candidate.startswith(_SPEC_RELATIVE_REFERENCE_PREFIXES):
-        resolved = _SPEC_ROOT / candidate
-        normalized = _normalize_resolved_path(resolved)
-        return normalized
-
-    if candidate.startswith("commands/"):
-        relative = candidate.removeprefix("commands/")
-        resolved = _COMMAND_ROOT / relative
-        normalized = _normalize_resolved_path(resolved)
-        return normalized
-
-    if candidate.startswith("agents/"):
-        relative = candidate.removeprefix("agents/")
-        resolved = _AGENT_ROOT / relative
-        normalized = _normalize_resolved_path(resolved)
-        return normalized
 
     if candidate.startswith(("GPD/", "@GPD/")):
         project_path = candidate.removeprefix("@")
@@ -438,20 +461,11 @@ def _portable_reference_path(raw_path: str, *, base_path: Path | None = None) ->
 
 
 def _reference_kind(path: str) -> str:
+    for spec in _REFERENCE_PREFIX_SPECS:
+        if path.startswith(spec.portable_prefix):
+            return spec.kind
     if path.startswith("@GPD/"):
         return "project"
-    if path.startswith("@{GPD_AGENTS_DIR}/"):
-        return "agent"
-    if path.startswith("@{GPD_INSTALL_DIR}/commands/"):
-        return "command"
-    if path.startswith("@{GPD_INSTALL_DIR}/templates/"):
-        return "template"
-    if path.startswith("@{GPD_INSTALL_DIR}/workflows/"):
-        return "workflow"
-    if path.startswith("@{GPD_INSTALL_DIR}/bundles/"):
-        return "bundle"
-    if path.startswith("@{GPD_INSTALL_DIR}/references/"):
-        return "reference"
     return "spec"
 
 
@@ -478,7 +492,7 @@ def _extract_referenced_files(
         entry_list.append(entry)
 
     def _collect(markdown: str, *, current_path: Path | None, depth: int) -> None:
-        for match in _MARKDOWN_REFERENCE_RE.finditer(markdown):
+        for match in _markdown_reference_re().finditer(markdown):
             normalized = _portable_reference_path(match.group("path"), base_path=current_path)
             if normalized is None:
                 continue

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -43,6 +43,7 @@ from gpd.contracts import (
     THEOREM_CLAIM_KIND_VALUES,
     THEOREM_STYLE_STATEMENT_REGEX_PATTERNS,
     ResearchContract,
+    _split_missing_must_surface_anchor_findings,
     collect_plan_contract_integrity_errors,
     contract_has_explicit_context_intake,
     parse_project_contract_data_salvage,
@@ -50,6 +51,7 @@ from gpd.contracts import (
     statement_looks_theorem_like,
 )
 from gpd.core.contract_validation import (
+    _must_surface_locator_warnings,
     is_authoritative_project_contract_schema_finding,
     is_repair_relevant_project_contract_schema_finding,
     split_project_contract_schema_findings,
@@ -80,6 +82,18 @@ from gpd.mcp.verification_contract_policy import (
 logger = configure_mcp_logging("gpd-verification")
 
 mcp = FastMCP("gpd-verification")
+
+
+def _approved_contract_warnings(contract: ResearchContract, *, project_root: Path | None) -> list[str]:
+    """Return non-blocking approved-mode contract warnings shared by MCP tools."""
+
+    _, missing_anchor_warnings = _split_missing_must_surface_anchor_findings(
+        contract,
+        project_root=project_root,
+        mode="approved",
+    )
+    locator_warnings = _must_surface_locator_warnings(contract, project_root=project_root)
+    return list(dict.fromkeys([*missing_anchor_warnings, *locator_warnings]))
 
 _CONTRACT_ERROR_PATH_RE = re.compile(
     r"^(schema_version|[A-Za-z_][A-Za-z0-9_]*(?:\.\d+|\.[A-Za-z_][A-Za-z0-9_]*|\[\d+\])*)(?:: | )"
@@ -4502,8 +4516,11 @@ def run_contract_check(request: RunContractCheckPayload, project_dir: OptionalAb
                     metadata=metadata,
                 )
 
-            return stable_mcp_response(
-                {
+            contract_warnings: list[str] = []
+            if contract is not None:
+                contract_warnings = _approved_contract_warnings(contract, project_root=project_root)
+
+            response = {
                 "check_id": check_meta.check_id,
                 "check_key": check_meta.check_key,
                 "check_name": check_meta.name,
@@ -4521,8 +4538,11 @@ def run_contract_check(request: RunContractCheckPayload, project_dir: OptionalAb
                 "contract_salvaged": bool(contract_salvage_errors),
                 "contract_salvage_findings": list(contract_salvage_errors),
                 "guidance": check_meta.oracle_hint,
-                }
-            )
+            }
+            if contract_warnings:
+                response["contract_warnings"] = contract_warnings
+
+            return stable_mcp_response(response)
         except Exception as exc:  # pragma: no cover - defensive envelope
             return _error_result(exc)
 
@@ -4644,11 +4664,14 @@ def suggest_contract_checks(
                 "contract_salvaged": bool(contract_salvage_errors),
                 "contract_salvage_findings": list(contract_salvage_errors),
             }
+            contract_warnings = _approved_contract_warnings(parsed, project_root=project_root)
             if contract_salvage_errors:
-                response["contract_warnings"] = [
+                contract_warnings = [
                     "Contract payload was salvaged before check suggestion: "
                     + _summarize_contract_salvage_errors(contract_salvage_errors)
-                ]
+                ] + contract_warnings
+            if contract_warnings:
+                response["contract_warnings"] = contract_warnings
             return stable_mcp_response(response)
         except Exception as exc:  # pragma: no cover - defensive envelope
             if isinstance(exc, PydanticValidationError):

--- a/src/gpd/runtime_cli.py
+++ b/src/gpd/runtime_cli.py
@@ -37,6 +37,7 @@ from gpd.core.cli_args import (
 from gpd.core.constants import ENV_GPD_ACTIVE_RUNTIME, ENV_GPD_DISABLE_CHECKOUT_REEXEC
 from gpd.hooks.install_metadata import (
     config_dir_has_managed_install_markers,
+    load_install_manifest_explicit_target_status,
     load_install_manifest_runtime_status,
     load_install_manifest_scope_status,
 )
@@ -173,25 +174,39 @@ def _paths_equal(left: Path, right: Path) -> bool:
 
 def _is_matching_local_install_candidate(candidate: Path, *, runtime: str) -> bool:
     """Return whether *candidate* should satisfy a local bridge config-dir lookup."""
-    if not candidate.is_dir():
-        return False
+    return _local_install_candidate_status(candidate, runtime=runtime) == "matching"
 
+
+def _is_global_config_candidate(candidate: Path, *, runtime: str) -> bool:
     adapter = get_adapter(runtime)
+    return any(_paths_equal(candidate, global_dir) for global_dir in resolve_global_config_dir_candidates(adapter.runtime_descriptor))
+
+
+def _local_install_candidate_status(candidate: Path, *, runtime: str) -> str:
+    """Classify local config-dir candidates for ancestor resolution."""
+    if not candidate.is_dir():
+        return "none"
+
     manifest_status, manifest, manifest_runtime = load_install_manifest_runtime_status(candidate)
+    manifest_scope = manifest.get("install_scope")
     if manifest_status == "ok":
         if manifest_runtime != runtime:
-            return False
+            return "diagnostic"
+        if manifest_scope == "local":
+            return "matching"
+        if manifest_scope == "global":
+            return "none"
+        return "diagnostic"
 
-        manifest_scope = manifest.get("install_scope")
-        return manifest_scope == "local"
-
-    global_config_dirs = resolve_global_config_dir_candidates(adapter.runtime_descriptor, home=Path.home())
-    has_install_markers = config_dir_has_managed_install_markers(candidate)
-    if not has_install_markers:
-        return False
-    if any(_paths_equal(candidate, global_dir) for global_dir in global_config_dirs):
-        return False
-    return True
+    if manifest_status != "ok":
+        if manifest_scope == "global":
+            return "none"
+        if manifest_scope != "local" and _is_global_config_candidate(candidate, runtime=runtime):
+            return "none"
+        if manifest_status != "missing" or config_dir_has_managed_install_markers(candidate):
+            return "diagnostic"
+        return "none"
+    return "none"
 
 
 def _resolve_local_config_dir(raw_value: str, *, runtime: str, cli_cwd: Path) -> Path:
@@ -200,7 +215,7 @@ def _resolve_local_config_dir(raw_value: str, *, runtime: str, cli_cwd: Path) ->
     resolved_cwd = cli_cwd.resolve(strict=False)
     for base in (resolved_cwd, *resolved_cwd.parents):
         candidate = (base / relative).resolve(strict=False)
-        if _is_matching_local_install_candidate(candidate, runtime=runtime):
+        if _local_install_candidate_status(candidate, runtime=runtime) != "none":
             return candidate
     return (resolved_cwd / relative).resolve(strict=False)
 
@@ -656,19 +671,23 @@ def main(argv: list[str] | None = None) -> int:
         explicit_target=bool(options.explicit_target),
         cli_cwd=cli_cwd,
     )
-    manifest_status, manifest_payload, manifest_runtime = load_install_manifest_runtime_status(config_dir)
+    manifest_status, _manifest_payload, manifest_runtime = load_install_manifest_runtime_status(config_dir)
     manifest_scope_status, manifest_scope_payload, manifest_install_scope = load_install_manifest_scope_status(config_dir)
-    manifest_explicit_target = manifest_payload.get("explicit_target")
-    if not isinstance(manifest_explicit_target, bool):
-        manifest_explicit_target = None
-    repair_explicit_target = (
-        manifest_explicit_target if manifest_explicit_target is not None else bool(options.explicit_target)
+    _manifest_explicit_target_status, _manifest_explicit_target_payload, manifest_explicit_target = (
+        load_install_manifest_explicit_target_status(config_dir)
     )
     if manifest_scope_status == "ok":
         manifest_install_scope = manifest_scope_payload.get("install_scope")
         if not isinstance(manifest_install_scope, str):
             manifest_install_scope = None
     has_managed_install_markers = config_dir_has_managed_install_markers(config_dir)
+    repair_explicit_target = _uses_effective_explicit_target(
+        runtime=runtime,
+        config_dir=config_dir,
+        install_scope=manifest_install_scope if isinstance(manifest_install_scope, str) else options.install_scope,
+        explicit_target=manifest_explicit_target if manifest_explicit_target is not None else False,
+        cli_cwd=cli_cwd,
+    )
     failure = _classify_bridge_failure(
         runtime=runtime,
         config_dir=config_dir,

--- a/src/gpd/specs/references/execution/executor-completion.md
+++ b/src/gpd/specs/references/execution/executor-completion.md
@@ -289,7 +289,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: ["GPD/phases/XX-name/{phase}-{plan}-SUMMARY.md"]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   state_updates:
     advance_plan: true
     update_progress: true

--- a/src/gpd/specs/references/orchestration/agent-infrastructure.md
+++ b/src/gpd/specs/references/orchestration/agent-infrastructure.md
@@ -61,7 +61,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [list of file paths created or modified]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
 ```
 
 Agents may extend this with additional fields specific to their role (e.g., `phases_created`, `dimensions_checked`). The four base fields above are required on this envelope.
@@ -78,7 +78,9 @@ For the human-readable markdown portion of your return, end with a short continu
 
 - If your agent-specific template already has a next-step section, make that section concrete and command-oriented instead of adding a duplicate
 - Otherwise, append a `## > Next Up` block using `references/orchestration/continuation-format.md`
+- Any failed return, retry gate, manual stop, or "needs user input" checkpoint that expects later action must also end this way
 - Include `Also available:` when there are meaningful secondary options
+- Include `gpd:suggest-next` for project-backed states when the primary route may be unclear
 - Include the note `<sub>\`/clear\` first -> fresh context window</sub>` when the next step is another GPD command
 
 ---

--- a/src/gpd/specs/references/orchestration/continuation-format.md
+++ b/src/gpd/specs/references/orchestration/continuation-format.md
@@ -35,6 +35,21 @@ This format is a presentation layer only: the displayed next step is derived fro
 6. **Visual separators** -- `---` above and below to make it stand out
 7. **Derived, not authoritative** -- the message is a projection of the current recovery decision, not a competing source of truth
 
+## Stop And Checkpoint Rules
+
+Every user-visible completion, checkpoint, blocked return, failed return, retry gate, or stop that expects later action must end with this block. Do not end on labels such as "ready", "continue", "retry", "review", or "stop here" unless the same final section gives the exact command or artifact action.
+
+Use this routing unless a workflow has a more specific command:
+
+- Resumable handoff/checkpoint persisted: primary `gpd:resume-work`; include `gpd:suggest-next`
+- Same workflow should be retried after user edits input: show the exact original command, e.g. `gpd:new-project --minimal @file.md`
+- Phase lacks context: primary `gpd:discuss-phase N`; alternative `gpd:plan-phase N`
+- Phase has context but no plan: primary `gpd:plan-phase N`; include `gpd:research-phase N` when discovery is needed
+- Phase has plans to execute: primary `gpd:execute-phase N`
+- Verification gaps exist: primary `gpd:plan-phase N --gaps`; after gap plans exist, `gpd:execute-phase N --gaps-only`; confirm with `gpd:verify-work N`
+- Convention issue blocks progress: primary `gpd:validate-conventions`; include `gpd:resume-work` after repair
+- No clear primary route: primary `gpd:suggest-next`
+
 ## Variants
 
 ### Execute Next Plan

--- a/src/gpd/specs/workflows/execute-phase.md
+++ b/src/gpd/specs/workflows/execute-phase.md
@@ -1095,6 +1095,12 @@ Plans with `interactive: true` require user interaction.
 
    [Checkpoint Details from agent return]
    [Awaiting section from agent return]
+
+   ## > Next Up
+
+   `gpd:resume-work`
+
+   Also available: `gpd:execute-phase {PHASE_NUMBER}` or `gpd:suggest-next`
    ```
 
 5. User responds: "approved"/"done" | issue description | decision selection
@@ -1600,7 +1606,7 @@ Re-verify Phase {PHASE_NUMBER} after gap closure.
 )
 ```
 
-**If the verifier agent fails to spawn or returns an error:** Stop in a blocked state. Do not mark the phase complete or clear gap-closure state on this path. The user should run `gpd:verify-work` separately to confirm gaps are closed. If the phase is proof-bearing, do NOT mark it complete on this path; proof-obligation work remains blocked until re-verification and proof-redteam audits actually clear. Do not trust the runtime handoff status by itself. Do not let a stale existing verification file satisfy the success path.
+**If the verifier agent fails to spawn or returns an error:** Stop in a blocked state. Do not mark the phase complete or clear gap-closure state on this path. End with `## > Next Up`: primary `gpd:verify-work {PHASE_NUMBER}` to confirm gaps are closed, plus `gpd:resume-work` and `gpd:suggest-next`. If the phase is proof-bearing, do NOT mark it complete on this path; proof-obligation work remains blocked until re-verification and proof-redteam audits actually clear. Do not trust the runtime handoff status by itself. Do not let a stale existing verification file satisfy the success path.
 
 **Handle the verifier response through `gpd_return.status`:**
 
@@ -1610,9 +1616,9 @@ Re-verify Phase {PHASE_NUMBER} after gap closure.
   3. If either check fails, treat the re-verification handoff as blocked. Do not let a stale existing verification file satisfy the success path.
   4. After the artifact gate passes, use the canonical verifier verdict from `gpd_return.verification_status` or the written report frontmatter:
      - `passed` -> mark phase complete, proceed to `update_roadmap`
-     - `gaps_found` / `expert_needed` / `human_needed` -> report remaining gaps and STOP -- do not auto-loop. Present: "Re-verification found {N} remaining gaps. Review: {phase_dir}/{phase}-VERIFICATION.md"
-- `gpd_return.status: checkpoint`: stop and surface the checkpoint payload. Do not wait in place for user input inside this run.
-- `gpd_return.status: blocked` / `gpd_return.status: failed`: stop in a blocked state, surface the issues, and keep gap-closure state intact.
+     - `gaps_found` / `expert_needed` / `human_needed` -> report remaining gaps and STOP -- do not auto-loop. Present: "Re-verification found {N} remaining gaps. Review: {phase_dir}/{phase}-VERIFICATION.md" and end with `## > Next Up`: primary `gpd:plan-phase {PHASE_NUMBER} --gaps`, then `gpd:execute-phase {PHASE_NUMBER} --gaps-only`, `gpd:verify-work {PHASE_NUMBER}`, and `gpd:suggest-next`.
+- `gpd_return.status: checkpoint`: stop, surface the checkpoint payload, and end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:verify-work {PHASE_NUMBER}` and `gpd:suggest-next`. Do not wait in place for user input inside this run.
+- `gpd_return.status: blocked` / `gpd_return.status: failed`: stop in a blocked state, surface the issues, keep gap-closure state intact, and end with `## > Next Up`: primary `gpd:verify-work {PHASE_NUMBER}`, plus `gpd:resume-work` and `gpd:suggest-next`.
 
 **If the verifier output is malformed or omits `gpd_return.status`:** Treat it as blocked. Do not infer success from prose headings or untyped legacy routing.
 
@@ -1664,12 +1670,12 @@ if [ ! -f "$CONSISTENCY_REPORT" ]; then
 fi
 ```
 
-**If the consistency checker agent fails to spawn or returns an error:** Treat the consistency check as blocked. Do not proceed as if the phase was checked. The user can rerun `gpd:validate-conventions` or resume this phase from a fresh continuation if they want the cross-phase sweep.
+**If the consistency checker agent fails to spawn or returns an error:** Treat the consistency check as blocked. Do not proceed as if the phase was checked. End with `## > Next Up`: primary `gpd:validate-conventions`, plus `gpd:resume-work`, `gpd:execute-phase {PHASE_NUMBER}`, and `gpd:suggest-next`.
 
 **Handle the checker response through `gpd_return.status`:**
 - `gpd_return.status: completed`: accept only if the artifact gate passes. Surface any `issues` as warnings, then continue.
-- `gpd_return.status: checkpoint`: stop and surface the checkpoint payload from the checker. Do not wait in place for user input inside this run.
-- `gpd_return.status: blocked` / `gpd_return.status: failed`: stop execution and surface the returned issues. If the user wants convention repair, spawn `gpd-notation-coordinator` from a fresh continuation after the stop.
+- `gpd_return.status: checkpoint`: stop, surface the checkpoint payload from the checker, and end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:validate-conventions` and `gpd:suggest-next`. Do not wait in place for user input inside this run.
+- `gpd_return.status: blocked` / `gpd_return.status: failed`: stop execution, surface the returned issues, and end with `## > Next Up`: primary `gpd:validate-conventions`, plus `gpd:resume-work` and `gpd:suggest-next`. If the user wants convention repair, spawn `gpd-notation-coordinator` from a fresh continuation after the stop.
 
 **If the checker output is malformed or omits `gpd_return.status`:** Treat it as blocked. Do not infer success from prose headings or untyped legacy routing.
 
@@ -1714,7 +1720,7 @@ Load conventions: gpd convention list
 )
 ```
 
-**If the notation coordinator agent fails to spawn or returns an error:** The consistency issues remain unresolved. Offer: 1) Retry notation coordinator, 2) Resolve conflicts manually by editing CONVENTIONS.md and using `gpd convention set`, 3) Force continue with known inconsistencies (log to DECISIONS.md). Do not silently proceed — convention errors compound across phases.
+**If the notation coordinator agent fails to spawn or returns an error:** The consistency issues remain unresolved. End with `## > Next Up`: primary `gpd:validate-conventions`, plus `gpd:resume-work`, `gpd convention set <key> <value>`, and `gpd:suggest-next`. Do not silently proceed — convention errors compound across phases.
 
 Handle notation-coordinator return:
 - **`CONVENTION UPDATE`:** Conventions fixed. Commit CONVENTIONS.md. Then verify `gpd convention check` reports `locked` or `complete`, and re-check any phase artifacts flagged for re-execution are still present on disk before continuing. If the lock is still open or a flagged artifact is missing, treat the update as incomplete and keep the phase blocked.
@@ -1789,7 +1795,7 @@ fi
 After phase completion, check the project's autonomy mode. If yolo or balanced with no pending checkpoint, auto-route to the next phase. If supervised, or if a checkpoint requires review, pause with a clear status message showing: current phase completed, why execution paused, exact next command to continue, and key artifacts to review. See `{GPD_INSTALL_DIR}/references/orchestration/continuous-execution.md` for the standard checkpoint protocol.
 </continuation_routing>
 
-Never end with only "ready to plan/continue" prose. After a successful closeout, choose the matching variant and emit a `Next Up` block with concrete commands:
+Never end with only "ready to plan/continue" prose. After a successful closeout, choose exactly one matching variant and emit a `Next Up` block with concrete commands; do not print conditional "if context is missing/exists" labels in the final answer.
 
 - If the next phase has no `*-CONTEXT.md`, make `gpd:discuss-phase {X+1}` the primary command and show `gpd:plan-phase {X+1}` as the direct-plan alternative.
 - If the next phase already has context, make `gpd:plan-phase {X+1}` the primary command.
@@ -1802,14 +1808,11 @@ Never end with only "ready to plan/continue" prose. After a successful closeout,
 
 **Phase {X+1}: {Name}** -- {Goal}
 
-If context is missing:
-Primary: `gpd:discuss-phase {X+1}`
-Direct plan alternative: `gpd:plan-phase {X+1}`
+Primary: `{chosen primary command}`
 
-If context exists:
-Primary: `gpd:plan-phase {X+1}`
-
-Confirm next action: `gpd:suggest-next`
+**Also available:**
+- `{secondary command}` -- when relevant
+- `gpd:suggest-next` -- confirm the next action
 
 <sub>`/clear` first for fresh context, then run the primary command above.</sub>
 ```
@@ -1822,6 +1825,10 @@ MILESTONE COMPLETE!
 All {N} phases executed.
 
 `gpd:complete-milestone`
+
+**Also available:** `gpd:suggest-next`
+
+<sub>`/clear` first for fresh context, then run `gpd:complete-milestone`.</sub>
 ```
 
 </step>

--- a/src/gpd/specs/workflows/execute-phase.md
+++ b/src/gpd/specs/workflows/execute-phase.md
@@ -1789,6 +1789,12 @@ fi
 After phase completion, check the project's autonomy mode. If yolo or balanced with no pending checkpoint, auto-route to the next phase. If supervised, or if a checkpoint requires review, pause with a clear status message showing: current phase completed, why execution paused, exact next command to continue, and key artifacts to review. See `{GPD_INSTALL_DIR}/references/orchestration/continuous-execution.md` for the standard checkpoint protocol.
 </continuation_routing>
 
+Never end with only "ready to plan/continue" prose. After a successful closeout, choose the matching variant and emit a `Next Up` block with concrete commands:
+
+- If the next phase has no `*-CONTEXT.md`, make `gpd:discuss-phase {X+1}` the primary command and show `gpd:plan-phase {X+1}` as the direct-plan alternative.
+- If the next phase already has context, make `gpd:plan-phase {X+1}` the primary command.
+- Always include `gpd:suggest-next` as the shortest recovery/confirmation command when the user only wants the next action.
+
 **If more phases:**
 
 ```
@@ -1796,9 +1802,16 @@ After phase completion, check the project's autonomy mode. If yolo or balanced w
 
 **Phase {X+1}: {Name}** -- {Goal}
 
-`gpd:plan-phase {X+1}`
+If context is missing:
+Primary: `gpd:discuss-phase {X+1}`
+Direct plan alternative: `gpd:plan-phase {X+1}`
 
-<sub>`/clear` first for fresh context</sub>
+If context exists:
+Primary: `gpd:plan-phase {X+1}`
+
+Confirm next action: `gpd:suggest-next`
+
+<sub>`/clear` first for fresh context, then run the primary command above.</sub>
 ```
 
 **If milestone complete:**

--- a/src/gpd/specs/workflows/execute-plan.md
+++ b/src/gpd/specs/workflows/execute-plan.md
@@ -758,7 +758,7 @@ ls -1 "${phase_dir}"/SUMMARY.md "${phase_dir}"/*-SUMMARY.md 2>/dev/null | wc -l
 
 | Condition                                  | Route                 | Action                                                                                                                                                  |
 | ------------------------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| summaries < plans                          | **A: More plans**     | Find next PLAN without SUMMARY. **balanced/yolo:** auto-continue to next plan when no blockers remain. **supervised:** show next plan + completion summary, wait for explicit "proceed" before continuing. STOP here. |
+| summaries < plans                          | **A: More plans**     | Find next PLAN without SUMMARY. **balanced/yolo:** auto-continue to next plan when no blockers remain. **supervised:** show next plan + completion summary, then end with `## > Next Up`: primary `gpd:execute-phase {phase}`, plus `gpd:suggest-next`. STOP here. |
 | summaries = plans, current < highest phase | **B: Phase done**     | Show completion, suggest `gpd:plan-phase {Z+1}` + `gpd:verify-work {Z}` + `gpd:discuss-phase {Z+1}`                                                  |
 | summaries = plans, current = highest phase | **C: Milestone done** | Show banner, suggest `gpd:complete-milestone` + `gpd:verify-work` + `gpd:add-phase`                                                                  |
 

--- a/src/gpd/specs/workflows/map-research.md
+++ b/src/gpd/specs/workflows/map-research.md
@@ -416,7 +416,7 @@ gpd_return:
   status: completed | checkpoint | blocked | failed
   files_written: [GPD/research-map/{DOC1}.md, ...]
   issues: [list of issues encountered, if any]
-  next_actions: [list of recommended follow-up actions]
+  next_actions: [concrete commands or exact artifact review actions]
   focus: "theory | computation | methodology | status"
 ```
 

--- a/src/gpd/specs/workflows/new-milestone.md
+++ b/src/gpd/specs/workflows/new-milestone.md
@@ -270,6 +270,8 @@ Before trusting the scout handoff, route on `gpd_return.status` and `gpd_return.
 
 **If `gpd_return.status: failed`:** surface the failure details, retry only the missing scout once in the same task-local write scope if the artifact is absent, and stop the survey path if freshness still cannot be proven.
 
+Any scout `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-milestone [milestone name]` to re-enter staged milestone setup, plus `gpd:suggest-next`.
+
 **If any research agent fails to spawn or returns an error:** Verify which required scout artifacts exist (`PRIOR-WORK.md`, `METHODS.md`, `COMPUTATIONAL.md`, `PITFALLS.md`). Retry only the missing scout tasks once with the same task-local write scope. If any required research file is still missing after the retry, STOP this survey path and present the missing artifacts. Do not synthesize from incomplete scout output and do not continue the milestone on partial survey results.
 
 **Artifact gate:** If a scout reports success but its `expected_artifacts` entry (`GPD/literature/{FILE}`) is missing, treat that scout as incomplete. Retry only the missing scout once in the same task-local write scope. If the artifact is still missing, stop the survey path. Do not substitute main-context research for the missing scout and do not continue with a partial survey.
@@ -346,6 +348,8 @@ This synthesizer contract is task-local. Do not reuse survey write scopes or wid
 **If `gpd_return.status: blocked`:** Present the blocker, work with the user to resolve it, and spawn a fresh continuation once the blocker is resolved.
 
 **If `gpd_return.status: failed`:** Present the failure details, ask whether to retry the same continuation once or stop, and do not infer success from preexisting files.
+
+Any synthesizer `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-milestone [milestone name]`, plus `gpd:suggest-next`.
 
 **Artifact gate:** If the synthesizer reports `gpd_return.status: completed`, verify that `GPD/literature/SUMMARY.md` is readable and named in `gpd_return.files_written`. If the summary artifact is missing from disk or from `gpd_return.files_written`, treat the handoff as incomplete. Retry the synthesizer once if the summary file is still missing. If it remains missing, stop and review the missing inputs. Do not create SUMMARY.md in the main context from partial scout output or from a stale summary that was not named in the fresh return.
 
@@ -571,6 +575,8 @@ This roadmapper contract is task-local. Do not widen the write scope or reuse it
 
 **If `gpd_return.status: failed`:** Present the failure details, ask whether to retry the same continuation once or stop, and do not infer success from preexisting files.
 
+Any roadmapper `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-milestone [milestone name]`, plus `gpd:suggest-next`.
+
 **Artifact gate:** If the roadmapper reports `gpd_return.status: completed`, verify that `GPD/ROADMAP.md`, `GPD/STATE.md`, and `GPD/REQUIREMENTS.md` are readable and named in `gpd_return.files_written`. If any expected artifact was already present before this handoff, it only counts as fresh output when the same path appears in `gpd_return.files_written`. If any expected artifact is missing from disk or from `gpd_return.files_written`, treat the handoff as incomplete and request a fresh continuation. Do not trust runtime completion text alone.
 
 **One-shot freshness rule:** the only proof of success is a completed typed return naming the updated files. Existing files on disk are stale unless the same paths appear in `gpd_return.files_written` from this run.
@@ -665,6 +671,16 @@ gpd commit "docs: create milestone v[X.Y] roadmap ([N] phases)" --files GPD/ROAD
 ## >> Next Up
 
 **Phase [N]: [Phase Name]** — [Goal]
+
+`gpd:discuss-phase [N]`
+
+<sub>`/clear` first for fresh context, then run `gpd:discuss-phase [N]`.</sub>
+
+---
+
+**Also available:**
+- `gpd:plan-phase [N]` — skip discussion and plan directly
+- `gpd:suggest-next` — confirm the next action
 ```
 </process>
 

--- a/src/gpd/specs/workflows/new-project.md
+++ b/src/gpd/specs/workflows/new-project.md
@@ -99,6 +99,8 @@ Example structure:
   Set up the Monte Carlo simulation and finite-size scaling workflow.
 ```
 
+Stop after this error with `## > Next Up`: tell the user to edit the file and rerun `gpd:new-project --minimal @your-file.md`.
+
 **If `--minimal` without file** (`gpd:new-project --minimal`):
 
 Ask ONE question inline (freeform, NOT ask_user):
@@ -170,6 +172,8 @@ Then present a concise scoping summary and require explicit approval:
   - "Adjust scope" -- revise before writing files
   - "Review raw contract" -- show the structured contract
   - "Stop here" -- do not create downstream artifacts
+
+If the user selects "Stop here", end with `## > Next Up`: primary `gpd:new-project` (or `gpd:new-project --minimal @file.md` for file-backed minimal intake) and `gpd:suggest-next` if any project state was written.
 
 **CRITICAL:** Minimal mode is still allowed to be lean, but it is not allowed to be contract-free.
 
@@ -556,6 +560,16 @@ were skipped. Use gpd:settings to adjust workflow preferences.
 ## >> Next Up
 
 **Phase 1: [Phase Name]** — [Goal from ROADMAP.md]
+
+`gpd:discuss-phase 1`
+
+<sub>`/clear` first for fresh context, then run `gpd:discuss-phase 1`.</sub>
+
+---
+
+**Also available:**
+- `gpd:plan-phase 1` — skip discussion and plan directly
+- `gpd:suggest-next` — confirm the next action
 ```
 
 Use ask_user:
@@ -569,7 +583,7 @@ Use ask_user:
 
 **If "Discuss phase 1":** Tell the user to run `gpd:discuss-phase 1` (and suggest `/clear` first for a fresh context window).
 
-**If "Review artifacts first":** List the files and let the user inspect them. Suggest edits if needed, then re-offer planning.
+**If "Review artifacts first":** List the files and let the user inspect them. Suggest edits if needed, then re-offer `gpd:discuss-phase 1` as primary and `gpd:plan-phase 1` as the direct-plan alternative.
 
 **If "Done for now":** Exit. Remind them to use `gpd:resume-work` or `gpd:discuss-phase 1` when ready.
 
@@ -1471,6 +1485,8 @@ shared_state_policy: return_only
 
 **Handle scout returns:** Route on the full canonical `gpd_return` envelope (`status`, `files_written`, `issues`, and `next_actions`), and fail closed unless `gpd_return.status` is typed and the expected artifact is freshly named in `gpd_return.files_written`. If `checkpoint`, present it to the user, collect the response, and spawn a fresh continuation; do not keep the original scout alive. If `blocked`, surface the blocker, stop this scout path, and do not treat it as a retryable success. If `failed`, surface the failure and retry only once. If `completed`, verify the expected artifact exists on disk and is named in the fresh `gpd_return.files_written`. Treat any preexisting scout file as stale unless the same path appears in the fresh return. Do not trust runtime completion text alone.
 
+Any scout `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-project` (it will detect `GPD/init-progress.json` when present and offer resume) and `gpd:suggest-next`.
+
 **If any research agent fails to spawn or returns an error:** Verify which required scout artifacts exist (`PRIOR-WORK.md`, `METHODS.md`, `COMPUTATIONAL.md`, `PITFALLS.md`). Retry only the missing scout tasks once. If any required research file is still missing after the retry, STOP this survey path and present the missing artifacts. Do not proceed with a partial literature survey. Do not synthesize from incomplete scout output. Do not silently downgrade to manual main-context research.
 
 After all 4 scout artifacts are present on disk and each fresh `gpd_return.files_written` proves its expected artifact, spawn synthesizer to create SUMMARY.md:
@@ -1513,6 +1529,8 @@ shared_state_policy: return_only
 ```
 
 **Handle the synthesizer return:** Route on the full canonical `gpd_return` envelope (`status`, `files_written`, `issues`, and `next_actions`), and fail closed unless `gpd_return.status` is typed and `GPD/literature/SUMMARY.md` is freshly named in `gpd_return.files_written`. If `checkpoint`, present it to the user, collect the response, and spawn a fresh continuation after the response. If `blocked`, surface the blocker and stop this synth path until it is resolved. If `failed`, surface the failure and retry once. If `completed`, verify `GPD/literature/SUMMARY.md` exists and is named in the fresh return. Do not trust runtime completion text alone.
+
+Any synthesizer `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-project` (resume from staged init state when present) and `gpd:suggest-next`.
 
 **Artifact gate:** If a scout reports success but its `expected_artifacts` entry (`GPD/literature/{FILE}`) is missing, treat that scout as incomplete. If the synthesizer reports success but `GPD/literature/SUMMARY.md` is missing, treat that handoff as incomplete. Do not trust the runtime handoff status by itself.
 
@@ -1827,6 +1845,8 @@ If the roadmapper reports `gpd_return.status: completed`, verify that `GPD/ROADM
 - Retry the roadmapper once
 - If the retry still fails, surface the blocker and stop
 
+Any roadmapper `checkpoint`, `blocked`, or final `failed` stop must end with `## > Next Up`: primary `gpd:new-project` (resume from `GPD/init-progress.json` when present), plus `gpd:suggest-next`.
+
 **If `gpd_return.status: completed`:**
 
 Read the created ROADMAP.md and present it nicely inline:
@@ -2036,7 +2056,7 @@ shared_state_policy: direct
    gpd convention set metric_signature "$RESOLVED_METRIC"
    ```
 
-6. Note that full convention establishment was skipped. The user can run `gpd:validate-conventions` or rerun convention setup later, but the fallback lock must match the values written into `GPD/CONVENTIONS.md`.
+6. Note that full convention establishment was skipped. The user can run `gpd:validate-conventions`; the fallback lock must match the values written into `GPD/CONVENTIONS.md`.
 
 - **`CONVENTIONS ESTABLISHED`:** Display confirmation with convention summary. Commit CONVENTIONS.md:
 
@@ -2091,14 +2111,15 @@ Present completion with next steps:
 
 **Phase 1: [Phase Name]** — [Goal from ROADMAP.md]
 
-gpd:discuss-phase 1 — gather context and clarify approach
+`gpd:discuss-phase 1`
 
-<sub>/clear first -> fresh context window</sub>
+<sub>`/clear` first for fresh context, then run `gpd:discuss-phase 1`.</sub>
 
 ---
 
 **Also available:**
-- gpd:plan-phase 1 — skip discussion, plan directly
+- `gpd:plan-phase 1` — skip discussion and plan directly
+- `gpd:suggest-next` — confirm the next action
 
 ---------------------------------------------------------------
 ```

--- a/src/gpd/specs/workflows/plan-phase.md
+++ b/src/gpd/specs/workflows/plan-phase.md
@@ -138,13 +138,13 @@ bind_plan_phase_init "$INIT"
 
 **If `planning_exists` is false:** Error -- run `gpd:new-project` first.
 
-**If `project_contract_load_info.status` starts with `blocked`:** STOP and checkpoint with the user. Show the specific `project_contract_load_info.errors` / `warnings`; do not silently continue from `ROADMAP.md` or `REQUIREMENTS.md` alone when the stored contract could not even be loaded cleanly.
+**If `project_contract_load_info.status` starts with `blocked`:** STOP and checkpoint with the user. Show the specific `project_contract_load_info.errors` / `warnings`; do not silently continue from `ROADMAP.md` or `REQUIREMENTS.md` alone when the stored contract could not even be loaded cleanly. End with `## > Next Up`: primary `gpd:sync-state`, then `gpd:plan-phase {PHASE}` after repair, plus `gpd:suggest-next`.
 
-**If `project_contract` is empty or null:** STOP and checkpoint with the user. Planning requires an approved scoping contract in `GPD/state.json`; do not infer phase scope from `ROADMAP.md` or `REQUIREMENTS.md` alone.
+**If `project_contract` is empty or null:** STOP and checkpoint with the user. Planning requires an approved scoping contract in `GPD/state.json`; do not infer phase scope from `ROADMAP.md` or `REQUIREMENTS.md` alone. End with `## > Next Up`: primary `gpd:new-project` for project setup repair or `gpd:sync-state` if state exists but drifted, then `gpd:plan-phase {PHASE}`, plus `gpd:suggest-next`.
 
 **Treat `project_contract` as authoritative only when `project_contract_gate.authoritative` is true.** If the gate is false, keep the contract visible as context and diagnostics, not as approved planning scope.
 
-**If `project_contract_validation.valid` is false:** STOP and checkpoint with the user. Quote the `project_contract_validation.errors` explicitly and repair the contract before planning; a visible-but-blocked contract is not an approved planning contract.
+**If `project_contract_validation.valid` is false:** STOP and checkpoint with the user. Quote the `project_contract_validation.errors` explicitly and repair the contract before planning; a visible-but-blocked contract is not an approved planning contract. End with `## > Next Up`: primary `gpd:sync-state`, then `gpd:plan-phase {PHASE}` after repair, plus `gpd:suggest-next`.
 
 ## 1.5 Proof-Obligation Planning Gate
 

--- a/src/gpd/specs/workflows/research-phase.md
+++ b/src/gpd/specs/workflows/research-phase.md
@@ -187,12 +187,12 @@ Human-readable headings such as `## RESEARCH COMPLETE` and `## CHECKPOINT REACHE
 
 ## Step 5: Handle Return
 
-**If the researcher agent fails to spawn or returns an error:** Report the failure. Offer: 1) Retry with the same context, 2) Execute the research in the main context (slower but reliable), 3) Skip research and proceed to `gpd:plan-phase` directly (planner will work with less context). Do not silently continue without research output.
+**If the researcher agent fails to spawn or returns an error:** Report the failure. End with `## > Next Up`: primary `gpd:research-phase {phase_number}` to retry, plus `gpd:plan-phase {phase_number}` to skip research and plan directly, and `gpd:suggest-next`. Do not silently continue without research output.
 
-- **Artifact gate:** If `gpd_return.status: completed` but the `expected_artifacts` entry (`RESEARCH.md`) is missing from the phase directory or absent from `gpd_return.files_written`, treat the handoff as incomplete. Offer: 1) Retry researcher, 2) Execute the research in the main context, 3) Abort.
-- `gpd_return.status: completed` -- Display summary, offer: Plan/Dig deeper/Review/Done
-- `gpd_return.status: checkpoint` -- Present the checkpoint to the user, collect the response, and spawn a fresh continuation handoff. Do not resume the same spawned run.
-- `gpd_return.status: blocked` or `failed` -- Show attempts, offer: Add context/Try different approach/Manual
+- **Artifact gate:** If `gpd_return.status: completed` but the `expected_artifacts` entry (`RESEARCH.md`) is missing from the phase directory or absent from `gpd_return.files_written`, treat the handoff as incomplete. End with `## > Next Up`: primary `gpd:research-phase {phase_number}` to retry, plus `gpd:plan-phase {phase_number}` and `gpd:suggest-next`.
+- `gpd_return.status: completed` -- Display summary and end with `## > Next Up`: primary `gpd:plan-phase {phase_number}`, plus `gpd:research-phase {phase_number}` to dig deeper, `gpd:show-phase {phase_number}` to review, and `gpd:suggest-next`.
+- `gpd_return.status: checkpoint` -- Present the checkpoint to the user, collect the response, spawn a fresh continuation handoff, and end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:research-phase {phase_number}` and `gpd:suggest-next`. Do not resume the same spawned run.
+- `gpd_return.status: blocked` or `failed` -- Show attempts and end with `## > Next Up`: primary `gpd:discuss-phase {phase_number}` to add context, plus `gpd:research-phase {phase_number}` and `gpd:suggest-next`.
 
 ## Step 6: Spawn Continuation Researcher
 

--- a/src/gpd/specs/workflows/respond-to-referees.md
+++ b/src/gpd/specs/workflows/respond-to-referees.md
@@ -49,7 +49,7 @@ RESEARCH_MODE=$(echo "$INIT" | gpd json get .research_mode --default balanced)
 - Accept the literal `paste` sentinel as an explicit report source.
 - Preserve the legacy shorthand `gpd:respond-to-referees path/to/report.md` or `gpd:respond-to-referees paste` only when the manuscript subject still resolves from the current GPD project.
 - Treat a bare positional path as a referee-report source only. Do not reinterpret it as the manuscript subject for this workflow.
-- Keep all GPD-authored auxiliary outputs under `GPD/` even when the manuscript subject itself is external; manuscript edits still occur in place on the resolved manuscript subject.
+- Keep all GPD-authored auxiliary outputs under `GPD/` even when the manuscript subject itself is external, and keep manuscript edits on the resolved manuscript subject.
 - Project-backed response rounds keep the current global `GPD/` / `GPD/review/` ownership. If centralized preflight resolves an explicit external publication subject with a managed subject-owned publication root at `GPD/publication/{subject_slug}`, keep the same round-artifact family inside that managed root instead of writing sidecars beside `${PAPER_DIR}`.
 - Set `PREFLIGHT_ARGUMENTS` to the validator-safe normalized intake string before shelling out. For the explicit `--manuscript ... --report ...` lane, keep the normalized manuscript/report payload in that single variable and do not explode it back into separate validator argv tokens.
 

--- a/src/gpd/specs/workflows/validate-conventions.md
+++ b/src/gpd/specs/workflows/validate-conventions.md
@@ -162,8 +162,8 @@ If either check fails, treat the handoff as incomplete and do not accept success
 Route only on the canonical `gpd_return.status`:
 
 - `gpd_return.status: completed` means the checker finished for the selected scope. Surface any advisory items from `gpd_return.issues`, but do not reinterpret the status text.
-- `gpd_return.status: checkpoint` means the checker needs user input. Present the checkpoint, offer the user the next action, and stop. Present options, checkpoint, and return.
-- `gpd_return.status: blocked` or `gpd_return.status: failed` means the checker could not complete. Surface `gpd_return.issues`, keep the run fail-closed, and stop.
+- `gpd_return.status: checkpoint` means the checker needs user input. Present options, checkpoint, and return. End with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:validate-conventions` and `gpd:suggest-next`.
+- `gpd_return.status: blocked` or `gpd_return.status: failed` means the checker could not complete. Surface `gpd_return.issues`, keep the run fail-closed, and end with `## > Next Up`: primary `gpd:validate-conventions`, plus `gpd:resume-work`, `gpd convention set <key> <value>` when a lock repair is known, and `gpd:suggest-next`.
 
 Do not route on checker-local text markers or headings. Those are presentation only; route only on the canonical `gpd_return.status`.
 

--- a/src/gpd/specs/workflows/verify-phase.md
+++ b/src/gpd/specs/workflows/verify-phase.md
@@ -660,6 +660,7 @@ If expert_needed: list items requiring expert review with explanation of why com
 If human_needed: list items requiring non-expert human review with explanation of why computational verification was insufficient.
 
 Orchestrator routes: `passed` -> update_roadmap | `gaps_found` -> create/execute fixes, re-verify | `expert_needed` -> present to researcher/expert review | `human_needed` -> present to researcher.
+When this workflow returns directly to the user or a blocking status stops orchestration, include concrete `next_actions`: `gpd:plan-phase {phase} --gaps` for gaps, `gpd:verify-work {phase}` to rerun verification, `gpd:show-phase {phase}` to review artifacts, and `gpd:suggest-next` as the recovery/confirmation route.
 </step>
 
 </process>

--- a/src/gpd/specs/workflows/verify-work.md
+++ b/src/gpd/specs/workflows/verify-work.md
@@ -293,9 +293,9 @@ Read the verifier-produced verification file or report path.
   2. the same path appears in `gpd_return.files_written`
   3. `gpd validate verification-contract "${phase_dir}/${phase_number}-VERIFICATION.md"` passes before any downstream routing
 - If a canonical verification file already existed before this run, do not treat it as fresh verifier output unless the child reported that same path in `gpd_return.files_written`.
-- `gpd_return.status: checkpoint` means present the verifier checkpoint, collect user input, and spawn a fresh verifier continuation. Do not overwrite canonical verification status in this workflow.
-- `gpd_return.status: blocked` or `failed` means keep the session fail-closed, present the issues, and offer retry or manual follow-up. Do not treat any preexisting verification file as a new verifier result on this path.
-- If the verifier agent fails to spawn or returns an error, keep the session fail-closed. Do not let a stale existing verification file satisfy the success path.
+- `gpd_return.status: checkpoint` means present the verifier checkpoint, collect user input, spawn a fresh verifier continuation, and end the stop with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:verify-work ${phase_number}` and `gpd:suggest-next`. Do not overwrite canonical verification status in this workflow.
+- `gpd_return.status: blocked` or `failed` means keep the session fail-closed, present the issues, and end with `## > Next Up`: primary `gpd:verify-work ${phase_number}`, plus `gpd:resume-work` and `gpd:suggest-next`. Do not treat any preexisting verification file as a new verifier result on this path.
+- If the verifier agent fails to spawn or returns an error, keep the session fail-closed. End with the same `gpd:verify-work ${phase_number}` Next Up route. Do not let a stale existing verification file satisfy the success path.
 - If the canonical verification artifact is missing, unreadable, absent from `gpd_return.files_written`, or fails contract validation, treat the handoff as incomplete and request a fresh verifier continuation. Never trust the return text alone.
 - If a canonical verification file already exists, preserve its authoritative frontmatter and append only the session-local overlay here.
 - Do not recompute canonical verification status in this workflow.
@@ -457,10 +457,10 @@ Use `templates/planner-subagent-prompt.md` to build the gap_closure planner hand
 
 Before treating the handoff as complete, verify that the expected `PLAN.md` files exist in the phase directory and are listed in `gpd_return.files_written` from the fresh planner run.
 After the planner returns, route on `gpd_return.status`, not on headings. If `gpd_return.status` is `completed`, verify that each expected path is present on disk, readable, and present in `gpd_return.files_written` before treating the handoff as complete.
-If `gpd_return.status` is `checkpoint`, present the checkpoint, collect user input, and spawn a fresh planner continuation from the staged gap-repair payload instead of waiting inside the same run.
-If the planner reports `blocked` or `failed`, or if the expected `PLAN.md` files are missing, unreadable, stale, or absent from `gpd_return.files_written`, keep the session fail-closed and offer retry or manual plan creation.
+If `gpd_return.status` is `checkpoint`, present the checkpoint, collect user input, spawn a fresh planner continuation from the staged gap-repair payload instead of waiting inside the same run, and end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:plan-phase ${phase_number} --gaps` and `gpd:suggest-next`.
+If the planner reports `blocked` or `failed`, or if the expected `PLAN.md` files are missing, unreadable, stale, or absent from `gpd_return.files_written`, keep the session fail-closed and end with `## > Next Up`: primary `gpd:plan-phase ${phase_number} --gaps`, plus `gpd:resume-work` and `gpd:suggest-next`.
 
-If the planner fails to spawn or returns an error, keep the session fail-closed and offer retry or manual plan creation. Do not fall through to gap verification on the basis of preexisting `PLAN.md` files alone.
+If the planner fails to spawn or returns an error, keep the session fail-closed and offer retry or manual plan creation. Do not fall through to gap verification on the basis of preexisting `PLAN.md` files alone. End with the same `gpd:plan-phase ${phase_number} --gaps` Next Up route.
 </step>
 
 <step name="verify_gap_plans">
@@ -487,9 +487,9 @@ If the checker fails to spawn or returns an error, proceed without plan verifica
 If the checker returns a structured `gpd_return`, route on `gpd_return.status` and the structured plan lists, not on presentation text:
 
 - `completed`: treat the fresh fix plans as verified only after the on-disk files still match the planner's `files_written` set.
-- `checkpoint`: some plans are approved and others need revision; record `approved_plans` and `blocked_plans`, then send only the blocked plans back through the revision loop.
-- `blocked`: nothing is approved; feed the checker issues and blocked plan IDs back into the revision loop without rewriting approved plans.
-- `failed`: present the issues and offer retry or manual revision.
+- `checkpoint`: some plans are approved and others need revision; record `approved_plans` and `blocked_plans`, then send only the blocked plans back through the revision loop. If stopping for user input, end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:plan-phase ${phase_number} --gaps` and `gpd:suggest-next`.
+- `blocked`: nothing is approved; feed the checker issues and blocked plan IDs back into the revision loop without rewriting approved plans. If stopping, use the same Next Up route.
+- `failed`: present the issues and offer retry or manual revision. End with `## > Next Up`: primary `gpd:plan-phase ${phase_number} --gaps`, plus `gpd:resume-work` and `gpd:suggest-next`.
 </step>
 
 <step name="revision_loop">
@@ -505,6 +505,8 @@ If iteration count reaches 3, stop and offer the user:
 1. Force proceed
 2. Provide guidance and retry
 3. Abandon and exit
+
+End that stop with `## > Next Up`: primary `gpd:plan-phase ${phase_number} --gaps`, plus `gpd:execute-phase ${phase_number} --gaps-only`, `gpd:verify-work ${phase_number}`, and `gpd:suggest-next`.
 </step>
 
 <step name="complete_session">
@@ -525,6 +527,14 @@ gpd commit "verify(${phase_number}): complete research validation - {passed} pas
 ```
 
 Present the summary of passed, issue, and skipped checks. Do not relax verifier fail-closed results.
+
+End with `## > Next Up`:
+
+- If verification passed and more phases remain: primary `gpd:discuss-phase ${next_phase}` when context is missing, otherwise `gpd:plan-phase ${next_phase}`
+- If verification passed and the milestone is complete: primary `gpd:complete-milestone`
+- If gaps remain: primary `gpd:plan-phase ${phase_number} --gaps`; after gap plans exist, `gpd:execute-phase ${phase_number} --gaps-only`; confirm with `gpd:verify-work ${phase_number}`
+- Always include `gpd:suggest-next` as the recovery/confirmation command
+- Include `<sub>\`/clear\` first for fresh context, then run the primary command above.</sub>`
 </step>
 
 </process>

--- a/tests/adapters/test_runtime_projected_command_requirement_coverage.py
+++ b/tests/adapters/test_runtime_projected_command_requirement_coverage.py
@@ -56,13 +56,20 @@ def _project_command(command_name: str, runtime: str) -> str:
     return projected
 
 
+def _runtime_command_visibility_note(runtime: str) -> str:
+    note = command_visibility_note()
+    if runtime == "codex":
+        return note.replace("`gpd:suggest-next`", "`$gpd-suggest-next`")
+    return note
+
+
 @pytest.mark.parametrize("runtime", RUNTIMES)
 @pytest.mark.parametrize("command_name", COMMANDS_WITH_REQUIREMENTS)
 def test_runtime_projected_commands_keep_requirements_visible(command_name: str, runtime: str) -> None:
     command_requires = _command_requirements(command_name)
     projected = _project_command(command_name, runtime)
 
-    assert command_visibility_note() in projected
+    assert _runtime_command_visibility_note(runtime) in projected
     assert projected.count("## Command Requirements") == 1
 
     for require_key, require_value in command_requires.items():

--- a/tests/adapters/test_runtime_projected_prompt_parity.py
+++ b/tests/adapters/test_runtime_projected_prompt_parity.py
@@ -55,6 +55,12 @@ def _contract_bearing_command_surfaces() -> dict[str, tuple[str, ...]]:
     return surfaces
 
 
+def _runtime_expected_fragments(fragments: tuple[str, ...], *, runtime: str) -> tuple[str, ...]:
+    if runtime == "codex":
+        return tuple(fragment.replace("`gpd:suggest-next`", "`$gpd-suggest-next`") for fragment in fragments)
+    return fragments
+
+
 def _spawn_contract_commands() -> tuple[str, ...]:
     return tuple(command_name for command_name in _command_names() if "<spawn_contract>" in _read(COMMANDS_DIR / f"{command_name}.md"))
 
@@ -118,7 +124,7 @@ def _extract_spawn_contracts(text: str) -> list[dict[str, object]]:
 def test_runtime_projected_commands_keep_model_visible_contract_wrappers(command_name: str, expected_fragments: tuple[str, ...], runtime: str) -> None:
     projected = _project_markdown(COMMANDS_DIR / f"{command_name}.md", runtime, is_agent=False)
 
-    for fragment in expected_fragments:
+    for fragment in _runtime_expected_fragments(expected_fragments, runtime=runtime):
         assert fragment in projected, f"{runtime} {command_name} missing {fragment!r}"
 
 

--- a/tests/core/test_contract_validation.py
+++ b/tests/core/test_contract_validation.py
@@ -20,6 +20,7 @@ from gpd.contracts import (
     ProjectContractParseResult,
     ResearchContract,
     SuggestedContractCheck,
+    _split_missing_must_surface_anchor_findings,
     claim_requires_proof_audit,
     collect_plan_contract_integrity_errors,
     contract_from_data,
@@ -1873,6 +1874,23 @@ def test_validate_project_contract_approved_mode_accepts_non_reference_grounding
     assert result.valid is True
     assert result.mode == "approved"
     assert "references must include at least one must_surface=true anchor" in result.warnings
+
+
+def test_split_missing_must_surface_anchor_findings_warns_only_when_other_grounding_exists(
+    tmp_path: Path,
+) -> None:
+    contract = _load_contract_fixture()
+    contract["references"][0]["must_surface"] = False
+    prior_output = tmp_path / "GPD" / "phases" / "00-baseline" / "00-01-SUMMARY.md"
+    prior_output.parent.mkdir(parents=True)
+    prior_output.write_text("# Summary\n", encoding="utf-8")
+    contract["context_intake"]["must_include_prior_outputs"] = ["GPD/phases/00-baseline/00-01-SUMMARY.md"]
+    parsed = ResearchContract.model_validate(contract)
+
+    errors, warnings = _split_missing_must_surface_anchor_findings(parsed, project_root=tmp_path, mode="approved")
+
+    assert errors == []
+    assert warnings == ["references must include at least one must_surface=true anchor"]
 
 
 def test_validate_project_contract_approved_mode_rejects_nonexistent_prior_output_grounding(tmp_path: Path) -> None:

--- a/tests/core/test_health.py
+++ b/tests/core/test_health.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import shutil
 import subprocess
@@ -14,7 +15,7 @@ from unittest.mock import patch
 import pytest
 
 import gpd.core.health as health_module
-from gpd.core.constants import ProjectLayout
+from gpd.core.constants import STATE_LINES_TARGET, ProjectLayout
 from gpd.core.contract_validation import validate_project_contract
 from gpd.core.errors import ValidationError
 from gpd.core.frontmatter import compute_knowledge_reviewed_content_sha256
@@ -1012,6 +1013,17 @@ class TestCheckCompaction:
         (planning / "STATE.md").write_text("# State\nShort content\n", encoding="utf-8")
         result = check_compaction_needed(tmp_path)
         assert result.status == CheckStatus.OK
+
+    def test_trailing_newline_does_not_overcount_lines(self, tmp_path: Path):
+        planning = tmp_path / "GPD"
+        planning.mkdir()
+        content = "\n".join(f"line {index}" for index in range(STATE_LINES_TARGET)) + "\n"
+        (planning / "STATE.md").write_text(content, encoding="utf-8")
+
+        result = check_compaction_needed(tmp_path)
+
+        assert result.status == CheckStatus.OK
+        assert result.details["lines"] == STATE_LINES_TARGET
 
 
 class TestCheckOrphans:
@@ -2533,6 +2545,42 @@ class TestCheckLatestReturn:
         assert result.status == CheckStatus.FAIL
         assert "tasks_completed not a number" in result.issues[0] or "tasks_completed not a number" in " ".join(result.issues)
         assert "tasks_total not a number" in " ".join(result.issues)
+
+    def test_identical_mtime_uses_phase_order_not_lexicographic_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cwd = _bootstrap_health_project(tmp_path)
+        phases_dir = cwd / "GPD" / "phases"
+        early = phases_dir / "02.2-old"
+        late = phases_dir / "02.10-new"
+        early.mkdir(parents=True)
+        late.mkdir(parents=True)
+        early_summary = early / "SUMMARY.md"
+        late_summary = late / "SUMMARY.md"
+        early_summary.write_text("# Summary\n", encoding="utf-8")
+        late_summary.write_text("# Summary\n", encoding="utf-8")
+
+        same_mtime = 1_700_000_000_000_000_000
+        os.utime(early_summary, ns=(same_mtime, same_mtime))
+        os.utime(late_summary, ns=(same_mtime, same_mtime))
+
+        monkeypatch.setattr(
+            health_module,
+            "cmd_validate_return",
+            lambda path: SimpleNamespace(
+                passed=True,
+                errors=[],
+                warnings=[],
+                fields={"status": "completed"},
+                warning_count=0,
+            ),
+        )
+
+        result = check_latest_return(cwd)
+
+        assert result.status == CheckStatus.OK
+        assert result.details["file"] == "02.10-new/SUMMARY.md"
+        assert result.details["summary_path"] == str(late_summary)
 
 
 class TestCheckResultConsistency:

--- a/tests/core/test_phase10_typed_return_prompt_cleanup.py
+++ b/tests/core/test_phase10_typed_return_prompt_cleanup.py
@@ -30,7 +30,7 @@ def test_roadmapper_prompt_example_includes_required_base_return_fields() -> Non
     assert "status: completed | checkpoint | blocked | failed" in envelope
     assert "files_written: [ROADMAP.md, STATE.md]" in envelope
     assert "issues: [list of issues encountered, if any]" in envelope
-    assert "next_actions: [list of recommended follow-up actions]" in envelope
+    assert "next_actions: [concrete commands or exact artifact review actions]" in envelope
     assert "phases_created: {count}" in envelope
     assert "base fields (status, files_written, issues, next_actions)" not in roadmapper
 
@@ -63,7 +63,7 @@ def test_phase_researcher_machine_readable_return_is_typed_first() -> None:
     assert "status: completed | checkpoint | blocked | failed" in researcher
     assert "files_written: [$PHASE_DIR/$PADDED_PHASE-RESEARCH.md]" in researcher
     assert "issues: [list of issues encountered, if any]" in researcher
-    assert "next_actions: [list of recommended follow-up actions]" in researcher
+    assert "next_actions: [concrete commands or exact artifact review actions]" in researcher
     assert "confidence: HIGH | MEDIUM | LOW" in researcher
     assert "Mapping: RESEARCH COMPLETE → completed, RESEARCH BLOCKED → blocked" not in researcher
     assert "Headings above are presentation only; route on gpd_return.status." in researcher
@@ -75,7 +75,7 @@ def test_executor_completion_spawned_handoff_example_keeps_base_fields_and_exten
     assert "status: completed | checkpoint | blocked | failed" in completion
     assert 'files_written: ["GPD/phases/XX-name/{phase}-{plan}-SUMMARY.md"]' in completion
     assert "issues: [list of issues encountered, if any]" in completion
-    assert "next_actions: [list of recommended follow-up actions]" in completion
+    assert "next_actions: [concrete commands or exact artifact review actions]" in completion
     assert "state_updates:" in completion
     assert "advance_plan: true" in completion
     assert "update_progress: true" in completion

--- a/tests/core/test_phase11_plan_checker_bibliographer_prompt_cleanup.py
+++ b/tests/core/test_phase11_plan_checker_bibliographer_prompt_cleanup.py
@@ -31,7 +31,7 @@ def test_plan_checker_prompt_uses_typed_status_and_concise_presentation_language
     assert "status: completed | checkpoint | blocked | failed" in envelope
     assert "files_written: []" in envelope
     assert "issues: [issue objects from Issue Format above]" in envelope
-    assert "next_actions: [list of recommended follow-up actions]" in envelope
+    assert "next_actions: [concrete commands or exact artifact review actions]" in envelope
     assert "approved_plans: [list of plan IDs that passed]" in envelope
     assert "blocked_plans: [list of plan IDs needing revision or escalation]" in envelope
 
@@ -49,7 +49,7 @@ def test_bibliographer_prompt_uses_typed_checkpoint_language_and_shorter_heading
     assert "status: completed | checkpoint | blocked | failed" in envelope
     assert "files_written: [references/references.bib, GPD/references-status.json]" in envelope
     assert "issues: [list of citation problems, if any]" in envelope
-    assert "next_actions: [list of recommended follow-up actions]" in envelope
+    assert "next_actions: [concrete commands or exact artifact review actions]" in envelope
     assert "entries_added: N" in envelope
     assert "{GPD_INSTALL_DIR}/references/publication/publication-pipeline-modes.md" in source
     assert "@{GPD_INSTALL_DIR}/references/publication/publication-pipeline-modes.md" not in source

--- a/tests/core/test_phase11_publication_agent_prompt_cleanup.py
+++ b/tests/core/test_phase11_publication_agent_prompt_cleanup.py
@@ -46,7 +46,7 @@ def test_paper_writer_return_example_shows_required_base_fields_before_extension
     assert "status: completed | checkpoint | blocked | failed" in envelope
     assert "files_written: [{resolved_manuscript_root}/{section_file}.tex]" in envelope
     assert "issues: [list of issues encountered, if any]" in envelope
-    assert "next_actions: [list of recommended follow-up actions]" in envelope
+    assert "next_actions: [concrete commands or exact artifact review actions]" in envelope
     assert 'section_name: "{section drafted}"' in envelope
     assert envelope.index("status: completed | checkpoint | blocked | failed") < envelope.index(
         "files_written: [{resolved_manuscript_root}/{section_file}.tex]"
@@ -55,9 +55,9 @@ def test_paper_writer_return_example_shows_required_base_fields_before_extension
         "issues: [list of issues encountered, if any]"
     )
     assert envelope.index("issues: [list of issues encountered, if any]") < envelope.index(
-        "next_actions: [list of recommended follow-up actions]"
+        "next_actions: [concrete commands or exact artifact review actions]"
     )
-    assert envelope.index("next_actions: [list of recommended follow-up actions]") < envelope.index(
+    assert envelope.index("next_actions: [concrete commands or exact artifact review actions]") < envelope.index(
         'section_name: "{section drafted}"'
     )
     assert "base fields (status, files_written, issues, next_actions)" not in source
@@ -82,7 +82,7 @@ def test_bibliographer_prompt_uses_typed_status_and_base_field_first_return_exam
     assert "status: completed | checkpoint | blocked | failed" in envelope
     assert "files_written: [references/references.bib, GPD/references-status.json]" in envelope
     assert "issues: [list of citation problems, if any]" in envelope
-    assert "next_actions: [list of recommended follow-up actions]" in envelope
+    assert "next_actions: [concrete commands or exact artifact review actions]" in envelope
     assert "entries_added: N" in envelope
     assert envelope.index("status: completed | checkpoint | blocked | failed") < envelope.index(
         "files_written: [references/references.bib, GPD/references-status.json]"
@@ -91,7 +91,9 @@ def test_bibliographer_prompt_uses_typed_status_and_base_field_first_return_exam
         "issues: [list of citation problems, if any]"
     )
     assert envelope.index("issues: [list of citation problems, if any]") < envelope.index(
-        "next_actions: [list of recommended follow-up actions]"
+        "next_actions: [concrete commands or exact artifact review actions]"
     )
-    assert envelope.index("next_actions: [list of recommended follow-up actions]") < envelope.index("entries_added: N")
+    assert envelope.index("next_actions: [concrete commands or exact artifact review actions]") < envelope.index(
+        "entries_added: N"
+    )
     assert "base fields (status, files_written, issues, next_actions)" not in source

--- a/tests/core/test_phase11_review_agent_prompt_cleanup.py
+++ b/tests/core/test_phase11_review_agent_prompt_cleanup.py
@@ -22,7 +22,7 @@ def test_referee_routes_on_status_and_shows_base_return_fields_first() -> None:
     status_idx = source.index("  status: completed | checkpoint | blocked | failed")
     files_idx = source.index("  files_written:")
     issues_idx = source.index("  issues: [list of blocking or unresolved review issues, if any]")
-    next_actions_idx = source.index("  next_actions: [list of recommended follow-up actions]")
+    next_actions_idx = source.index("  next_actions: [concrete commands or exact artifact review actions]")
     recommendation_idx = source.index('  recommendation: "{accept | minor_revision | major_revision | reject}"')
 
     assert status_idx < files_idx < issues_idx < next_actions_idx < recommendation_idx
@@ -35,7 +35,7 @@ def test_project_researcher_uses_presentation_only_heading_mapping_and_base_fiel
     assert "status: completed | checkpoint | blocked | failed" in source
     assert "files_written: [GPD/literature/SUMMARY.md, GPD/literature/METHODS.md, ...]" in source
     assert "issues: [list of issues encountered, if any]" in source
-    assert "next_actions: [list of recommended follow-up actions]" in source
+    assert "next_actions: [concrete commands or exact artifact review actions]" in source
     assert "confidence: HIGH | MEDIUM | LOW" in source
     assert "Mapping: RESEARCH COMPLETE → completed, RESEARCH BLOCKED → blocked" not in source
     assert "Headings above are presentation only; route on gpd_return.status." in source
@@ -43,7 +43,7 @@ def test_project_researcher_uses_presentation_only_heading_mapping_and_base_fiel
     status_idx = source.index("  status: completed | checkpoint | blocked | failed")
     files_idx = source.index("  files_written: [GPD/literature/SUMMARY.md, GPD/literature/METHODS.md, ...]")
     issues_idx = source.index("  issues: [list of issues encountered, if any]")
-    next_actions_idx = source.index("  next_actions: [list of recommended follow-up actions]")
+    next_actions_idx = source.index("  next_actions: [concrete commands or exact artifact review actions]")
     confidence_idx = source.index("  confidence: HIGH | MEDIUM | LOW")
 
     assert status_idx < files_idx < issues_idx < next_actions_idx < confidence_idx
@@ -65,7 +65,7 @@ def test_plan_checker_uses_typed_status_and_drops_nested_return_payload_examples
     status_idx = source.index("  status: completed | checkpoint | blocked | failed")
     files_idx = source.index("  files_written: []")
     issues_idx = source.index("  issues: [issue objects from Issue Format above]")
-    next_actions_idx = source.index("  next_actions: [list of recommended follow-up actions]")
+    next_actions_idx = source.index("  next_actions: [concrete commands or exact artifact review actions]")
     approved_idx = source.index("  approved_plans: [list of plan IDs that passed]")
 
     assert status_idx < files_idx < issues_idx < next_actions_idx < approved_idx

--- a/tests/core/test_prompt_cli_consistency.py
+++ b/tests/core/test_prompt_cli_consistency.py
@@ -740,3 +740,16 @@ def test_execute_phase_failure_recovery_counts_only_top_level_verification_statu
     )
     assert 'grep -c "status: failed"' not in workflow
     assert 'grep -c "status:"' not in workflow
+
+
+def test_execute_phase_closeout_always_surfaces_concrete_next_commands() -> None:
+    workflow = (REPO_ROOT / "src/gpd/specs/workflows/execute-phase.md").read_text(encoding="utf-8")
+
+    assert 'Never end with only "ready to plan/continue" prose.' in workflow
+    assert "make `gpd:discuss-phase {X+1}` the primary command" in workflow
+    assert "make `gpd:plan-phase {X+1}` the primary command" in workflow
+    assert "Always include `gpd:suggest-next`" in workflow
+    assert "Primary: `gpd:discuss-phase {X+1}`\nDirect plan alternative: `gpd:plan-phase {X+1}`" in workflow
+    assert "Primary: `gpd:plan-phase {X+1}`" in workflow
+    assert "Confirm next action: `gpd:suggest-next`" in workflow
+    assert "Primary: `gpd:discuss-phase {X+1}` if context is missing" not in workflow

--- a/tests/core/test_prompt_cli_consistency.py
+++ b/tests/core/test_prompt_cli_consistency.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from gpd.adapters.install_utils import expand_at_includes
 from gpd.core import public_surface_contract as public_surface_contract_module
 from gpd.core.cli_args import _ROOT_GLOBAL_FLAG_TOKENS
+from gpd.core.model_visible_text import command_visibility_note
 from gpd.core.public_surface_contract import (
     local_cli_bridge_note,
     local_cli_doctor_global_command,
@@ -746,10 +747,59 @@ def test_execute_phase_closeout_always_surfaces_concrete_next_commands() -> None
     workflow = (REPO_ROOT / "src/gpd/specs/workflows/execute-phase.md").read_text(encoding="utf-8")
 
     assert 'Never end with only "ready to plan/continue" prose.' in workflow
+    assert "choose exactly one matching variant" in workflow
     assert "make `gpd:discuss-phase {X+1}` the primary command" in workflow
     assert "make `gpd:plan-phase {X+1}` the primary command" in workflow
     assert "Always include `gpd:suggest-next`" in workflow
-    assert "Primary: `gpd:discuss-phase {X+1}`\nDirect plan alternative: `gpd:plan-phase {X+1}`" in workflow
-    assert "Primary: `gpd:plan-phase {X+1}`" in workflow
-    assert "Confirm next action: `gpd:suggest-next`" in workflow
+    assert "Primary: `{chosen primary command}`" in workflow
+    assert "`gpd:complete-milestone`" in workflow
+    assert "**Also available:** `gpd:suggest-next`" in workflow
     assert "Primary: `gpd:discuss-phase {X+1}` if context is missing" not in workflow
+    assert "If context is missing:" not in workflow
+    assert "If context exists:" not in workflow
+
+
+def test_command_requirements_force_concrete_next_up_for_stops() -> None:
+    note = command_visibility_note()
+
+    assert "completion, checkpoint, blocked return, failed return, retry gate, or stop" in note
+    assert "must end with a concrete `## > Next Up` or `## >> Next Up` section" in note
+    assert "copy-pasteable GPD commands" in note
+    assert "`gpd:suggest-next`" in note
+
+
+def test_continuation_format_covers_stop_and_checkpoint_routes() -> None:
+    continuation = (
+        REPO_ROOT / "src/gpd/specs/references/orchestration/continuation-format.md"
+    ).read_text(encoding="utf-8")
+
+    assert "## Stop And Checkpoint Rules" in continuation
+    for command in (
+        "`gpd:resume-work`",
+        "`gpd:new-project --minimal @file.md`",
+        "`gpd:discuss-phase N`",
+        "`gpd:plan-phase N --gaps`",
+        "`gpd:execute-phase N --gaps-only`",
+        "`gpd:verify-work N`",
+        "`gpd:validate-conventions`",
+        "`gpd:suggest-next`",
+    ):
+        assert command in continuation
+
+
+def test_new_project_and_new_milestone_closeouts_include_concrete_next_up_commands() -> None:
+    new_project = (WORKFLOWS_DIR / "new-project.md").read_text(encoding="utf-8")
+    new_milestone = (WORKFLOWS_DIR / "new-milestone.md").read_text(encoding="utf-8")
+    new_milestone_command = (COMMANDS_DIR / "new-milestone.md").read_text(encoding="utf-8")
+
+    assert "Stop after this error with `## > Next Up`" in new_project
+    assert "`gpd:discuss-phase 1`" in new_project
+    assert "`gpd:plan-phase 1`" in new_project
+    assert "`gpd:suggest-next`" in new_project
+    assert "re-offer `gpd:discuss-phase 1` as primary" in new_project
+
+    assert "`gpd:discuss-phase [N]`" in new_milestone
+    assert "`gpd:plan-phase [N]`" in new_milestone
+    assert "`gpd:suggest-next`" in new_milestone
+    assert "primary `gpd:new-milestone [milestone name]`" in new_milestone
+    assert "**After:** `gpd:discuss-phase [N]`" in new_milestone_command

--- a/tests/core/test_prompt_wiring.py
+++ b/tests/core/test_prompt_wiring.py
@@ -999,7 +999,7 @@ def test_respond_to_referees_references_staged_review_artifacts() -> None:
     workflow_text = (WORKFLOWS_DIR / "respond-to-referees.md").read_text(encoding="utf-8")
     writer_text = (AGENTS_DIR / "gpd-paper-writer.md").read_text(encoding="utf-8")
 
-    assert "argument-hint: \"[path to referee report or 'paste']\"" in command_text
+    assert "argument-hint: \"[--manuscript PATH] (--report PATH [--report PATH...] | paste)\"" in command_text
     assert "@{GPD_INSTALL_DIR}/references/publication/publication-review-wrapper-guidance.md" in command_text
     assert "Referee report source: $ARGUMENTS (file path or `paste`)." in command_text
     assert "subject-owned publication root at `GPD/publication/{subject_slug}`" in command_text
@@ -1094,6 +1094,7 @@ def test_publication_commands_accept_documented_manuscript_layouts() -> None:
     peer_review = (COMMANDS_DIR / "peer-review.md").read_text(encoding="utf-8")
     respond = (COMMANDS_DIR / "respond-to-referees.md").read_text(encoding="utf-8")
     arxiv = (COMMANDS_DIR / "arxiv-submission.md").read_text(encoding="utf-8")
+    respond_command = registry.get_command("respond-to-referees")
 
     assert "context_mode: project-aware" in write_paper
     assert "--intake path/to/paper-authoring-input.json" in write_paper
@@ -1102,7 +1103,16 @@ def test_publication_commands_accept_documented_manuscript_layouts() -> None:
     assert "`paper/`, `manuscript/`, and `draft/`" in peer_review
     assert "subject-owned publication root at `GPD/publication/{subject_slug}`" in peer_review
     assert "current global `GPD/` / `GPD/review/` round-artifact layout" in peer_review
-    assert 'files: ["paper/*.tex", "paper/*.md", "manuscript/*.tex", "manuscript/*.md", "draft/*.tex", "draft/*.md"]' in respond
+    assert respond_command.argument_hint == "[--manuscript PATH] (--report PATH [--report PATH...] | paste)"
+    assert respond_command.command_policy is not None
+    assert respond_command.command_policy.subject_policy is not None
+    assert respond_command.command_policy.subject_policy.explicit_input_kinds == [
+        "manuscript_path",
+        "referee_report_path",
+        "paste_referee_report",
+    ]
+    assert respond_command.command_policy.subject_policy.supported_roots == ["paper", "manuscript", "draft"]
+    assert 'files: ["paper/*.tex", "paper/*.md", "manuscript/*.tex", "manuscript/*.md", "draft/*.tex", "draft/*.md", "GPD/publication/*/manuscript/*.tex", "GPD/publication/*/manuscript/*.md"]' in respond
     assert "bounded continuation path, not a full relocation of manuscript-local publication artifacts." in respond
     assert 'files: ["paper/*.tex", "manuscript/*.tex", "draft/*.tex", "GPD/publication/*/manuscript/*.tex"]' in arxiv
 

--- a/tests/core/test_research_phase_stage_manifest.py
+++ b/tests/core/test_research_phase_stage_manifest.py
@@ -64,15 +64,15 @@ def test_research_phase_prompt_budget_keeps_the_vertical_reasonably_tight() -> N
     )
 
     assert agent_metrics.raw_include_count == 3
-    assert agent_metrics.expanded_line_count == 2003
-    assert agent_metrics.expanded_char_count == 99281
+    assert agent_metrics.expanded_line_count == 2005
+    assert agent_metrics.expanded_char_count == 99528
     assert agent_metrics.expanded_char_count < 130000
     assert command_metrics.raw_include_count == 2
     assert command_metrics.expanded_line_count == 421
-    assert command_metrics.expanded_char_count == 17557
+    assert command_metrics.expanded_char_count == 17964
     assert command_metrics.expanded_char_count < 20000
     assert workflow_metrics.expanded_line_count == 318
-    assert workflow_metrics.expanded_char_count == 13567
+    assert workflow_metrics.expanded_char_count == 13974
     assert workflow_metrics.expanded_char_count < 15000
 
 

--- a/tests/core/test_review_contract_prompt_visibility.py
+++ b/tests/core/test_review_contract_prompt_visibility.py
@@ -1262,6 +1262,8 @@ def test_respond_to_referees_command_policy_surfaces_explicit_manuscript_and_rep
                 "manuscript/*.md",
                 "draft/*.tex",
                 "draft/*.md",
+                "GPD/publication/*/manuscript/*.tex",
+                "GPD/publication/*/manuscript/*.md",
             ],
         ),
         output_policy=registry.CommandOutputPolicy(

--- a/tests/core/test_review_workflow_preflight_wiring.py
+++ b/tests/core/test_review_workflow_preflight_wiring.py
@@ -55,23 +55,26 @@ def test_respond_to_referees_workflow_runs_centralized_review_preflight() -> Non
     ).read_text(encoding="utf-8")
 
     assert "context_mode: project-aware" in command
+    assert "argument-hint: \"[--manuscript PATH] (--report PATH [--report PATH...] | paste)\"" in command
     assert "command-policy:" in command
     assert "subject_kind: publication" in command
     assert "explicit_input_kinds:" in command
     assert "- manuscript_path" in command
     assert "- referee_report_path" in command
     assert "- paste_referee_report" in command
+    assert "GPD/publication/*/manuscript/*.tex" in command
+    assert "GPD/publication/*/manuscript/*.md" in command
     assert "default_output_subtree: GPD" in command
     assert "scope_variants:" in command
     assert "scope: explicit_external_manuscript" in command
     assert "Project-backed response rounds keep the current global `GPD/` / `GPD/review/` ownership." in command
     assert "subject-owned publication root at `GPD/publication/{subject_slug}`" in command
     assert "Set `PREFLIGHT_ARGUMENTS` to the validator-safe normalized intake string before shelling out." in workflow
+    assert "Preferred explicit intake: `gpd:respond-to-referees --manuscript path/to/main.tex --report reviews/ref1.md --report reviews/ref2.md`" in workflow
     assert 'gpd --raw validate command-context respond-to-referees -- "$PREFLIGHT_ARGUMENTS"' in workflow
     assert 'gpd validate review-preflight respond-to-referees "$ARGUMENTS" --strict' in workflow
     assert 'gpd validate review-preflight respond-to-referees --strict -- "$PREFLIGHT_ARGUMENTS"' in workflow
     assert "gpd validate review-preflight respond-to-referees --strict" in workflow
-    assert "Preferred explicit intake: `gpd:respond-to-referees --manuscript path/to/main.tex --report reviews/ref1.md --report reviews/ref2.md`" in workflow
     assert "Treat a bare positional path as a referee-report source only." in workflow
     assert "the end-of-options marker is mandatory in both validator calls" in workflow
     assert "missing referee report source when provided as a path" in workflow

--- a/tests/core/test_settings_contract_wiring.py
+++ b/tests/core/test_settings_contract_wiring.py
@@ -53,7 +53,7 @@ def test_settings_and_planning_config_keep_conventions_outside_config_json() -> 
     assert "Project conventions are not part of `config.json`." in planning_config
     assert "Do **not** introduce a `physics` block there." in planning_config
     assert (
-        "The user can run `gpd:validate-conventions` or rerun convention setup later, but the fallback lock must match the values written into `GPD/CONVENTIONS.md`."
+        "The user can run `gpd:validate-conventions`; the fallback lock must match the values written into `GPD/CONVENTIONS.md`."
         in new_project
     )
 

--- a/tests/core/test_state_mutations.py
+++ b/tests/core/test_state_mutations.py
@@ -112,3 +112,64 @@ def test_markdown_mutator_recovers_missing_state_markdown_from_state_json(
     assert state_md.exists()
     regenerated = generate_state_markdown(load_state_json(cwd) or default_state_dict())
     assert regenerated.startswith("# Research State")
+
+
+def test_state_update_prefers_literal_dotted_field_before_dot_stripping(tmp_path: Path) -> None:
+    cwd = _bootstrap_markdown_recovery_project(tmp_path)
+    state_md = cwd / "GPD" / "STATE.md"
+    content = state_md.read_text(encoding="utf-8")
+    import re as _re
+
+    content = _re.sub(
+        r"(## Session Continuity)",
+        "**custom.field.status:** old_value\n\n\\1",
+        content,
+        count=1,
+        flags=_re.IGNORECASE,
+    )
+    state_md.write_text(content, encoding="utf-8")
+
+    result = state_update(cwd, "custom.field.status", "new_value")
+
+    assert result.updated is True
+    updated_content = state_md.read_text(encoding="utf-8")
+    assert "**custom.field.status:** new_value" in updated_content
+    assert "**Status:** Executing" in updated_content
+
+
+def test_state_update_strips_dot_prefix_after_underscore_resolution(tmp_path: Path) -> None:
+    cwd = _bootstrap_markdown_recovery_project(tmp_path)
+
+    result = state_update(cwd, "position.status", "Paused")
+
+    assert result.updated is True
+    stored = load_state_json(cwd)
+    assert stored is not None
+    assert stored["position"]["status"] == "Paused"
+
+
+def test_state_update_rejects_invalid_dotted_status_after_resolution(tmp_path: Path) -> None:
+    state = default_state_dict()
+    state["position"]["status"] = "Paused"
+    cwd = _bootstrap_markdown_recovery_project(tmp_path, state=state)
+
+    result = state_update(cwd, "position.status", "banana")
+
+    assert result.updated is False
+    assert 'Invalid status: "banana"' in (result.reason or "")
+    stored = load_state_json(cwd)
+    assert stored is not None
+    assert stored["position"]["status"] == "Paused"
+
+
+def test_state_update_rejects_dotted_session_continuity_mirror_field(tmp_path: Path) -> None:
+    cwd = _bootstrap_markdown_recovery_project(tmp_path)
+    state_record_session(cwd, stopped_at="Phase 03 Plan 2", resume_file="canonical-handoff.md")
+
+    result = state_update(cwd, "continuation.handoff.resume_file", "edited-in-markdown.md")
+
+    assert result.updated is False
+    assert "mirror field" in (result.reason or "").lower()
+    stored = load_state_json(cwd)
+    assert stored is not None
+    assert stored["continuation"]["handoff"]["resume_file"] == "canonical-handoff.md"

--- a/tests/hooks/test_install_metadata.py
+++ b/tests/hooks/test_install_metadata.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from gpd.adapters.runtime_catalog import ManagedInstallSurfacePolicy
-from gpd.hooks.install_metadata import inspect_managed_install_surface
+from gpd.hooks.install_metadata import inspect_managed_install_surface, load_install_manifest_explicit_target_status
 
 
 def test_inspect_managed_install_surface_uses_runtime_catalog_policy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -64,3 +64,20 @@ def test_inspect_managed_install_surface_does_not_fall_back_to_legacy_literal_pa
     assert surface.has_nested_commands is False
     assert surface.has_flat_commands is False
     assert surface.has_managed_agents is False
+
+
+def test_load_install_manifest_explicit_target_status_rejects_legacy_manifests(
+    tmp_path: Path,
+) -> None:
+    config_dir = tmp_path / ".custom-runtime"
+    config_dir.mkdir()
+    (config_dir / "gpd-file-manifest.json").write_text(
+        '{"runtime": "test-runtime", "install_scope": "local"}',
+        encoding="utf-8",
+    )
+
+    state, payload, explicit_target = load_install_manifest_explicit_target_status(config_dir)
+
+    assert state == "missing_explicit_target"
+    assert payload == {"runtime": "test-runtime", "install_scope": "local"}
+    assert explicit_target is None

--- a/tests/mcp/test_skills_server_tool_lists.py
+++ b/tests/mcp/test_skills_server_tool_lists.py
@@ -641,6 +641,33 @@ def test_get_skill_planner_agent_does_not_expose_staged_loading_sidecar(monkeypa
     assert "staged_loading" not in result["structured_metadata_authority"]
 
 
+def test_get_skill_planner_surfaces_docs_references(monkeypatch) -> None:
+    from pathlib import Path
+
+    from gpd import registry as content_registry
+    from gpd.mcp.servers.skills_server import get_skill
+
+    repo_agents_dir = Path(__file__).resolve().parents[2] / "src/gpd/agents"
+    monkeypatch.setattr(content_registry, "AGENTS_DIR", repo_agents_dir)
+    content_registry.invalidate_cache()
+
+    result = get_skill("gpd-planner")
+    docs_references = [entry for entry in result["referenced_files"] if entry["kind"] == "docs"]
+
+    assert any(entry["path"] == "@GPD/docs/conventions.md" for entry in docs_references)
+    assert all(not entry["path"].startswith("/") for entry in docs_references)
+    assert result["loading_hint"].startswith("Treat `content` as the wrapper/context surface.")
+
+
+def test_missing_docs_reference_rejects_unsafe_relative_suffixes() -> None:
+    from gpd.mcp.servers.skills_server import _portable_reference_path
+
+    assert _portable_reference_path("docs/future-conventions.md") == ("@GPD/docs/future-conventions.md", None)
+    assert _portable_reference_path("docs/../README.md") is None
+    assert _portable_reference_path("docs//future-conventions.md") is None
+    assert _portable_reference_path("docs/./future-conventions.md") is None
+
+
 def test_get_skill_plan_checker_agent_surfaces_direct_schema_dependency_and_least_privilege(
     tmp_path, monkeypatch
 ) -> None:

--- a/tests/mcp/test_state_server_consistency.py
+++ b/tests/mcp/test_state_server_consistency.py
@@ -79,6 +79,47 @@ def test_state_server_apply_return_updates_rejects_relative_project_dir(monkeypa
 
 
 @pytest.mark.parametrize(
+    ("tool_fn", "patch_target", "fake_result"),
+    [
+        (get_state, "gpd.mcp.servers.state_server.load_state_json", {"state": "loaded"}),
+        (
+            get_config,
+            "gpd.mcp.servers.state_server.load_config",
+            SimpleNamespace(model_dump=lambda: {"mode": "review"}),
+        ),
+    ],
+)
+def test_state_server_read_only_calls_do_not_migrate_root_planning_files(
+    tool_fn,
+    patch_target: str,
+    fake_result,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    planning = tmp_path
+    (planning / "PROJECT.md").write_text("# Project\n", encoding="utf-8")
+    (planning / "ROADMAP.md").write_text("# Roadmap\n", encoding="utf-8")
+
+    monkeypatch.setattr(patch_target, lambda *_args, **_kwargs: fake_result)
+    monkeypatch.setattr(
+        "gpd.mcp.servers.state_server.load_config"
+        if patch_target.endswith("load_state_json")
+        else "gpd.mcp.servers.state_server.load_state_json",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected loader call")),
+    )
+
+    result = tool_fn(str(tmp_path))
+
+    assert result["schema_version"] == 1
+    assert not (tmp_path / "GPD" / "PROJECT.md").exists()
+    assert not (tmp_path / "GPD" / "ROADMAP.md").exists()
+    if tool_fn is get_state:
+        assert result["state"] == "loaded"
+    else:
+        assert result["mode"] == "review"
+
+
+@pytest.mark.parametrize(
     ("tool_fn", "kwargs"),
     [
         (get_state, {"project_dir": "relative/project"}),

--- a/tests/mcp/test_verification_contract_server_regressions.py
+++ b/tests/mcp/test_verification_contract_server_regressions.py
@@ -150,18 +150,13 @@ def test_suggest_contract_checks_rejects_placeholder_only_context_intake(tmp_pat
     assert "context_intake must not be empty" in result["error"]
 
 
-def test_run_contract_check_accepts_non_must_surface_reference_when_project_dir_supplied(tmp_path: Path) -> None:
-    from gpd.mcp.servers.verification_server import run_contract_check
+def test_contract_tools_warn_when_references_lack_must_surface_anchor(tmp_path: Path) -> None:
+    from gpd.mcp.servers.verification_server import run_contract_check, suggest_contract_checks
 
     contract = _project_local_contract_fixture(tmp_path)
     reference = contract["references"][0]
     assert isinstance(reference, dict)
     reference["must_surface"] = False
-    prior_output = contract["context_intake"]["must_include_prior_outputs"][0]
-    assert isinstance(prior_output, str)
-    grounded_output = tmp_path / prior_output
-    grounded_output.parent.mkdir(parents=True, exist_ok=True)
-    grounded_output.write_text("baseline summary\n", encoding="utf-8")
 
     request = {
         "check_key": "contract.benchmark_reproduction",
@@ -174,6 +169,34 @@ def test_run_contract_check_accepts_non_must_surface_reference_when_project_dir_
     rooted = run_contract_check(request, project_dir=tmp_path.resolve(strict=False).as_posix())
 
     assert rooted["status"] == "pass"
+    assert "references must include at least one must_surface=true anchor" in rooted["contract_warnings"]
+
+    suggested = suggest_contract_checks(contract, project_dir=tmp_path.resolve(strict=False).as_posix())
+    assert "references must include at least one must_surface=true anchor" in suggested["contract_warnings"]
+
+
+def test_contract_tools_warn_for_non_concrete_must_surface_locator(tmp_path: Path) -> None:
+    from gpd.mcp.servers.verification_server import run_contract_check, suggest_contract_checks
+
+    contract = _project_local_contract_fixture(tmp_path)
+    reference = contract["references"][0]
+    assert isinstance(reference, dict)
+    reference["locator"] = "TBD"
+
+    request = {
+        "check_key": "contract.benchmark_reproduction",
+        "contract": contract,
+        "binding": {"claim_ids": ["claim-benchmark"], "reference_ids": ["ref-benchmark"]},
+        "metadata": {"source_reference_id": "ref-benchmark"},
+        "observed": {"metric_value": 0.01, "threshold_value": 0.02},
+    }
+
+    rooted = run_contract_check(request, project_dir=tmp_path.resolve(strict=False).as_posix())
+    suggested = suggest_contract_checks(contract, project_dir=tmp_path.resolve(strict=False).as_posix())
+
+    assert rooted["status"] == "pass"
+    assert any("locator is not concrete enough" in warning for warning in rooted["contract_warnings"])
+    assert any("locator is not concrete enough" in warning for warning in suggested["contract_warnings"])
 
 
 def test_suggest_contract_checks_accepts_rootless_prior_output_as_visible_context_intake() -> None:

--- a/tests/test_import_stability_contracts.py
+++ b/tests/test_import_stability_contracts.py
@@ -46,8 +46,31 @@ def test_registry_import_remains_stable_after_adapter_package_import() -> None:
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
+        timeout=15,
         check=False,
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert result.stdout.strip() == "True"
+
+
+def test_key_entrypoint_modules_import_stably() -> None:
+    result = subprocess.run(
+        [
+            *_repo_python_command(),
+            "-c",
+            (
+                "import importlib; "
+                "modules = ['gpd', 'gpd.cli', 'gpd.runtime_cli', 'gpd.mcp.servers.skills_server']; "
+                "[importlib.import_module(name) for name in modules]; "
+                "print(len(modules))"
+            ),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == "4"

--- a/tests/test_phase11_literature_review_typed_routing.py
+++ b/tests/test_phase11_literature_review_typed_routing.py
@@ -37,6 +37,6 @@ def test_literature_reviewer_shows_base_return_fields_and_one_shot_checkpointing
     status_idx = completed_block.index("  status: completed | checkpoint | blocked | failed")
     files_idx = completed_block.index("  files_written: [GPD/literature/{slug}-REVIEW.md]")
     issues_idx = completed_block.index("  issues: [most important unresolved issues or empty list]")
-    next_actions_idx = completed_block.index("  next_actions: [recommended follow-up actions or reading path]")
+    next_actions_idx = completed_block.index("  next_actions: [concrete commands or exact reading/review path]")
 
     assert status_idx < files_idx < issues_idx < next_actions_idx

--- a/tests/test_runtime_cli.py
+++ b/tests/test_runtime_cli.py
@@ -567,12 +567,37 @@ def test_runtime_cli_manifest_scoped_local_candidate_matching_does_not_consult_h
     assert runtime_cli._is_matching_local_install_candidate(global_config_dir, runtime=adapter.runtime_name) is False
 
 
+@pytest.mark.parametrize("descriptor", _RUNTIME_DESCRIPTORS, ids=lambda descriptor: descriptor.runtime_name)
+def test_runtime_cli_resolves_manifestless_managed_surface_for_diagnostics(
+    tmp_path: Path,
+    descriptor,
+) -> None:
+    workspace = tmp_path / "workspace"
+    ancestor_config_dir = workspace / descriptor.config_dir_name
+    nested_cwd = workspace / "research" / "notes"
+    nested_cwd.mkdir(parents=True)
+
+    seed_complete_runtime_install(ancestor_config_dir, runtime=descriptor.runtime_name)
+    (ancestor_config_dir / MANIFEST_NAME).unlink()
+
+    resolved = runtime_cli._resolve_local_config_dir(
+        f"./{descriptor.config_dir_name}",
+        runtime=descriptor.runtime_name,
+        cli_cwd=nested_cwd,
+    )
+
+    assert resolved == ancestor_config_dir.resolve()
+    assert resolved != (nested_cwd / descriptor.config_dir_name).resolve()
+
+
+@pytest.mark.parametrize("descriptor", _RUNTIME_DESCRIPTORS, ids=lambda descriptor: descriptor.runtime_name)
 def test_runtime_cli_uses_manifest_explicit_target_for_repair_guidance(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
+    descriptor,
 ) -> None:
-    adapter = get_adapter("codex")
+    adapter = get_adapter(descriptor.runtime_name)
     config_dir = tmp_path / "custom-global" / adapter.config_dir_name
     config_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = config_dir / MANIFEST_NAME
@@ -620,6 +645,45 @@ def test_runtime_cli_uses_manifest_explicit_target_for_repair_guidance(
     assert "GPD runtime bridge rejected incomplete install manifest" in captured.err
     assert "--target-dir" in captured.err
     assert str(config_dir) in captured.err
+
+
+@pytest.mark.parametrize("descriptor", _RUNTIME_DESCRIPTORS, ids=lambda descriptor: descriptor.runtime_name)
+def test_runtime_cli_infers_target_dir_for_missing_explicit_target_repair_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    descriptor,
+) -> None:
+    adapter = get_adapter(descriptor.runtime_name)
+    config_dir = tmp_path / "custom-parent" / adapter.config_dir_name
+    seed_complete_runtime_install(config_dir, runtime=adapter.runtime_name, explicit_target=True)
+    manifest_path = config_dir / MANIFEST_NAME
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest.pop("runtime", None)
+    manifest.pop("explicit_target", None)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("gpd.runtime_cli._maybe_reexec_from_checkout", lambda *_args, **_kwargs: None)
+
+    exit_code = main(
+        [
+            "--runtime",
+            adapter.runtime_name,
+            "--config-dir",
+            str(config_dir),
+            "--install-scope",
+            "local",
+            "state",
+            "load",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 127
+    assert "GPD runtime bridge rejected incomplete install manifest" in captured.err
+    assert "--target-dir" in captured.err
+    assert shlex.quote(str(config_dir)) in captured.err
 
 
 @pytest.mark.parametrize("descriptor", _RUNTIME_DESCRIPTORS, ids=lambda descriptor: descriptor.runtime_name)
@@ -1082,9 +1146,8 @@ def test_runtime_cli_rejects_local_config_dir_from_ancestor_workspace_without_ma
 
     captured = capsys.readouterr()
     assert exit_code == 127
-    assert "GPD runtime bridge rejected incomplete install manifest" in captured.err
-    assert "The manifest must declare a non-empty `runtime` field." in captured.err
-    assert str(config_dir) in captured.err
+    assert f"GPD runtime bridge rejected incomplete install manifest at `{config_dir}`." in captured.err
+    assert f"--target-dir {shlex.quote(str(config_dir))}" in captured.err
     assert str(nested_cwd / descriptor.config_dir_name) not in captured.err
 
 
@@ -1223,9 +1286,8 @@ def test_runtime_cli_rejects_manifestless_ancestor_local_candidate_before_dispat
 
     captured = capsys.readouterr()
     assert exit_code == 127
-    assert "GPD runtime bridge rejected missing install manifest" in captured.err
-    assert f"`{MANIFEST_NAME}`" in captured.err
-    assert str(config_dir) in captured.err
+    assert f"GPD runtime bridge rejected missing install manifest at `{config_dir}`." in captured.err
+    assert f"--target-dir {shlex.quote(str(config_dir))}" in captured.err
     assert str(nested_cwd / descriptor.config_dir_name) not in captured.err
 
 

--- a/tests/test_runtime_install_smoke.py
+++ b/tests/test_runtime_install_smoke.py
@@ -73,6 +73,7 @@ def test_runtime_cli_rejects_manifestless_ancestor_install(monkeypatch: pytest.M
     captured = capsys.readouterr()
     assert exit_code == 127
     assert f"GPD runtime bridge rejected missing install manifest at `{ancestor.resolve()}`." in captured.err
+    assert str(nested_cwd / adapter.config_dir_name) not in captured.err
 
 
 def test_runtime_cli_rejects_wrong_runtime_manifest_for_explicit_target(

--- a/tests/test_update_workflow.py
+++ b/tests/test_update_workflow.py
@@ -12,7 +12,7 @@ from gpd.adapters.runtime_catalog import (
     iter_runtime_descriptors,
     resolve_global_config_dir,
 )
-from gpd.hooks.install_metadata import installed_update_command
+from gpd.hooks.install_metadata import installed_update_command, load_install_manifest_explicit_target_status
 
 GPD_ROOT = Path(__file__).resolve().parent.parent / "src" / "gpd"
 _RUNTIME_DESCRIPTORS = iter_runtime_descriptors()
@@ -159,6 +159,11 @@ def test_local_install_without_explicit_target_returns_no_trusted_update_command
     manifest.pop("explicit_target", None)
     manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
 
+    explicit_target_state, explicit_target_payload, explicit_target = load_install_manifest_explicit_target_status(target)
+
+    assert explicit_target_state == "missing_explicit_target"
+    assert explicit_target_payload["runtime"] == descriptor.runtime_name
+    assert explicit_target is None
     assert installed_update_command(target) is None
 
 


### PR DESCRIPTION
## Summary

- Require concrete `Next Up` guidance at GPD user-visible completion, checkpoint, blocked, failed, and pause/stop points.
- Tighten runtime wiring, MCP tool-list consistency, install metadata handling, state mutation behavior, and prompt/runtime parity tests.
- Add coverage for follow-up command requirements, state/status consistency, contract validation, runtime install wiring, and import stability.

## Why

Phase closeout could finish with vague continuation text instead of exact next GPD commands, leaving users unsure how to proceed after workflows such as `gpd-new-project` and phase closeout. The prompts and runtime checks now consistently preserve actionable next-command guidance while keeping runtime-specific behavior inside adapters.

## Validation

- `uv run pytest` -> 8098 passed, 5 skipped in 167.82s
- `uv run ruff check` -> passed
- Runtime smoke for edited GPD closeout/Next Up behavior -> passed
- Provider-backed Codex smoke for `gpd-new-project --minimal @project-brief.md` -> passed; final response ended with `$gpd-discuss-phase 1`, `$gpd-plan-phase 1`, and `$gpd-suggest-next`

## Notes

The provider-backed temp smoke could not create a git commit inside its temporary workspace because the Codex sandbox denied `.git/index.lock` writes there. Artifact generation and validation completed successfully.