### PR TITLE
Allow publish workflow to open metadata PRs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -168,6 +168,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
 
     steps:
       - name: Check out release commit

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -446,6 +446,7 @@ def test_publish_release_workflow_uses_trusted_publishing_from_merged_release_co
     assert "name: npm" in workflow
     assert "NODE_AUTH_TOKEN" not in workflow
     assert "NPM_TOKEN" not in workflow
+    assert "pull-requests: write" in workflow
     assert "npm publish" in workflow
     assert "gh release create" in workflow
     assert "post-release/v${VERSION}-publish-date" in workflow


### PR DESCRIPTION
## Summary
- Grant the publish-release job pull-requests: write so its post-release metadata PR creation step can succeed.
- Add release consistency coverage for the permission required by gh pr create.

## Verification
- uv run pytest -q tests/test_release_consistency.py
- uv run ruff check tests/test_release_consistency.py
- git diff --check

## Context
The v1.2.0 publish completed through PyPI, npm, and GitHub Release creation, then failed only when GITHUB_TOKEN tried to create the publish-date follow-up PR. That PR has been opened manually as #196.