### PR TITLE
fix(arxiv): make source storage path project-aware

### DIFF
--- a/src/gpd/core/arxiv_source_download.py
+++ b/src/gpd/core/arxiv_source_download.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import re
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass
 from email.message import Message
 from pathlib import Path
@@ -18,6 +20,8 @@ logger = logging.getLogger(__name__)
 
 ARXIV_SOURCE_URL_TEMPLATE = "https://arxiv.org/e-print/{arxiv_id}"
 ARXIV_SOURCE_STORAGE_DIRNAME = "sources"
+ARXIV_SOURCE_STORAGE_ENV_VAR = "GPD_ARXIV_SOURCE_DIR"
+ARXIV_PROJECT_LOCAL_CACHE_DIRNAME = ".arxiv-cache"
 ARXIV_SOURCE_USER_AGENT_TEMPLATE = "get-physics-done/{version} (https://github.com/psi-oss/get-physics-done)"
 ARXIV_SOURCE_TIMEOUT_SECONDS = 60
 ARXIV_SOURCE_CHUNK_BYTES = 64 * 1024
@@ -50,6 +54,65 @@ def default_arxiv_source_storage_path() -> Path:
     """Return the default arXiv source storage root using the current home directory."""
 
     return Path.home() / ".arxiv-mcp-server" / "papers"
