### PR TITLE
release: v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+## v1.2.2
+
+### Live command audit hardening
+
+- Stabilize live command behavior across Codex, Claude, Gemini, and OpenCode, including update, install, uninstall, help, profile, and new-project workflows.
+- Harden phase planning, phase execution, checkpoint routing, project-local verification reports, and publication command gates so live audit recovery paths fail closed instead of drifting across projects.
+- Tighten verifier prompt budgets, staged context handling, raw help surfaces, arXiv command subject validation, and external-project read-only routing.
+
+### Maintenance
+
+- Refresh arXiv, arXiv MCP server, Typer, and Ruff dependencies.
+- Clarify paper-submission README guidance and add the Eberhardt GPD acknowledgement to the public papers list.
+
 ## v1.2.1
 
 ### Workflow and release hardening

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If GPD contributes to published research, please cite it using the metadata below."
 title: "Get Physics Done (GPD)"
 type: software
-version: 1.2.1
+version: 1.2.2
 date-released: '2026-04-27'
 license: Apache-2.0
 abstract: "An open-source agentic AI system for physics research that structures, executes, verifies, and documents research workflows across multiple AI runtimes."

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ If GPD contributes to published research, please cite the software using [`CITAT
 @software{physical_superintelligence_2026_gpd,
   author = {{Physical Superintelligence PBC}},
   title = {Get Physics Done (GPD)},
-  version = {1.2.1},
+  version = {1.2.2},
   year = {2026},
   url = {https://github.com/psi-oss/get-physics-done},
   license = {Apache-2.0}
@@ -567,7 +567,7 @@ If GPD contributes to published research, please cite the software using [`CITAT
 ```
 
 ```text
-Physical Superintelligence PBC (2026). Get Physics Done (GPD) (Version 1.2.1). https://github.com/psi-oss/get-physics-done
+Physical Superintelligence PBC (2026). Get Physics Done (GPD) (Version 1.2.2). https://github.com/psi-oss/get-physics-done
 ```
 
 If your paper includes an acknowledgements section, use:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-physics-done",
-  "version": "1.2.1",
-  "gpdPythonVersion": "1.2.1",
+  "version": "1.2.2",
+  "gpdPythonVersion": "1.2.2",
   "description": "Open-source agentic AI system for physics research across supported AI runtimes",
   "bin": {
     "get-physics-done": "bin/install.js"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "get-physics-done"
-version = "1.2.1"
+version = "1.2.2"
 description = "GPD — Get Physics Done: open-source agentic AI system for physics research"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -667,7 +667,7 @@ wheels = [
 
 [[package]]
 name = "get-physics-done"
-version = "1.2.1"
+version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary
- Prepare release `v1.2.2` from `main`.
- Update the tracked version, changelog, citation metadata, README citation, package metadata, and lockfile.
- Validate the Python and npm release artifacts before any publish step.

## Release notes

### Live command audit hardening

- Stabilize live command behavior across Codex, Claude, Gemini, and OpenCode, including update, install, uninstall, help, profile, and new-project workflows.
- Harden phase planning, phase execution, checkpoint routing, project-local verification reports, and publication command gates so live audit recovery paths fail closed instead of drifting across projects.
- Tighten verifier prompt budgets, staged context handling, raw help surfaces, arXiv command subject validation, and external-project read-only routing.

### Maintenance

- Refresh arXiv, arXiv MCP server, Typer, and Ruff dependencies.
- Clarify paper-submission README guidance and add the Eberhardt GPD acknowledgement to the public papers list.

## Validation
- `uv tool run --from uv==0.9.12 uv run pytest -n 0 tests/test_release_consistency.py -v`
- `uv tool run --from uv==0.9.12 uv build --out-dir dist`
- `uv tool run --from twine twine check dist/*`
- `npm_config_cache=/tmp/gpd-npm-cache npm pack --dry-run --json`
- `git diff --check`

## After merge
- Run the `Publish release` workflow from `main` with the merged release commit SHA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced command stability and reliability across all live workflows including update, install, uninstall, help, profile management, and new project creation with improved audit and recovery handling.

* **Maintenance**
  * Refreshed core dependencies including arXiv integration, API server components, and command-line utilities.
  * Updated documentation with improved guidance for paper submission and citation examples for version 1.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->