### PR TITLE
docs: stamp v1.2.0 publish date

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If GPD contributes to published research, please cite it using the met
 title: "Get Physics Done (GPD)"
 type: software
 version: 1.2.0
-date-released: '2026-03-15'
+date-released: '2026-04-27'
 license: Apache-2.0
 abstract: "An open-source agentic AI system for physics research that structures, executes, verifies, and documents research workflows across multiple AI runtimes."
 authors:


### PR DESCRIPTION
## Summary
- Persist the actual publish date for v1.2.0 after the manual publish workflow completed.
- Update CITATION.cff to match the publish date.

## Context
- The publish workflow successfully published v1.2.0 to PyPI, npm, and GitHub Releases.
- The workflow-created branch exists, but the final PR creation step failed because the workflow token could not create pull requests.

## Verification
- Release workflow generated this one-line metadata branch.
- npm registry reports get-physics-done@1.2.0.
- GitHub Release v1.2.0 exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->