### PR TITLE
Add Eberhardt paper to GPD usage list

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ This research made use of Get Physics Done (GPD), developed by Physical Superint
 
 ## Papers Using GPD
 
-Papers that cite or acknowledge use of GPD. If your paper should be listed here, open a pull request.
+Papers that cite or acknowledge use of GPD. If your paper should be listed here, please open a pull request.
 
 - L. Eberhardt, *The Super Virasoro Minimal String from 3d Supergravity* (2026), [arXiv:2604.26038](https://arxiv.org/abs/2604.26038).
 - C. Ferko, J. Halverson, V. Jejjala and B. Robinson, *Topological Effects in Neural Network Field Theory* (2026), [arXiv:2604.02313](https://arxiv.org/abs/2604.02313).

--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ This research made use of Get Physics Done (GPD), developed by Physical Superint
 
 Papers that cite or acknowledge use of GPD. If your paper should be listed here, open a pull request.
 
+- L. Eberhardt, *The Super Virasoro Minimal String from 3d Supergravity* (2026), [arXiv:2604.26038](https://arxiv.org/abs/2604.26038).
 - C. Ferko, J. Halverson, V. Jejjala and B. Robinson, *Topological Effects in Neural Network Field Theory* (2026), [arXiv:2604.02313](https://arxiv.org/abs/2604.02313).
 - V. G. Filev, *Holographic entanglement entropy, Wilson loops, and neural networks* (2026), [arXiv:2604.05970](https://arxiv.org/abs/2604.05970).
 


### PR DESCRIPTION
Summary: Add Lorenz Eberhardt's arXiv:2604.26038 paper to the README Papers Using GPD list. Validation: git diff --check and uv run pytest -q tests/core/test_paper_contribution_prompt.py.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new paper reference to the "Papers Using GPD" section in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->