### PR TITLE
Harden npm release publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,7 +1,9 @@
 # Admin-owned publish workflow:
 # - Run manually from merged `main` after the release PR has landed.
 # - This workflow rebuilds from that reviewed commit, publishes to PyPI first,
-#   then publishes npm and creates the GitHub Release/tag.
+#   then publishes npm, and finally creates the GitHub Release/tag.
+# - PyPI and npm use trusted publishing. Configure the matching publishers in
+#   the package registries before running this workflow.
 # - If the actual publish day differs from the already-merged release PR, this
 #   workflow stamps the real publish date locally for the release artifacts and
 #   opens a tiny follow-up PR to persist `CITATION.cff` / `README.md`.
@@ -10,6 +12,12 @@ name: publish release
 
 on:
   workflow_dispatch:
+    inputs:
+      release_sha:
+        description: "Optional reviewed main-branch release commit SHA to publish; leave empty for current main."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -39,8 +47,18 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.release_sha || github.sha }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure release commit is on default branch history
+        run: |
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch origin "$DEFAULT_BRANCH"
+          if ! git merge-base --is-ancestor HEAD "origin/${DEFAULT_BRANCH}"; then
+            echo "::error::Release commit $(git rev-parse HEAD) is not on origin/${DEFAULT_BRANCH}."
+            exit 1
+          fi
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -136,6 +154,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
+          skip-existing: true
 
   publish-npm-and-github-release:
     name: publish npm and create GitHub release
@@ -143,8 +162,12 @@ jobs:
       - build-release
       - publish-pypi
     runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/get-physics-done
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - name: Check out release commit
@@ -166,22 +189,11 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Ensure npm token is configured
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [ -z "$NODE_AUTH_TOKEN" ]; then
-            echo "::error::NPM_TOKEN is not configured."
-            exit 1
-          fi
 
       - name: Publish to npm
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         id: github_release
@@ -270,7 +282,7 @@ jobs:
             echo "- Commit: \`${RELEASE_SHA}\`"
             echo "- Publish date: \`${RELEASE_DATE}\`"
             echo "- PyPI: published via trusted publishing from environment \`PyPI\`"
-            echo "- npm: published from the merged release commit"
+            echo "- npm: published via trusted publishing from environment \`npm\`"
             echo "- GitHub release: ${RELEASE_URL}"
             if [ "${METADATA_CHANGED}" = "true" ]; then
               echo "- Follow-up metadata PR: ${METADATA_PR_URL}"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/psi-oss/get-physics-done"
+    "url": "git+https://github.com/psi-oss/get-physics-done.git"
   },
   "homepage": "https://github.com/psi-oss/get-physics-done#readme",
   "bugs": {

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -275,6 +275,10 @@ def test_public_bootstrap_package_exposes_npx_installer() -> None:
     packaged_files = set(package_json.get("files", []))
 
     assert package_json["name"] == "get-physics-done"
+    assert package_json["repository"] == {
+        "type": "git",
+        "url": "git+https://github.com/psi-oss/get-physics-done.git",
+    }
     assert package_json.get("bin", {}).get("get-physics-done") == "bin/install.js"
     assert "bin/" in packaged_files
     assert set(_BOOTSTRAP_JSON_ASSETS) <= packaged_files
@@ -423,17 +427,25 @@ def test_publish_release_workflow_uses_trusted_publishing_from_merged_release_co
     assert "Ordinary PR merges to `main` must never invoke this flow automatically." in workflow
     assert "name: publish release" in workflow
     assert "workflow_dispatch:" in workflow
+    assert "release_sha:" in workflow
+    assert "ref: ${{ inputs.release_sha || github.sha }}" in workflow
+    assert "git merge-base --is-ancestor HEAD" in workflow
     assert "scripts/release_workflow.py show-version" in workflow
     assert "scripts/release_workflow.py stamp-publish-date" in workflow
     assert "environment:" in workflow
     assert "name: PyPI" in workflow
     assert "id-token: write" in workflow
+    assert "skip-existing: true" in workflow
     assert "actions/checkout@v6" in workflow
     assert "actions/setup-python@v6" in workflow
     assert "actions/setup-node@v6" in workflow
+    assert 'node-version: "24"' in workflow
     assert "actions/upload-artifact@v7" in workflow
     assert "actions/download-artifact@v8" in workflow
     assert "pypa/gh-action-pypi-publish@release/v1" in workflow
+    assert "name: npm" in workflow
+    assert "NODE_AUTH_TOKEN" not in workflow
+    assert "NPM_TOKEN" not in workflow
     assert "npm publish" in workflow
     assert "gh release create" in workflow
     assert "post-release/v${VERSION}-publish-date" in workflow


### PR DESCRIPTION
## Summary
- Normalize npm repository metadata so npm does not auto-correct package.json during publish.
- Switch npm release publishing to trusted publishing with an npm deployment environment instead of NPM_TOKEN.
- Make the PyPI publish step skip already-uploaded distributions so partial release retries are recoverable.

## Verification
- uv run pytest -q tests/test_release_consistency.py
- uv run ruff check tests/test_release_consistency.py
- npm_config_cache=/tmp/gpd-npm-cache-harden npm pack --dry-run --json
- git diff --check

## Release note
For the already-partial v1.2.0 run, prefer fixing the current NPM_TOKEN and rerunning failed jobs so the release completes from the original release commit. This PR is the long-term hardening path for future release runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Node.js to version 24 for npm publishing operations
  * Enhanced release publishing workflow with optional commit SHA selection and ancestor validation
  * Updated repository URL format with git+ protocol prefix and .git suffix
  * Migrated npm publishing authentication from token-based to trusted publishing method
  * Strengthened release consistency validation testing with additional metadata checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->