### PR TITLE
Fix publish release date validation

### DIFF
--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -768,7 +768,11 @@ def test_stamp_publish_date_reports_no_changes_when_release_date_already_matches
     repo_root = _repo_root()
     _copy_release_surfaces(repo_root, tmp_path)
 
-    metadata = stamp_publish_date(tmp_path, release_date="2026-03-15")
+    citation = (tmp_path / "CITATION.cff").read_text(encoding="utf-8")
+    match = re.search(r"^date-released: '(\d{4}-\d{2}-\d{2})'$", citation, re.M)
+    assert match is not None
+
+    metadata = stamp_publish_date(tmp_path, release_date=match.group(1))
 
     assert metadata.changed_files == ()
 


### PR DESCRIPTION
## Summary
- Make the publish-date no-op release test derive the current copied CITATION.cff date instead of hard-coding the old release date.
- Keeps the test valid after the publish workflow stamps the real publish date before running release validation.

## Tests
- uv run pytest -q tests/test_release_consistency.py
- uv run ruff check tests/test_release_consistency.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by reading release information dynamically instead of relying on hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->