### PR TITLE
Test live phase lifecycle contracts

### DIFF
--- a/src/gpd/adapters/codex.py
+++ b/src/gpd/adapters/codex.py
@@ -146,7 +146,7 @@ _CODEX_COMMAND_RUNTIME_NOTE = (
     "Codex shell compatibility:\n"
     "- Keep user-facing command names canonical in prose: `gpd ...` for your normal terminal and `{public_prefix}...` for Codex commands.\n"
     "- When shell steps call the GPD CLI, put the runtime bridge directly in command position: {launcher}.\n"
-    '- The bridge is a command with arguments, not one executable path. Do not assign it to a scalar like `GPD_CLI="{launcher}"` and then run `$GPD_CLI ...`.\n'
+    "- The bridge is a command with arguments, not one executable path. Do not store it in a scalar variable and then expand that variable as the command.\n"
     '- If you need reuse inside one shell block, define a function: `gpd_cli() {{ {launcher} "$@"; }}` and call `gpd_cli --raw ...`.\n'
     "- In zsh examples, use `cmd_status=$?`; `status` is a reserved read-only parameter.\n"
     "</codex_runtime_notes>\n\n"

--- a/src/gpd/adapters/codex.py
+++ b/src/gpd/adapters/codex.py
@@ -145,7 +145,10 @@ _CODEX_COMMAND_RUNTIME_NOTE = (
     "<codex_runtime_notes>\n"
     "Codex shell compatibility:\n"
     "- Keep user-facing command names canonical in prose: `gpd ...` for your normal terminal and `{public_prefix}...` for Codex commands.\n"
-    "- When shell steps call the GPD CLI, use {launcher} instead of the ambient `gpd` on PATH.\n"
+    "- When shell steps call the GPD CLI, put the runtime bridge directly in command position: {launcher}.\n"
+    '- The bridge is a command with arguments, not one executable path. Do not assign it to a scalar like `GPD_CLI="{launcher}"` and then run `$GPD_CLI ...`.\n'
+    '- If you need reuse inside one shell block, define a function: `gpd_cli() {{ {launcher} "$@"; }}` and call `gpd_cli --raw ...`.\n'
+    "- In zsh examples, use `cmd_status=$?`; `status` is a reserved read-only parameter.\n"
     "</codex_runtime_notes>\n\n"
 )
 _CODEX_COMMAND_RUNTIME_NOTE_BLOCK_RE = re.compile(

--- a/src/gpd/core/state.py
+++ b/src/gpd/core/state.py
@@ -1460,7 +1460,15 @@ VALID_TRANSITIONS: dict[str, list[str] | None] = {
     "ready to plan": ["planning", "researching", "paused", "blocked", "not started", "milestone complete"],
     "planning": ["ready to execute", "researching", "paused", "blocked", "ready to plan", "not started"],
     "researching": ["planning", "ready to execute", "paused", "blocked", "ready to plan", "not started"],
-    "ready to execute": ["executing", "planning", "researching", "paused", "blocked", "not started"],
+    "ready to execute": [
+        "executing",
+        "phase complete \u2014 ready for verification",
+        "planning",
+        "researching",
+        "paused",
+        "blocked",
+        "not started",
+    ],
     "executing": [
         "phase complete \u2014 ready for verification",
         "planning",
@@ -1474,6 +1482,7 @@ VALID_TRANSITIONS: dict[str, list[str] | None] = {
     "phase complete \u2014 ready for verification": [
         "verifying",
         "verified",
+        "blocked",
         "not started",
         "planning",
         "executing",
@@ -4992,12 +5001,15 @@ def state_record_verification(
         normalized = status.strip().lower()
         if normalized in {"passed", "pass", "ok", "success"}:
             normalized_status = "passed"
-        elif normalized in {"failed", "fail", "blocked"}:
+        elif normalized in {"failed", "fail", "blocked", "gaps_found", "expert_needed", "human_needed"}:
             normalized_status = "failed"
         elif normalized:
             return RecordVerificationResult(
                 recorded=False,
-                error=f"unrecognized status '{status}' (expected passed|failed)",
+                error=(
+                    f"unrecognized status '{status}' "
+                    "(expected passed|failed or canonical non-passed verification status)"
+                ),
             )
 
     if normalized_status is None:
@@ -5038,7 +5050,7 @@ def state_record_verification(
                     val = m.group(1).strip().strip("'\"").lower()
                     if val in {"passed", "pass", "ok"}:
                         normalized_status = "passed"
-                    elif val in {"failed", "fail"}:
+                    elif val in {"failed", "fail", "blocked", "gaps_found", "expert_needed", "human_needed"}:
                         normalized_status = "failed"
                     break
         if normalized_status is None:

--- a/src/gpd/specs/references/orchestration/agent-infrastructure.md
+++ b/src/gpd/specs/references/orchestration/agent-infrastructure.md
@@ -253,11 +253,15 @@ gpd convention check
 
 Used by verifiers and orchestrators to validate research artifacts:
 
+These terminal `gpd verify ...` commands are structural checks. They do not
+replace the runtime `gpd:verify-work <phase>` workflow, which owns full
+phase-level physics verification and report generation.
+
 ```bash
 # Verify plan structure (wave assignments, dependencies, frontmatter)
 gpd verify plan <plan-file-path>
 
-# Verify phase completeness (all plans have `*-SUMMARY.md`)
+# Structural completeness only: all plans have `*-SUMMARY.md`
 gpd verify phase <phase-number>
 
 # Verify cross-file references in a document

--- a/src/gpd/specs/workflows/execute-phase.md
+++ b/src/gpd/specs/workflows/execute-phase.md
@@ -1794,7 +1794,7 @@ Use the structured init-state payload (`convention_lock` / `derived_convention_l
 Use `gpd convention list` and `file_read: GPD/STATE.md, GPD/state.json` only if the payload is missing or inconsistent.
 file_read: All SUMMARY.md files from phase {PHASE_NUMBER}
 
-Return exactly one typed `gpd_return` envelope with `status: completed | checkpoint | blocked | failed`, include `files_written`, and write `{phase_dir}/CONSISTENCY-CHECK.md`.
+Return exactly one typed `gpd_return` envelope with `status: completed | checkpoint | blocked | failed`, include `files_written`, and write `{phase_dir}/CONSISTENCY-CHECK.md`. Append the same typed YAML `gpd_return` block to `{phase_dir}/CONSISTENCY-CHECK.md` before returning so the canonical applicator can validate the durable handoff from the artifact itself.
 ", subagent_type="gpd-consistency-checker", model="{consistency_model}", readonly=false, description="Rapid consistency check")
 
 **Artifact gate:** Do not accept `gpd_return.status: completed` until `{phase_dir}/CONSISTENCY-CHECK.md` exists on disk. If the artifact is missing, treat the handoff as blocked even when the runtime reported success.
@@ -1814,7 +1814,7 @@ fi
 - `gpd_return.status: checkpoint`: stop, surface the checkpoint payload from the checker, and end with `## > Next Up`: primary `gpd:resume-work`, plus `gpd:validate-conventions` and `gpd:suggest-next`. Do not wait in place for user input inside this run.
 - `gpd_return.status: blocked` / `gpd_return.status: failed`: stop execution, surface the returned issues, and end with `## > Next Up`: primary `gpd:validate-conventions`, plus `gpd:resume-work` and `gpd:suggest-next`. If the user wants convention repair, route through `gpd:validate-conventions`; the fresh continuation handoff owns any notation-coordinator work.
 
-**If the checker output is malformed or omits `gpd_return.status`:** Treat it as blocked. Do not infer success from prose headings or untyped routing.
+**If the checker output is malformed or omits `gpd_return.status`:** Treat it as blocked. Do not infer success from prose headings or untyped routing. Do not hand-author or paste a synthetic `gpd_return` into an already-returned report in the orchestrator; retry or repair the checker handoff so the child owns the typed envelope.
 
 Convention repair is intentionally out-of-line here. Do not spawn `gpd-notation-coordinator` from `execute-phase`, do not route on checker-local prose markers, and do not accept a stale convention document as proof of repair. The next step is `gpd:validate-conventions`, followed by `gpd:resume-work` or a fresh `gpd:execute-phase {PHASE_NUMBER}` continuation after that workflow reports a typed result and the convention lock is valid.
 

--- a/src/gpd/specs/workflows/verify-work-stage-manifest.json
+++ b/src/gpd/specs/workflows/verify-work-stage-manifest.json
@@ -122,7 +122,7 @@
         "inventory_build"
       ],
       "checkpoints": [
-        "proof-bearing work detected",
+        "proof-readiness context loaded; classify proof-bearing status from inspected proof metadata",
         "bootstrap gate remains fail-closed"
       ]
     },

--- a/src/gpd/specs/workflows/verify-work.md
+++ b/src/gpd/specs/workflows/verify-work.md
@@ -9,7 +9,7 @@ The verifier owns target construction, proof policy, checks, comparison verdicts
 
 - Fail closed before delegation if the project, roadmap, contract, or proof readiness are not usable.
 - Present verifier-produced evidence one check at a time and record only the session overlay in this workflow.
-- Every spawned agent is a one-shot delegation: if it needs user input, it must checkpoint and return, and the wrapper must start a fresh continuation after the user responds.
+- Every spawned agent is a one-shot delegation: if it needs user input or new evidence arrives after return, start a fresh continuation; never send more input to closed child.
 - File-producing handoffs must prove the expected artifact exists before success is accepted.
 </philosophy>
 
@@ -174,9 +174,11 @@ PHASE_DIR_ABS=$(echo "$PHASE_BOOTSTRAP_INIT" | gpd json get .phase_dir_abs --def
 
 Use `phase_bootstrap.required_init_fields` as the refreshed payload.
 
-Use `phase_proof_review_status` as the proof-review freshness summary. If a required proof-redteam audit is missing, stale, malformed, or not `passed`, spawn `gpd-check-proof` once before finalizing the gap ledger.
-Proof-bearing phases require a canonical `*-PROOF-REDTEAM.md` artifact.
-For proof-bearing work, an additional mandatory floor applies before the wrapper can accept a passed verification result.
+`staged_loading.checkpoints` is not a proof classifier; ignore `phase_proof_review_status.state=not_reviewed|fresh` alone.
+Classify proof-bearing only from research artifacts; exclude installed runtime/config/skills trees and generated manifests.
+
+Use `phase_proof_review_status` as the proof-review freshness summary. For proof-bearing work, require a canonical `*-PROOF-REDTEAM.md` artifact; if missing/stale/malformed/not `passed`, spawn `gpd-check-proof` once before finalizing gaps.
+This additional mandatory floor applies.
 
 ```bash
 CHECK_PROOF_MODEL=$(gpd resolve-model gpd-check-proof)
@@ -516,9 +518,8 @@ gpd commit "verify(${phase_number}): complete research validation - {passed} pas
 gpd --raw state record-verification --phase "${phase_number}"
 ```
 
-The command reads the canonical verification frontmatter `status:` field and
-transitions STATE.md / state.json to `Verified` on pass or `Blocked` on fail.
-Pass `--status passed|failed` explicitly only when bypassing the frontmatter.
+`record-verification` reads frontmatter `status:` (`passed` -> `Verified`; non-passed -> `Blocked`).
+Use `--status passed|failed` only when bypassing frontmatter. Barrier: wait before state get/validate/repair; never parallelize state mutation with validation.
 
 Present the summary of passed, issue, and skipped checks. Do not relax verifier fail-closed results.
 

--- a/tests/adapters/test_codex.py
+++ b/tests/adapters/test_codex.py
@@ -83,7 +83,8 @@ def test_codex_command_runtime_note_injection_is_idempotent() -> None:
     assert twice.count("Codex shell compatibility:") == 1
     assert twice.count("When shell steps call the GPD CLI") == 1
     assert f"put the runtime bridge directly in command position: {launcher}" in twice
-    assert f'GPD_CLI="{launcher}"' in twice
+    assert "Do not store it in a scalar variable" in twice
+    assert "GPD_CLI=" not in twice
     assert f'gpd_cli() {{ {launcher} "$@"; }}' in twice
     assert "use `cmd_status=$?`; `status` is a reserved read-only parameter" in twice
     assert "The bridge already pins Codex" not in twice
@@ -773,7 +774,8 @@ class TestInstall:
 
         assert "Codex shell compatibility:" in skill
         assert f"When shell steps call the GPD CLI, put the runtime bridge directly in command position: {expected_bridge}" in skill
-        assert f'GPD_CLI="{expected_bridge}"' in skill
+        assert "Do not store it in a scalar variable" in skill
+        assert "GPD_CLI=" not in skill
         assert f'gpd_cli() {{ {expected_bridge} "$@"; }}' in skill
         assert "use `cmd_status=$?`; `status` is a reserved read-only parameter" in skill
         assert "The bridge already pins Codex" not in skill

--- a/tests/adapters/test_codex.py
+++ b/tests/adapters/test_codex.py
@@ -82,6 +82,10 @@ def test_codex_command_runtime_note_injection_is_idempotent() -> None:
     assert twice.count("<codex_runtime_notes>") == 1
     assert twice.count("Codex shell compatibility:") == 1
     assert twice.count("When shell steps call the GPD CLI") == 1
+    assert f"put the runtime bridge directly in command position: {launcher}" in twice
+    assert f'GPD_CLI="{launcher}"' in twice
+    assert f'gpd_cli() {{ {launcher} "$@"; }}' in twice
+    assert "use `cmd_status=$?`; `status` is a reserved read-only parameter" in twice
     assert "The bridge already pins Codex" not in twice
 
 
@@ -768,7 +772,10 @@ class TestInstall:
         agent = (target / "agents" / "gpd-planner.md").read_text(encoding="utf-8")
 
         assert "Codex shell compatibility:" in skill
-        assert f"When shell steps call the GPD CLI, use {expected_bridge}" in skill
+        assert f"When shell steps call the GPD CLI, put the runtime bridge directly in command position: {expected_bridge}" in skill
+        assert f'GPD_CLI="{expected_bridge}"' in skill
+        assert f'gpd_cli() {{ {expected_bridge} "$@"; }}' in skill
+        assert "use `cmd_status=$?`; `status` is a reserved read-only parameter" in skill
         assert "The bridge already pins Codex" not in skill
         assert "`GPD_ACTIVE_RUNTIME=codex uv run gpd ...`" not in skill
         assert expected_bridge + " config ensure-section" in skill

--- a/tests/adapters/test_install_roundtrip.py
+++ b/tests/adapters/test_install_roundtrip.py
@@ -396,7 +396,10 @@ def _assert_installed_contract_visibility(
     assert "{plan_id}-PROOF-REDTEAM.md" in execute_phase
     assert "Targeted flags narrow the optional check mix only." in verify_work
     assert "Every spawned agent is a one-shot delegation" in verify_work
-    assert "If a required proof-redteam audit is missing, stale, malformed, or not `passed`, spawn `gpd-check-proof` once" in verify_work
+    assert (
+        "For proof-bearing work, require a canonical `*-PROOF-REDTEAM.md` artifact; "
+        "if missing/stale/malformed/not `passed`, spawn `gpd-check-proof` once"
+    ) in verify_work
 
 
 @pytest.mark.parametrize("runtime", FULL_RUNTIME_MATRIX)

--- a/tests/adapters/test_runtime_projected_prompt_parity.py
+++ b/tests/adapters/test_runtime_projected_prompt_parity.py
@@ -41,7 +41,7 @@ VERIFIER_SCHEMA_INCLUDE_SUFFIXES = (
 VERIFY_WORK_CONCISE_GUIDANCE_FRAGMENTS = (
     "Every spawned agent is a one-shot delegation",
     "File-producing handoffs must prove the expected artifact exists before success is accepted.",
-    "If a required proof-redteam audit is missing, stale, malformed, or not `passed`, spawn `gpd-check-proof` once",
+    "For proof-bearing work, require a canonical `*-PROOF-REDTEAM.md` artifact; if missing/stale/malformed/not `passed`, spawn `gpd-check-proof` once",
     "Route only on the canonical verification frontmatter and `gpd_return.status`",
     "Do not recompute canonical verification status in this workflow.",
     "verification_report_skeleton_bridge",

--- a/tests/core/test_execute_phase_consistency_contract.py
+++ b/tests/core/test_execute_phase_consistency_contract.py
@@ -20,6 +20,10 @@ def test_execute_phase_consistency_check_uses_typed_return_and_file_gate() -> No
     assert "expected_artifacts:" in workflow
     assert "{phase_dir}/CONSISTENCY-CHECK.md" in workflow
     assert "Return exactly one typed `gpd_return` envelope with `status: completed | checkpoint | blocked | failed`" in workflow
+    assert (
+        "Append the same typed YAML `gpd_return` block to `{phase_dir}/CONSISTENCY-CHECK.md` before returning"
+        in workflow
+    )
     assert "Artifact gate:" in workflow
     assert "gpd_return.status: completed" in workflow
     assert "gpd_return.status: checkpoint" in workflow
@@ -38,3 +42,4 @@ def test_execute_phase_consistency_check_no_longer_routes_on_legacy_status() -> 
     assert "Proceed without cross-phase consistency checking for this wave." not in workflow
     assert "Present issues to user with resolution options" not in workflow
     assert "Do not infer success from prose headings or untyped routing." in workflow
+    assert "Do not hand-author or paste a synthetic `gpd_return`" in workflow

--- a/tests/core/test_phase_lifecycle_live_contract.py
+++ b/tests/core/test_phase_lifecycle_live_contract.py
@@ -219,6 +219,10 @@ def test_completed_phase_suggests_active_runtime_verify_work_not_structural_veri
 
     result = suggest_next(tmp_path)
 
-    verify = next(suggestion for suggestion in result.suggestions if suggestion.action == "verify-work")
+    verify = next((suggestion for suggestion in result.suggestions if suggestion.action == "verify-work"), None)
+    assert verify is not None, (
+        f"No 'verify-work' suggestion found for runtime={runtime!r}; "
+        f"got: {[suggestion.action for suggestion in result.suggestions]}"
+    )
     assert verify.command == f"{adapter.format_command('verify-work')} 02"
     assert "gpd verify phase" not in verify.command

--- a/tests/core/test_phase_lifecycle_live_contract.py
+++ b/tests/core/test_phase_lifecycle_live_contract.py
@@ -1,0 +1,224 @@
+"""End-to-end phase lifecycle contracts that mirror live agent handoffs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from gpd.adapters import get_adapter
+from gpd.adapters.runtime_catalog import iter_runtime_descriptors
+from gpd.cli import app
+from gpd.core.state import default_state_dict, generate_state_markdown
+from gpd.core.suggest import suggest_next
+from tests.runtime_install_helpers import seed_complete_runtime_install
+
+
+class _StableCliRunner(CliRunner):
+    def invoke(self, *args, **kwargs):
+        kwargs.setdefault("color", False)
+        return super().invoke(*args, **kwargs)
+
+
+RUNNER = _StableCliRunner()
+_RUNTIME_NAMES = tuple(descriptor.runtime_name for descriptor in iter_runtime_descriptors())
+
+
+def _write_phase_project(
+    root: Path,
+    *,
+    phase: str = "02",
+    phase_name: str = "analysis",
+    current_plan: int = 2,
+    total_plans: int = 2,
+    status: str = "Ready to execute",
+    summaries: int = 2,
+) -> Path:
+    gpd_dir = root / "GPD"
+    phase_dir = gpd_dir / "phases" / f"{phase}-{phase_name}"
+    phase_dir.mkdir(parents=True)
+    (gpd_dir / "PROJECT.md").write_text("# Project\n", encoding="utf-8")
+    (gpd_dir / "ROADMAP.md").write_text(
+        "# Roadmap\n\n"
+        "## Phase 1: Setup\n\n"
+        "## Phase 2: Analysis\n\n"
+        "## Phase 3: Synthesis\n",
+        encoding="utf-8",
+    )
+    for index in range(1, total_plans + 1):
+        (phase_dir / f"{phase}-{index:02d}-PLAN.md").write_text(
+            f"# Phase {phase} Plan {index:02d}\n",
+            encoding="utf-8",
+        )
+    for index in range(1, summaries + 1):
+        (phase_dir / f"{phase}-{index:02d}-SUMMARY.md").write_text(
+            f"# Phase {phase} Plan {index:02d} Summary\n",
+            encoding="utf-8",
+        )
+
+    state = default_state_dict()
+    state["position"]["current_phase"] = phase
+    state["position"]["current_phase_name"] = phase_name.title()
+    state["position"]["current_plan"] = str(current_plan)
+    state["position"]["total_plans_in_phase"] = total_plans
+    state["position"]["total_phases"] = 3
+    state["position"]["progress_percent"] = 66
+    state["position"]["status"] = status
+    (gpd_dir / "state.json").write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+    (gpd_dir / "STATE.md").write_text(generate_state_markdown(state), encoding="utf-8")
+    return phase_dir
+
+
+def _write_completed_return(summary_path: Path, *, phase: str = "02", plan: str = "02") -> None:
+    summary_path.write_text(
+        "# Completed Summary\n\n"
+        "```yaml\n"
+        "gpd_return:\n"
+        "  status: completed\n"
+        f"  files_written: [{summary_path.as_posix()}]\n"
+        "  issues: []\n"
+        f"  next_actions: [gpd:verify-work {phase}]\n"
+        f"  phase: \"{phase}\"\n"
+        f"  plan: \"{plan}\"\n"
+        "  tasks_completed: 1\n"
+        "  tasks_total: 1\n"
+        "  duration_seconds: 12\n"
+        "  state_updates:\n"
+        "    advance_plan: true\n"
+        "    update_progress: true\n"
+        "    record_metric:\n"
+        f"      phase: \"{phase}\"\n"
+        f"      plan: \"{plan}\"\n"
+        "      duration: \"12s\"\n"
+        "      tasks: \"1\"\n"
+        "      files: \"1\"\n"
+        "```\n",
+        encoding="utf-8",
+    )
+
+
+def _write_gap_verification(report_path: Path) -> None:
+    report_path.write_text(
+        "---\n"
+        "phase: 02-analysis\n"
+        'verified: "2026-05-07T00:00:00Z"\n'
+        "status: gaps_found\n"
+        'score: "0/1 contract targets verified"\n'
+        "---\n\n"
+        "# Phase 02 Verification\n\n"
+        "```bash\n"
+        "printf 'missing benchmark evidence\\n'\n"
+        "```\n\n"
+        "**Output:**\n\n"
+        "```output\n"
+        "missing benchmark evidence\n"
+        "```\n\n"
+        "FAIL: benchmark evidence is absent.\n",
+        encoding="utf-8",
+    )
+
+
+def test_apply_return_updates_completes_last_plan_from_ready_to_execute_state(tmp_path: Path) -> None:
+    """A final-plan child return should not require manual Ready -> Executing repair."""
+    phase_dir = _write_phase_project(tmp_path, status="Ready to execute")
+    summary = phase_dir / "02-02-SUMMARY.md"
+    _write_completed_return(summary)
+
+    result = RUNNER.invoke(
+        app,
+        [
+            "--raw",
+            "--cwd",
+            str(tmp_path),
+            "apply-return-updates",
+            "GPD/phases/02-analysis/02-02-SUMMARY.md",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["passed"] is True
+    assert "advance_plan:last_plan" in payload["applied_state_operations"]
+    state = json.loads((tmp_path / "GPD" / "state.json").read_text(encoding="utf-8"))
+    assert state["position"]["status"] == "Phase complete \u2014 ready for verification"
+
+
+def test_apply_return_updates_rejects_report_without_gpd_return_without_mutating_state(tmp_path: Path) -> None:
+    phase_dir = _write_phase_project(tmp_path, status="Ready to execute")
+    report = phase_dir / "CONSISTENCY-CHECK.md"
+    report.write_text("# Consistency Check\n\nNo issues found.\n", encoding="utf-8")
+    before_state = (tmp_path / "GPD" / "state.json").read_text(encoding="utf-8")
+
+    result = RUNNER.invoke(
+        app,
+        [
+            "--raw",
+            "--cwd",
+            str(tmp_path),
+            "apply-return-updates",
+            "GPD/phases/02-analysis/CONSISTENCY-CHECK.md",
+        ],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["passed"] is False
+    assert payload["errors"] == ["No gpd_return YAML block found"]
+    assert (tmp_path / "GPD" / "state.json").read_text(encoding="utf-8") == before_state
+
+
+@pytest.mark.parametrize("initial_status", ["verifying", "Phase complete \u2014 ready for verification"])
+def test_record_verification_maps_gap_report_to_blocked_and_keeps_state_surfaces_in_sync(
+    tmp_path: Path,
+    initial_status: str,
+) -> None:
+    phase_dir = _write_phase_project(tmp_path, status=initial_status)
+    _write_gap_verification(phase_dir / "02-VERIFICATION.md")
+
+    result = RUNNER.invoke(
+        app,
+        [
+            "--raw",
+            "--cwd",
+            str(tmp_path),
+            "state",
+            "record-verification",
+            "--phase",
+            "02",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["recorded"] is True
+    assert payload["status"] == "Blocked"
+    assert payload["previous_status"] == initial_status
+
+    state = json.loads((tmp_path / "GPD" / "state.json").read_text(encoding="utf-8"))
+    markdown = (tmp_path / "GPD" / "STATE.md").read_text(encoding="utf-8")
+    assert state["position"]["status"] == "Blocked"
+    assert "**Status:** Blocked" in markdown
+
+    validation = RUNNER.invoke(app, ["--raw", "--cwd", str(tmp_path), "state", "validate"])
+    assert validation.exit_code == 0, validation.output
+    validation_payload = json.loads(validation.output)
+    assert validation_payload["valid"] is True
+    assert validation_payload["integrity_status"] == "healthy"
+
+
+@pytest.mark.parametrize("runtime", _RUNTIME_NAMES)
+def test_completed_phase_suggests_active_runtime_verify_work_not_structural_verify_phase(
+    tmp_path: Path,
+    runtime: str,
+) -> None:
+    adapter = get_adapter(runtime)
+    seed_complete_runtime_install(tmp_path / adapter.local_config_dir_name, runtime=runtime)
+    _write_phase_project(tmp_path, status="Phase complete \u2014 ready for verification", summaries=2)
+
+    result = suggest_next(tmp_path)
+
+    verify = next(suggestion for suggestion in result.suggestions if suggestion.action == "verify-work")
+    assert verify.command == f"{adapter.format_command('verify-work')} 02"
+    assert "gpd verify phase" not in verify.command

--- a/tests/core/test_prompt_cli_consistency.py
+++ b/tests/core/test_prompt_cli_consistency.py
@@ -278,7 +278,8 @@ def test_agent_infrastructure_distinguishes_structural_phase_verify_from_verify_
     )
 
     assert "These terminal `gpd verify ...` commands are structural checks." in text
-    assert "They do not\nreplace the runtime `gpd:verify-work <phase>` workflow" in text
+    assert "They do not" in text
+    assert "replace the runtime `gpd:verify-work <phase>` workflow" in text
     assert "# Structural completeness only: all plans have `*-SUMMARY.md`" in text
     assert "gpd verify phase <phase-number>" in text
 

--- a/tests/core/test_prompt_cli_consistency.py
+++ b/tests/core/test_prompt_cli_consistency.py
@@ -272,6 +272,17 @@ def test_prompt_shell_fences_do_not_add_runtime_command_labels() -> None:
     assert offenders == []
 
 
+def test_agent_infrastructure_distinguishes_structural_phase_verify_from_verify_work() -> None:
+    text = (REPO_ROOT / "src/gpd/specs/references/orchestration/agent-infrastructure.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "These terminal `gpd verify ...` commands are structural checks." in text
+    assert "They do not\nreplace the runtime `gpd:verify-work <phase>` workflow" in text
+    assert "# Structural completeness only: all plans have `*-SUMMARY.md`" in text
+    assert "gpd verify phase <phase-number>" in text
+
+
 def test_command_looking_fences_are_explicitly_labeled() -> None:
     offenders: list[str] = []
 

--- a/tests/core/test_verify_work_child_return_contracts.py
+++ b/tests/core/test_verify_work_child_return_contracts.py
@@ -245,6 +245,10 @@ def test_verify_work_proof_check_handoff_uses_structured_freshness_and_fail_clos
     workflow = _read(WORKFLOWS_DIR / "verify-work.md")
 
     assert "Use `phase_proof_review_status` as the proof-review freshness summary." in workflow
+    assert "`staged_loading.checkpoints` is not a proof classifier" in workflow
+    assert "ignore `phase_proof_review_status.state=not_reviewed|fresh` alone" in workflow
+    assert "Classify proof-bearing only from research artifacts" in workflow
+    assert "exclude installed runtime/config/skills trees" in workflow
     assert (
         "> Runtime delegation rule: this is a single-turn handoff. If the spawned agent needs user input, it checkpoints and returns; do not keep the original run waiting inside the same task."
         in workflow
@@ -263,3 +267,13 @@ def test_verify_work_proof_check_handoff_uses_structured_freshness_and_fail_clos
         in workflow
     )
     assert "File-producing handoffs must prove the expected artifact exists before success is accepted." in workflow
+    assert "never send more input to closed child" in workflow
+
+
+def test_verify_work_record_verification_state_closeout_is_sequential() -> None:
+    workflow = _read(WORKFLOWS_DIR / "verify-work.md")
+
+    assert 'gpd --raw state record-verification --phase "${phase_number}"' in workflow
+    assert "Use `--status passed|failed` only when bypassing frontmatter." in workflow
+    assert "Barrier: wait before state get/validate/repair" in workflow
+    assert "never parallelize state mutation with validation." in workflow

--- a/tests/core/test_workflow_staging.py
+++ b/tests/core/test_workflow_staging.py
@@ -207,6 +207,11 @@ def test_validate_workflow_stage_manifest_payload_loads_verify_work_manifest() -
     assert "project_contract_validation" in manifest.stages[0].required_init_fields
     assert "references/verification/core/verification-core.md" in manifest.stages[1].must_not_eager_load
     assert "phase_proof_review_status" in manifest.stages[1].required_init_fields
+    assert "proof-bearing work detected" not in manifest.stages[1].checkpoints
+    assert (
+        "proof-readiness context loaded; classify proof-bearing status from inspected proof metadata"
+        in manifest.stages[1].checkpoints
+    )
     assert manifest.stages[2].loaded_authorities == (
         "workflows/verify-work.md",
         "references/verification/meta/verification-independence.md",


### PR DESCRIPTION
## Summary

This PR adds live-style phase lifecycle coverage for the weird agent behaviors seen during GPD runs and fixes the concrete failures those runs exposed.

Behavior changes:
- final child returns can advance directly from `Ready to execute` to `Phase complete — ready for verification` without manual state repair
- verification closeout maps canonical non-passed statuses such as `gaps_found`, `expert_needed`, `human_needed`, and `blocked` to shared `Blocked` state
- `verify-work` suggestions now stay on active runtime commands instead of structural `gpd verify phase`
- consistency checker artifacts must carry the embedded `gpd_return` envelope required by the applicator
- `verify-work` proof routing no longer treats staged-loading checkpoints or fresh/not-reviewed proof status as proof-bearing work by themselves
- Codex runtime guidance now uses a callable bridge function and avoids zsh's read-only `status` variable
- verify-work one-shot child guidance now says to start a fresh continuation instead of sending input to a closed child

## Validation

- `uv run pytest tests/ -q` -> `9953 passed, 4 skipped`
- focused lifecycle/projection suite -> `148 passed`
- `uv run ruff check ...` -> passed
- `git diff --cached --check` -> passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified distinction between structural `gpd verify` checks and the runtime `verify-work` workflow; expanded verification command guidance.
  * Revised runtime CLI bridge usage guidance for shell steps (command-position insertion, wrapper usage, reserved-status handling).

* **Bug Fixes**
  * Tightened proof-bearing validation: require canonical proof artifact presence/passed status and spawn proof checks when missing/stale.
  * Expanded and clarified state transition and verification normalization rules.

* **Tests**
  * Updated and added tests to assert the new verification, proof-classification, and lifecycle behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->