### PR TITLE
Add PyPI release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
   <a href="https://github.com/psi-oss/get-physics-done/actions/workflows/test.yml"><img alt="CI" src="https://github.com/psi-oss/get-physics-done/actions/workflows/test.yml/badge.svg"></a>
   <a href="https://github.com/psi-oss/get-physics-done/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-d4d4d8?style=flat&labelColor=3f3f46"></a>
   <a href="https://www.python.org/downloads/"><img alt="Python 3.11+" src="https://img.shields.io/badge/Python-3.11%2B-ffd43b?style=flat&labelColor=3776ab&logo=python&logoColor=white"></a>
+  <a href="https://pypi.org/project/get-physics-done/"><img alt="PyPI" src="https://img.shields.io/pypi/v/get-physics-done?style=flat&logo=pypi&logoColor=white&labelColor=3775a9&color=ffd43b"></a>
   <a href="https://www.npmjs.com/package/get-physics-done"><img alt="npm" src="https://img.shields.io/npm/v/get-physics-done?style=flat&logo=npm&logoColor=white&labelColor=1f1f1f&color=cb3837"></a>
 </p>
 

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -269,6 +269,19 @@ def test_public_release_surfaces_share_agentic_system_positioning() -> None:
     assert expected in pyproject["project"]["description"].lower()
     assert "Open-source agentic AI system for physics research" in installer
 
+
+def test_readme_exposes_pypi_and_npm_release_badges() -> None:
+    repo_root = _repo_root()
+    readme = (repo_root / "README.md").read_text(encoding="utf-8")
+
+    assert "https://pypi.org/project/get-physics-done/" in readme
+    assert "https://img.shields.io/pypi/v/get-physics-done" in readme
+    assert "labelColor=3775a9&color=ffd43b" in readme
+    assert "https://www.npmjs.com/package/get-physics-done" in readme
+    assert "https://img.shields.io/npm/v/get-physics-done" in readme
+    assert "labelColor=1f1f1f&color=cb3837" in readme
+
+
 def test_public_bootstrap_package_exposes_npx_installer() -> None:
     repo_root = _repo_root()
     package_json = json.loads((repo_root / "package.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add a PyPI version badge beside the npm badge in the README release badge row.
- Keep the badge styling consistent with the existing flat Shields badges and official ecosystem colors.
- Add release-consistency coverage so PyPI/npm badge links and color accents stay present.

## Verification
- uv run pytest -q tests/test_release_consistency.py
- uv run ruff check tests/test_release_consistency.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PyPI badge to README displaying the current published version.

* **Tests**
  * Added test to verify README includes release badges for PyPI and NPM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->