### PR TITLE
docs: stamp v1.2.2 publish date

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@ message: "If GPD contributes to published research, please cite it using the met
 title: "Get Physics Done (GPD)"
 type: software
 version: 1.2.2
-date-released: '2026-04-27'
+date-released: '2026-05-07'
 license: Apache-2.0
 abstract: "An open-source agentic AI system for physics research that structures, executes, verifies, and documents research workflows across multiple AI runtimes."
 authors:


### PR DESCRIPTION
## Summary
- Persist the actual publish date for v1.2.2 after the manual publish workflow completed.
- Update CITATION.cff to match 2026-05-07.

## Context
- PyPI, npm, and the GitHub Release were already published by the release workflow.
- The workflow failed only because GitHub Actions is not permitted to create pull requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated citation release date metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->