### PR TITLE
docs: stamp v1.2.0 publish date

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If GPD contributes to published research, please cite it using the met
 title: "Get Physics Done (GPD)"
 type: software
 version: 1.2.0
-date-released: '2026-03-15'
+date-released: '2026-04-27'
 license: Apache-2.0
 abstract: "An open-source agentic AI system for physics research that structures, executes, verifies, and documents research workflows across multiple AI runtimes."
 authors:


### PR DESCRIPTION
## Summary
- Persist the actual publish date for v1.2.0 in CITATION.cff.

## Context
- The publish workflow successfully published v1.2.0 to PyPI, npm, and GitHub Releases.
- The workflow-created branch had the same one-line change, but its PR was blocked by CLA because the commit was authored by github-actions[bot].

## Verification
- uv run pytest -q tests/test_release_consistency.py
- git diff --check