### PR TITLE
fix(context): accept numeric step in GPD/init-progress.json validator

### DIFF
--- a/src/gpd/core/context.py
+++ b/src/gpd/core/context.py
@@ -920,7 +920,12 @@ def _new_project_init_progress_context(cwd: Path) -> dict[str, object]:
 
     step = payload.get("step")
     description = payload.get("description")
-    normalized_step = step.strip() if isinstance(step, str) else ""
+    if isinstance(step, str):
+        normalized_step = step.strip()
+    elif isinstance(step, (int, float)) and not isinstance(step, bool):
+        normalized_step = str(step)
+    else:
+        normalized_step = ""
     normalized_description = description.strip() if isinstance(description, str) else ""
     if not normalized_step:
         result["init_progress_status"] = "corrupt_init_progress"


### PR DESCRIPTION
The `_new_project_init_progress_context` validator only accepts `step: str`, but every checkpoint writer in `specs/workflows/new-project.md` emits a numeric step (`{"step": 4, ...}` through `8.5`). The result is that every successful checkpoint write is classified `corrupt_init_progress` on the next read, blocking resume of any interrupted bootstrap.

Loosens the validator to accept `int`/`float` (excluding `bool`) and string-coerce, so the downstream `init_progress_step` context value still hands the workflow prompt a string.

Verified empirically against the same code path: int/float steps now classify `interrupted_init_progress`; non-numeric/non-string still classifies `corrupt_init_progress`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced project initialization progress tracking with improved data normalization
  * Extended support for numeric step values (integers and floating-point numbers) in progress data
  * Strengthened error handling for non-standard or corrupted progress formats while maintaining existing error recovery behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->