### PR TITLE
release: v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+## v1.2.1
+
+### Workflow and release hardening
+
+- Harden runtime wiring across installers, projected commands, update checks, and runtime catalogs, including OpenCode permission preservation and fail-closed capability validation.
+- Tighten project, state, and continuation boundaries so nested repositories, live execution state, recent-project cache entries, and child-return rollback are handled more conservatively.
+- Strengthen publication and contract validation by rejecting mismatched or malformed latest review artifacts, aligning contract-link schemas with prompt-visible templates, and preserving valid optional MCP request fields.
+- Improve release recovery and CI guardrails for same-commit publish reruns, existing tag checks, release PR discovery, and human-author range validation.
+- Trim and clarify workflow and agent prompts while preserving canonical model-omission, artifact-gate, destructive-confirmation, and checkpoint semantics.
+
 ## v1.2.0
 
 ### Supervised by default

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If GPD contributes to published research, please cite it using the metadata below."
 title: "Get Physics Done (GPD)"
 type: software
-version: 1.2.0
+version: 1.2.1
 date-released: '2026-04-27'
 license: Apache-2.0
 abstract: "An open-source agentic AI system for physics research that structures, executes, verifies, and documents research workflows across multiple AI runtimes."

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ If GPD contributes to published research, please cite the software using [`CITAT
 @software{physical_superintelligence_2026_gpd,
   author = {{Physical Superintelligence PBC}},
   title = {Get Physics Done (GPD)},
-  version = {1.2.0},
+  version = {1.2.1},
   year = {2026},
   url = {https://github.com/psi-oss/get-physics-done},
   license = {Apache-2.0}
@@ -567,7 +567,7 @@ If GPD contributes to published research, please cite the software using [`CITAT
 ```
 
 ```text
-Physical Superintelligence PBC (2026). Get Physics Done (GPD) (Version 1.2.0). https://github.com/psi-oss/get-physics-done
+Physical Superintelligence PBC (2026). Get Physics Done (GPD) (Version 1.2.1). https://github.com/psi-oss/get-physics-done
 ```
 
 If your paper includes an acknowledgements section, use:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-physics-done",
-  "version": "1.2.0",
-  "gpdPythonVersion": "1.2.0",
+  "version": "1.2.1",
+  "gpdPythonVersion": "1.2.1",
   "description": "Open-source agentic AI system for physics research across supported AI runtimes",
   "bin": {
     "get-physics-done": "bin/install.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "get-physics-done"
-version = "1.2.0"
+version = "1.2.1"
 description = "GPD — Get Physics Done: open-source agentic AI system for physics research"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -667,7 +667,7 @@ wheels = [
 
 [[package]]
 name = "get-physics-done"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
- Prepare release `v1.2.1` from `main`.
- Update the tracked version, changelog, citation, package, and lockfile surfaces.
- Validate the Python and npm release artifacts before any publish step.

## Release notes

### Workflow and release hardening

- Harden runtime wiring across installers, projected commands, update checks, and runtime catalogs, including OpenCode permission preservation and fail-closed capability validation.
- Tighten project, state, and continuation boundaries so nested repositories, live execution state, recent-project cache entries, and child-return rollback are handled more conservatively.
- Strengthen publication and contract validation by rejecting mismatched or malformed latest review artifacts, aligning contract-link schemas with prompt-visible templates, and preserving valid optional MCP request fields.
- Improve release recovery and CI guardrails for same-commit publish reruns, existing tag checks, release PR discovery, and human-author range validation.
- Trim and clarify workflow and agent prompts while preserving canonical model-omission, artifact-gate, destructive-confirmation, and checkpoint semantics.

## Local validation
- `uv run pytest tests/test_release_consistency.py -q` -> 48 passed
- `uv build --out-dir dist` -> built wheel and sdist
- `uv run --with twine python -m twine check dist/*` -> passed
- `npm_config_cache=/tmp/gpd-npm-cache npm pack --dry-run --json` -> get-physics-done@1.2.1
- `git diff --check` -> passed

## After merge
- Run the `Publish release` workflow from `main`.