+
+
+def _env_arxiv_source_storage_path(environ: Mapping[str, str] | None = None) -> Path | None:
+    """Return the storage path from ``GPD_ARXIV_SOURCE_DIR`` if it is set and non-empty."""
+
+    env = os.environ if environ is None else environ
+    raw = env.get(ARXIV_SOURCE_STORAGE_ENV_VAR)
+    if not isinstance(raw, str):
+        return None
+    cleaned = raw.strip()
+    if not cleaned:
+        return None
+    return Path(cleaned).expanduser()
+
+
+def _project_local_arxiv_source_storage_path(workspace: Path | str | None = None) -> Path | None:
+    """Return ``<project_root>/.arxiv-cache`` when invoked inside a verified GPD project.
+
+    Detection uses the same marker-backed walk as the rest of the gpd
+    runtime: a ``GPD/`` directory is required for a hit. We import the
+    resolver lazily to avoid a hard import cycle through ``gpd.core``.
+    """
+
+    from gpd.core.root_resolution import resolve_project_root
+
+    candidate = Path(workspace) if workspace is not None else Path.cwd()
+    project_root = resolve_project_root(candidate, require_layout=True)
+    if project_root is None:
+        return None
+    return project_root / ARXIV_PROJECT_LOCAL_CACHE_DIRNAME
+
+
+def resolve_default_arxiv_storage_path(
+    workspace: Path | str | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Return the storage root the bridge should use when no caller override is supplied.
+
+    Precedence (highest first):
+
+    1. ``GPD_ARXIV_SOURCE_DIR`` environment variable
+    2. ``<project_root>/.arxiv-cache`` when *workspace* (or current working directory)
+       resolves to a verified GPD project layout
+    3. The legacy home cache at ``~/.arxiv-mcp-server/papers``
+
+    The legacy fallback preserves backward compatibility for invocations outside a
+    project (for example, when arxiv tools run from a bare shell with no GPD layout).
+    """
+
+    env_path = _env_arxiv_source_storage_path(environ)
+    if env_path is not None:
+        return env_path
+
+    project_path = _project_local_arxiv_source_storage_path(workspace)
+    if project_path is not None:
+        return project_path
+
+    return default_arxiv_source_storage_path()
 
 
 @dataclass(frozen=True, slots=True)
@@ -302,13 +365,16 @@ def download_arxiv_source_archive(
 
 
 __all__ = [
+    "ARXIV_PROJECT_LOCAL_CACHE_DIRNAME",
     "ARXIV_SOURCE_MAX_BYTES",
     "ARXIV_SOURCE_STORAGE_DIRNAME",
+    "ARXIV_SOURCE_STORAGE_ENV_VAR",
     "ArxivSourceDownload",
     "arxiv_source_user_agent",
     "build_source_download_url",
     "default_arxiv_source_storage_path",
     "download_arxiv_source_archive",
     "normalize_arxiv_id",
+    "resolve_default_arxiv_storage_path",
     "resolve_source_storage_dir",
 ]

--- a/src/gpd/mcp/servers/arxiv_bridge.py
+++ b/src/gpd/mcp/servers/arxiv_bridge.py
@@ -19,6 +19,7 @@ from mcp.server.stdio import stdio_server
 from gpd.core.arxiv_source_download import (
     default_arxiv_source_storage_path,
     download_arxiv_source_archive,
+    resolve_default_arxiv_storage_path,
 )
 from gpd.mcp.servers import mutating_tool_annotations
 from gpd.version import __version__ as GPD_VERSION
@@ -77,10 +78,26 @@ class ArxivBridgeConfig:
     storage_path: Path = field(default_factory=default_arxiv_source_storage_path)
 
 
-def load_settings(*, storage_path: str | Path | None = None) -> ArxivBridgeConfig:
-    """Load bridge settings for the upstream server and local source archive storage."""
+def load_settings(
+    *,
+    storage_path: str | Path | None = None,
+    workspace: str | Path | None = None,
+) -> ArxivBridgeConfig:
+    """Load bridge settings for the upstream server and local source archive storage.
 
-    resolved = default_arxiv_source_storage_path() if storage_path is None else Path(storage_path)
+    When *storage_path* is not supplied, the storage root is resolved from
+    :func:`gpd.core.arxiv_source_download.resolve_default_arxiv_storage_path`,
+    which honors ``GPD_ARXIV_SOURCE_DIR`` first, then a project-local
+    ``<project_root>/.arxiv-cache`` directory when invoked inside a verified
+    GPD project, and finally falls back to the legacy
+    ``~/.arxiv-mcp-server/papers`` cache so callers running outside any
+    project remain backward-compatible.
+    """
+
+    if storage_path is None:
+        resolved = resolve_default_arxiv_storage_path(workspace)
+    else:
+        resolved = Path(storage_path)
     return ArxivBridgeConfig(storage_path=resolved.expanduser().resolve(strict=False))
 
 
@@ -265,12 +282,23 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="GPD arXiv MCP bridge")
     parser.add_argument("--transport", choices=["stdio"], default="stdio")
     parser.add_argument("--storage-path", default=None)
+    parser.add_argument(
+        "--workspace",
+        default=None,
+        help=(
+            "Workspace hint used when --storage-path is not supplied. "
+            "Defaults to the current working directory; the bridge prefers a "
+            "project-local <project_root>/.arxiv-cache when the workspace "
+            "resolves to a verified GPD project, and falls back to "
+            "~/.arxiv-mcp-server/papers otherwise."
+        ),
+    )
     return parser.parse_args()
 
 
 async def _run() -> None:
     args = _parse_args()
-    config = load_settings(storage_path=args.storage_path)
+    config = load_settings(storage_path=args.storage_path, workspace=args.workspace)
     server, _bridge = build_server(config)
     async with stdio_server() as (read_stream, write_stream):
         await server.run(

--- a/tests/core/test_arxiv_source_download.py
+++ b/tests/core/test_arxiv_source_download.py
@@ -7,13 +7,16 @@ from unittest.mock import patch
 import pytest
 
 from gpd.core.arxiv_source_download import (
+    ARXIV_PROJECT_LOCAL_CACHE_DIRNAME,
     ARXIV_SOURCE_MAX_BYTES,
+    ARXIV_SOURCE_STORAGE_ENV_VAR,
     ArxivSourceDownload,
     arxiv_source_user_agent,
     build_source_download_url,
     default_arxiv_source_storage_path,
     download_arxiv_source_archive,
     normalize_arxiv_id,
+    resolve_default_arxiv_storage_path,
     resolve_source_storage_dir,
 )
 from gpd.version import resolve_active_version
@@ -244,3 +247,71 @@ def test_download_arxiv_source_archive_rejects_streams_that_grow_too_large(tmp_p
     with patch("gpd.core.arxiv_source_download.urlopen", return_value=response):
         with pytest.raises(ConnectionError, match="exceeds size limit"):
             download_arxiv_source_archive("2401.12345", storage_path=tmp_path)
+
+
+def _make_verified_gpd_project(root: Path) -> Path:
+    """Create the minimum set of markers that ``resolve_project_root`` accepts."""
+
+    gpd_dir = root / "GPD"
+    gpd_dir.mkdir(parents=True, exist_ok=True)
+    (gpd_dir / "state.json").write_text("{}", encoding="utf-8")
+    (gpd_dir / "PROJECT.md").write_text("# project\n", encoding="utf-8")
+    return root
+
+
+def test_resolve_default_storage_path_honors_env_var_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    override = tmp_path / "override-cache"
+    monkeypatch.setenv(ARXIV_SOURCE_STORAGE_ENV_VAR, str(override))
+
+    # Even when called from inside a verified GPD project, the env var wins.
+    project = _make_verified_gpd_project(tmp_path / "proj")
+    monkeypatch.chdir(project)
+
+    resolved = resolve_default_arxiv_storage_path()
+
+    assert resolved == override
+    # Sanity: env var override is independent of the legacy home cache.
+    assert resolved != default_arxiv_source_storage_path()
+
+
+def test_resolve_default_storage_path_uses_project_local_cache_when_inside_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ARXIV_SOURCE_STORAGE_ENV_VAR, raising=False)
+    project = _make_verified_gpd_project(tmp_path / "physics-paper")
+
+    resolved = resolve_default_arxiv_storage_path(project)
+
+    assert resolved == project / ARXIV_PROJECT_LOCAL_CACHE_DIRNAME
+
+
+def test_resolve_default_storage_path_falls_back_to_home_outside_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.delenv(ARXIV_SOURCE_STORAGE_ENV_VAR, raising=False)
+    home = tmp_path / "home"
+    monkeypatch.setattr("gpd.core.arxiv_source_download.Path.home", lambda: home)
+
+    bare = tmp_path / "no-project-here"
+    bare.mkdir()
+
+    resolved = resolve_default_arxiv_storage_path(bare)
+
+    assert resolved == home / ".arxiv-mcp-server" / "papers"
+
+
+def test_resolve_default_storage_path_ignores_blank_env_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv(ARXIV_SOURCE_STORAGE_ENV_VAR, "   ")
+    home = tmp_path / "home"
+    monkeypatch.setattr("gpd.core.arxiv_source_download.Path.home", lambda: home)
+
+    bare = tmp_path / "no-project-here"
+    bare.mkdir()
+
+    resolved = resolve_default_arxiv_storage_path(bare)
+
+    assert resolved == home / ".arxiv-mcp-server" / "papers"

--- a/tests/mcp/test_arxiv_bridge.py
+++ b/tests/mcp/test_arxiv_bridge.py
@@ -11,10 +11,18 @@ def test_load_settings_uses_current_home_for_default_storage_root(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
+    from gpd.core.arxiv_source_download import ARXIV_SOURCE_STORAGE_ENV_VAR
     from gpd.mcp.servers.arxiv_bridge import ArxivBridgeConfig, load_settings
 
+    monkeypatch.delenv(ARXIV_SOURCE_STORAGE_ENV_VAR, raising=False)
     home = tmp_path / "home"
     monkeypatch.setattr("gpd.core.arxiv_source_download.Path.home", lambda: home)
+
+    # Run the resolver from a directory that has no GPD/ markers so we
+    # exercise the legacy home fallback rather than auto-detecting a project.
+    bare_dir = tmp_path / "bare"
+    bare_dir.mkdir()
+    monkeypatch.chdir(bare_dir)
 
     config = load_settings()
     dataclass_default = ArxivBridgeConfig()
@@ -395,6 +403,63 @@ def test_build_server_registers_expected_server_name() -> None:
 
     assert server.name == "gpd-arxiv"
     assert bridge.config.storage_path.is_absolute()
+
+
+def _make_verified_gpd_project(root):
+    gpd_dir = root / "GPD"
+    gpd_dir.mkdir(parents=True, exist_ok=True)
+    (gpd_dir / "state.json").write_text("{}", encoding="utf-8")
+    (gpd_dir / "PROJECT.md").write_text("# project\n", encoding="utf-8")
+    return root
+
+
+def test_load_settings_honors_env_var_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from gpd.core.arxiv_source_download import ARXIV_SOURCE_STORAGE_ENV_VAR
+    from gpd.mcp.servers.arxiv_bridge import load_settings
+
+    override = tmp_path / "env-cache"
+    override.mkdir()
+    monkeypatch.setenv(ARXIV_SOURCE_STORAGE_ENV_VAR, str(override))
+
+    config = load_settings()
+
+    assert config.storage_path == override.resolve()
+
+
+def test_load_settings_prefers_project_local_cache_when_workspace_in_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from gpd.core.arxiv_source_download import (
+        ARXIV_PROJECT_LOCAL_CACHE_DIRNAME,
+        ARXIV_SOURCE_STORAGE_ENV_VAR,
+    )
+    from gpd.mcp.servers.arxiv_bridge import load_settings
+
+    monkeypatch.delenv(ARXIV_SOURCE_STORAGE_ENV_VAR, raising=False)
+    project = _make_verified_gpd_project(tmp_path / "paper-2401-12345")
+
+    config = load_settings(workspace=project)
+
+    expected = (project / ARXIV_PROJECT_LOCAL_CACHE_DIRNAME).resolve()
+    assert config.storage_path == expected
+
+
+def test_load_settings_explicit_storage_path_overrides_env_and_workspace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    from gpd.core.arxiv_source_download import ARXIV_SOURCE_STORAGE_ENV_VAR
+    from gpd.mcp.servers.arxiv_bridge import load_settings
+
+    project = _make_verified_gpd_project(tmp_path / "proj")
+    explicit = tmp_path / "explicit-storage"
+    explicit.mkdir()
+    monkeypatch.setenv(ARXIV_SOURCE_STORAGE_ENV_VAR, str(tmp_path / "env-cache"))
+
+    config = load_settings(storage_path=explicit, workspace=project)
+
+    assert config.storage_path == explicit.resolve()
 
 
 def test_module_entrypoint_runs_main(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`gpd-arxiv_download_source` (the GPD bridge tool) calls
`default_arxiv_source_storage_path()` at
`src/gpd/core/arxiv_source_download.py:49-52`, which hardcodes
`~/.arxiv-mcp-server/papers/`. The bridge then forwards
`--storage-path <that home cache>` to upstream `arxiv_mcp_server` at
`src/gpd/mcp/servers/arxiv_bridge.py:106`.

The result is that source archives extract into
`~/.arxiv-mcp-server/papers/sources/<id>-extracted/`, and once the
agent does its first `Read`/`Edit` inside that tree the entire downstream
workflow anchors there. The compiled artifacts (e.g.
`main_redlined.pdf`) then land inside the user's home cache instead of
their project.

This was confirmed in a 2026-05-08 trace audit of session
`ses_1f702344fffeFnfG2meJRseN9A` (AWG): the agent never `cd`'d back to
the project after `download_source`, every subsequent edit happened in
`~/.arxiv-mcp-server/papers/sources/2401.xxxxx-extracted/`, and AWG had
to manually `cp` the redlined PDF into his project after complaining.

## Fix

- New helper `resolve_default_arxiv_storage_path(workspace=None)` in
  `gpd.core.arxiv_source_download` with the following precedence:

  1. `GPD_ARXIV_SOURCE_DIR` environment variable, if set and non-blank.
  2. `<project_root>/.arxiv-cache/` when the workspace (or current
     working directory) resolves to a verified GPD project layout via
     the existing `gpd.core.root_resolution.resolve_project_root` walk
     (the same `GPD/` + state/marker detection used elsewhere in the
     runtime).
  3. The legacy `~/.arxiv-mcp-server/papers/` cache.

- `arxiv_bridge.load_settings` now defers to that resolver when no
  caller-supplied `storage_path` is provided. It also accepts a new
  optional `workspace` keyword argument so the CLI / programmatic
  callers can supply the workspace explicitly.

- `arxiv_bridge` CLI gains a `--workspace` flag, plumbed into
  `load_settings`. When neither `--storage-path` nor `--workspace` is
  supplied, the resolver uses the bridge's current working directory,
  which in normal GPD usage is the project the agent was invoked from.

- Explicit `--storage-path` (or programmatic `storage_path=...`) still
  wins over both the env var and project auto-detection, preserving the
  existing override path.

## Backward compatibility

When neither `GPD_ARXIV_SOURCE_DIR` is set nor a verified GPD project
layout is present, `resolve_default_arxiv_storage_path()` returns the
exact same path as before
(`Path.home() / ".arxiv-mcp-server" / "papers"`). `ArxivBridgeConfig`
still defaults its dataclass `storage_path` field to
`default_arxiv_source_storage_path()`, so the old test that asserts the
home cache as the dataclass default continues to hold.

## Tests

`tests/core/test_arxiv_source_download.py`:

- `test_resolve_default_storage_path_honors_env_var_override` — env var
  wins even from inside a verified project.
- `test_resolve_default_storage_path_uses_project_local_cache_when_inside_project`
  — auto-detects `<project_root>/.arxiv-cache/`.
- `test_resolve_default_storage_path_falls_back_to_home_outside_project`
  — legacy fallback still applies outside a project.
- `test_resolve_default_storage_path_ignores_blank_env_var` —
  whitespace-only env var is treated as unset.

`tests/mcp/test_arxiv_bridge.py`:

- `test_load_settings_honors_env_var_override`.
- `test_load_settings_prefers_project_local_cache_when_workspace_in_project`.
- `test_load_settings_explicit_storage_path_overrides_env_and_workspace`.
- The pre-existing
  `test_load_settings_uses_current_home_for_default_storage_root` was
  hardened to `monkeypatch.delenv` and `monkeypatch.chdir` into a bare
  directory so it deterministically exercises the legacy fallback.

Local run on this branch:

```
$ uv run pytest tests/ -k arxiv -q
177 passed in 26.98s
```

## Test plan

- [ ] CI passes (`tests/`, ruff).
- [ ] Set `GPD_ARXIV_SOURCE_DIR=/tmp/foo` and run an
      `arxiv_download_source` call; confirm the archive lands in
      `/tmp/foo/sources/<id>...`.
- [ ] Run `arxiv_download_source` from inside a project that has a
      `GPD/` directory; confirm the archive lands in
      `<project_root>/.arxiv-cache/sources/<id>...`.
- [ ] Run `arxiv_download_source` from a bare shell (no `GPD/` and no
      env var); confirm the archive still lands in
      `~/.arxiv-mcp-server/papers/sources/<id>...` for backward compat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment variable support for customizing arXiv source storage location
  * Introduced `--workspace` CLI argument for project-specific arXiv cache management with automatic project detection and home-directory fallback

* **Tests**
  * Added comprehensive test coverage for storage path resolution precedence and fallback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->