### PR TITLE
feat: add quantum circuit benchmark verification MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,3 @@ tmp/
 .playwright-mcp/
 # Local test files.
 memory/
-CLAUDE.md
-psi_oss_benchmark_export/
-sim-phase.md

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ tmp/
 .gemini/
 .opencode/
 .playwright-mcp/
+# Local test files.
+memory/
+CLAUDE.md
+psi_oss_benchmark_export/
+sim-phase.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Get Physics Done are documented here.
 ## vNEXT
 
 - Add quantum circuit benchmark verification MCP server (`gpd-quantum-benchmark`). Provides `compare_circuits`, `decide_better`, and `circuit_stats` tools for agents to verify newly derived quantum circuits against reference implementations using fidelity metrics and Pareto-frontier cost analysis. Requires optional `qiskit` dependency (`pip install get-physics-done[quantum]`).
+- Fix `decide_better` flaky cost metric: default `weight_time` changed from `1.0` to `0.0` so wall-clock simulation time no longer influences the verdict by default. Simulation time remains available as an informational metric and can be re-weighted explicitly.
+- Fix `decide_better` fidelity fallback: no longer silently falls back from `avg_state_fidelity` to `unitary_fidelity` (different scales — average state fidelity vs process fidelity). A new `fidelity_source` field on `Decision` makes provenance explicit.
+- Fix `average_state_fidelity` missing OOM guard: now enforces `max_qubits` cap (default 5) matching the existing guard in `unitary_fidelity`.
+- Fix two-qubit gate counting: `circuit_stats` now iterates `qc.data` and checks `len(qargs) == 2` instead of relying on an incomplete hardcoded gate name set. Removes dead `TWO_QUBIT_GATE_NAMES` frozenset.
+- Fix `unitary_fidelity` formula and docstring: corrected to canonical process fidelity `|Tr(U₁†U₂)|² / d²` with matching documentation.
+- Add Pareto frontier breakdown to `Decision`: per-metric `improvement_pct` for two-qubit gates, depth, and simulation time, ported from the original benchmark verifier.
+- Add `Decision.rationale()` method for human-readable decision explanations with emoji-annotated Pareto analysis.
+- Standardize QASM loading in MCP server: new `_parse_qasm` attempts `qiskit.qasm3.loads` then `qiskit.qasm2.loads` before legacy `from_qasm_str`, supporting modern QASM 3 emitters.
 - Fix `state patch` silent failures: failed fields now include `failure_reasons` with specific messages (invalid status, invalid transition, field not found). Dot-notation prefixes (e.g., `position.status` -> `Status`) are stripped only when the original name is not found. Session Continuity mirror fields (e.g., `resume_file`) are rejected with an explicit error directing users to the continuation API. CLI pretty-prints each failure reason as a separate row.
 - Recognize bare arXiv IDs (`1304.4926`, `hep-th/0603001`) and bare DOIs (`10.1103/PhysRevD.100.026003`) as concrete reference locators for `must_surface` anchor validation. Fix casefold mismatch in `_is_project_artifact_path` that misclassified mixed-case archive names (e.g., `math.DG/0211159`) as project artifact paths.
 - Fix `gpd suggest` ignoring actual project state: use `_project_scoped_cwd()` so root-level PROJECT.md is auto-migrated before `suggest_next()` runs, matching the pattern used by `progress`, `state`, and `status` commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Get Physics Done are documented here.
 
 ## vNEXT
 
+- Add quantum circuit benchmark verification MCP server (`gpd-quantum-benchmark`). Provides `compare_circuits`, `decide_better`, and `circuit_stats` tools for agents to verify newly derived quantum circuits against reference implementations using fidelity metrics and Pareto-frontier cost analysis. Requires optional `qiskit` dependency (`pip install get-physics-done[quantum]`).
 - Fix `state patch` silent failures: failed fields now include `failure_reasons` with specific messages (invalid status, invalid transition, field not found). Dot-notation prefixes (e.g., `position.status` -> `Status`) are stripped only when the original name is not found. Session Continuity mirror fields (e.g., `resume_file`) are rejected with an explicit error directing users to the continuation API. CLI pretty-prints each failure reason as a separate row.
 - Recognize bare arXiv IDs (`1304.4926`, `hep-th/0603001`) and bare DOIs (`10.1103/PhysRevD.100.026003`) as concrete reference locators for `must_surface` anchor validation. Fix casefold mismatch in `_is_project_artifact_path` that misclassified mixed-case archive names (e.g., `math.DG/0211159`) as project artifact paths.
 - Fix `gpd suggest` ignoring actual project state: use `_project_scoped_cwd()` so root-level PROJECT.md is auto-migrated before `suggest_next()` runs, matching the pattern used by `progress`, `state`, and `status` commands.

--- a/infra/gpd-quantum-benchmark.json
+++ b/infra/gpd-quantum-benchmark.json
@@ -21,7 +21,8 @@
     "input": {
       "qasm": "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nh q[0];"
     },
-    "expect": "contains total_gates"
+    "expect": "contains total_gates",
+    "skip_if_unavailable": true
   },
   "optional": true,
   "availability": "conditional",

--- a/infra/gpd-quantum-benchmark.json
+++ b/infra/gpd-quantum-benchmark.json
@@ -1,0 +1,39 @@
+{
+  "name": "gpd-quantum-benchmark",
+  "description": "Optional quantum circuit benchmark verification. Available only when the optional qiskit dependency is installed via the 'quantum' extras group. Tools for comparing quantum circuits on gate counts, fidelity metrics, and simulation time, with a Pareto-frontier decision engine.",
+  "transport": "stdio",
+  "command": "gpd-mcp-quantum-benchmark",
+  "args": [],
+  "env": {
+    "LOG_LEVEL": "${LOG_LEVEL:-WARNING}"
+  },
+  "capabilities": [
+    "compare_circuits",
+    "decide_better",
+    "circuit_stats"
+  ],
+  "registry_prefix": "gpd_quantum_benchmark",
+  "prerequisites": [
+    "Install GPD before enabling built-in MCP servers."
+  ],
+  "health_check": {
+    "tool": "circuit_stats",
+    "input": {
+      "qasm": "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nh q[0];"
+    },
+    "expect": "contains total_gates"
+  },
+  "optional": true,
+  "availability": "conditional",
+  "availability_condition": "Available only when the optional Python module 'qiskit' is installed.",
+  "alternatives": {
+    "python_module": {
+      "command": "${GPD_PYTHON}",
+      "args": [
+        "-m",
+        "gpd.mcp.servers.quantum_benchmark_server"
+      ],
+      "notes": "Replace `${GPD_PYTHON}` with a Python >=3.11 interpreter that has GPD installed."
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,10 @@ dependencies = [
 arxiv = [
     "arxiv-mcp-server>=0.4.11",
 ]
+quantum = [
+    "qiskit>=1.0",
+    "numpy>=1.24",
+]
 
 [project.scripts]
 gpd = "gpd.cli:entrypoint"
@@ -58,6 +62,7 @@ gpd = "gpd.cli:entrypoint"
 "gpd-mcp-wolfram" = "gpd.mcp.integrations.wolfram_bridge:main"
 "gpd-mcp-state" = "gpd.mcp.servers.state_server:main"
 "gpd-mcp-skills" = "gpd.mcp.servers.skills_server:main"
+"gpd-mcp-quantum-benchmark" = "gpd.mcp.servers.quantum_benchmark_server:main"
 
 [project.urls]
 Homepage = "https://github.com/psi-oss/get-physics-done"

--- a/src/gpd/core/quantum_benchmarks.py
+++ b/src/gpd/core/quantum_benchmarks.py
@@ -170,10 +170,10 @@ class CostWeights:
     time: float = 0.0
 
 
-def _pct_change(ref_val: float, new_val: float) -> float:
+def _pct_change(ref_val: float, new_val: float) -> float | None:
     """Calculate percentage change (negative = improvement / reduction)."""
     if ref_val == 0:
-        return 0.0 if new_val == 0 else float("inf")
+        return 0.0 if new_val == 0 else None
     return ((new_val - ref_val) / ref_val) * 100.0
 
 
@@ -186,7 +186,7 @@ class Decision:
     fidelity: float | None
     fidelity_source: str  # "avg_state" or "none"
     weights: CostWeights
-    pareto: dict[str, dict[str, float]] = field(default_factory=dict)
+    pareto: dict[str, dict[str, float | None]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -221,9 +221,12 @@ class Decision:
         if self.pareto:
             lines.append("\nPareto Frontier:")
             for metric, data in self.pareto.items():
-                imp = data.get("improvement_pct", 0.0)
-                symbol = "📈" if imp < 0 else ("📉" if imp > 0 else "➡️ ")
-                lines.append(f"  {symbol} {metric}: {data['ref']:.1f} → {data['new']:.1f} ({imp:+.1f}%)")
+                imp = data.get("improvement_pct")
+                if imp is None:
+                    lines.append(f"  ⚠️  {metric}: {data['ref']:.1f} → {data['new']:.1f} (N/A)")
+                else:
+                    symbol = "📈" if imp < 0 else ("📉" if imp > 0 else "➡️ ")
+                    lines.append(f"  {symbol} {metric}: {data['ref']:.1f} → {data['new']:.1f} ({imp:+.1f}%)")
 
         if self.better:
             lines.append(f"\n🏆 WINNER: New circuit (fidelity OK, {abs(cost_pct):.1f}% cost reduction)")

--- a/src/gpd/core/quantum_benchmarks.py
+++ b/src/gpd/core/quantum_benchmarks.py
@@ -1,6 +1,6 @@
 """Quantum circuit benchmark verification for GPD agents.
 
-Provides fidelity metrics (unitary process fidelity, average state fidelity),
+Provides fidelity metrics (process fidelity, average state fidelity),
 circuit cost analysis, and a Pareto-frontier decision engine for evaluating
 whether a newly derived quantum circuit improves on a reference.
 
@@ -42,9 +42,6 @@ class CircuitStats:
         }
 
 
-TWO_QUBIT_GATE_NAMES = frozenset(
-    {"cx", "cz", "swap", "cry", "crx", "cp", "rxx", "ryy", "rzz", "iswap", "ecr"}
-)
 
 
 def circuit_stats(qc: object) -> CircuitStats:
@@ -53,7 +50,16 @@ def circuit_stats(qc: object) -> CircuitStats:
         raise RuntimeError("qiskit is required for circuit_stats")
     counts = qc.count_ops()  # type: ignore[union-attr]
     total = int(sum(counts.values()))
-    twoq = int(sum(counts.get(k, 0) for k in TWO_QUBIT_GATE_NAMES))
+    
+    twoq = 0
+    if hasattr(qc, "data"):
+        for instr in qc.data:
+            qargs = getattr(instr, "qubits", None)
+            if qargs is None and isinstance(instr, tuple) and len(instr) > 1:
+                qargs = instr[1]
+            if qargs is not None and len(qargs) == 2:
+                twoq += 1
+
     return CircuitStats(
         total_gates=total,
         two_qubit_gates=twoq,
@@ -64,7 +70,7 @@ def circuit_stats(qc: object) -> CircuitStats:
 
 
 def unitary_fidelity(qc1: object, qc2: object, *, max_qubits: int = 5) -> float | None:
-    """Process fidelity via unitary overlap: F = |Tr(U1^dag U2)| / 2^n.
+    """Process fidelity via unitary overlap: F = |Tr(U1^dag U2)|^2 / d^2.
 
     Returns None if circuits are too large or qiskit is unavailable.
     """
@@ -79,15 +85,15 @@ def unitary_fidelity(qc1: object, qc2: object, *, max_qubits: int = 5) -> float 
     u1 = Operator(qc1).data
     u2 = Operator(qc2).data
     overlap = np.trace(np.conjugate(u1.T) @ u2)
-    return float(np.abs(overlap) / (2**n))
+    return float(np.abs(overlap)**2 / (2**(2*n)))
 
 
 def average_state_fidelity(
-    qc1: object, qc2: object, *, trials: int = 64, seed: int | None = 123
+    qc1: object, qc2: object, *, trials: int = 64, seed: int | None = 123, max_qubits: int = 5
 ) -> float | None:
     """Average state fidelity over Haar-random input states.
 
-    Returns None if qiskit is unavailable or qubit counts mismatch.
+    Returns None if qiskit is unavailable, circuits are too large, or qubit counts mismatch.
     """
     if not _qiskit_available():
         return None
@@ -97,6 +103,8 @@ def average_state_fidelity(
     if qc1.num_qubits != qc2.num_qubits:  # type: ignore[union-attr]
         return None
     n = qc1.num_qubits  # type: ignore[union-attr]
+    if n > max_qubits:
+        return None
     rng = np.random.default_rng(seed)
     d = 2**n
     acc = 0.0
@@ -159,7 +167,14 @@ def compare_circuits(qc_ref: object, qc_new: object, *, sim_reps: int = 3) -> Co
 class CostWeights:
     twoq: float = 2.0
     depth: float = 1.0
-    time: float = 1.0
+    time: float = 0.0
+
+
+def _pct_change(ref_val: float, new_val: float) -> float:
+    """Calculate percentage change (negative = improvement / reduction)."""
+    if ref_val == 0:
+        return 0.0 if new_val == 0 else float("inf")
+    return ((new_val - ref_val) / ref_val) * 100.0
 
 
 @dataclass
@@ -169,7 +184,9 @@ class Decision:
     cost_ref: float
     cost_new: float
     fidelity: float | None
+    fidelity_source: str  # "avg_state" or "none"
     weights: CostWeights
+    pareto: dict[str, dict[str, float]] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -178,8 +195,44 @@ class Decision:
             "cost_ref": self.cost_ref,
             "cost_new": self.cost_new,
             "fidelity": self.fidelity,
+            "fidelity_source": self.fidelity_source,
             "weights": {"twoq": self.weights.twoq, "depth": self.weights.depth, "time": self.weights.time},
+            "pareto": self.pareto,
         }
+
+    def rationale(self, fidelity_threshold: float = 0.999) -> str:
+        """Generate a human-readable decision explanation."""
+        lines = []
+        if self.fidelity is not None:
+            if self.meets_fidelity:
+                lines.append(f"✅ Fidelity {self.fidelity:.4f} >= {fidelity_threshold:.4f} (meets threshold, source: {self.fidelity_source})")
+            else:
+                lines.append(f"❌ Fidelity {self.fidelity:.4f} < {fidelity_threshold:.4f} (fails threshold, source: {self.fidelity_source})")
+        else:
+            lines.append("⚠️  No fidelity data available (avg_state_fidelity was None)")
+
+        cost_savings = self.cost_ref - self.cost_new
+        cost_pct = (cost_savings / self.cost_ref * 100) if self.cost_ref > 0 else 0.0
+        lines.append(f"\nCost (weights: 2Q={self.weights.twoq}, depth={self.weights.depth}, time={self.weights.time}):")
+        lines.append(f"  Reference: {self.cost_ref:.2f}")
+        lines.append(f"  New:       {self.cost_new:.2f}")
+        lines.append(f"  Savings:   {cost_savings:+.2f} ({cost_pct:+.1f}%)")
+
+        if self.pareto:
+            lines.append("\nPareto Frontier:")
+            for metric, data in self.pareto.items():
+                imp = data.get("improvement_pct", 0.0)
+                symbol = "📈" if imp < 0 else ("📉" if imp > 0 else "➡️ ")
+                lines.append(f"  {symbol} {metric}: {data['ref']:.1f} → {data['new']:.1f} ({imp:+.1f}%)")
+
+        if self.better:
+            lines.append(f"\n🏆 WINNER: New circuit (fidelity OK, {abs(cost_pct):.1f}% cost reduction)")
+        elif not self.meets_fidelity:
+            lines.append("\n❌ REJECTED: Fidelity below threshold")
+        else:
+            lines.append(f"\n❌ REJECTED: New circuit is more expensive ({cost_pct:+.1f}%)")
+
+        return "\n".join(lines)
 
 
 def decide_better(
@@ -192,13 +245,17 @@ def decide_better(
 
     New wins if: avg_state_fidelity >= threshold AND cost_new < cost_ref.
     Cost = w_twoq * two_qubit_gates + w_depth * depth + w_time * sim_time.
+
+    Note: w_time defaults to 0.0 — simulation time is informational only
+    unless explicitly re-weighted. The decision does NOT fall back to
+    unitary_fidelity because it is on a different scale (process fidelity
+    vs average state fidelity).
     """
     if weights is None:
         weights = CostWeights()
 
     f = result.avg_state_fidelity
-    if f is None:
-        f = result.unitary_fidelity
+    fidelity_source = "avg_state" if f is not None else "none"
 
     cost_ref = (
         weights.twoq * result.ref_stats.two_qubit_gates
@@ -214,11 +271,37 @@ def decide_better(
     meets_fidelity = (f is not None) and (f >= fidelity_threshold)
     better = meets_fidelity and (cost_new < cost_ref)
 
+    pareto = {
+        "two_qubit_gates": {
+            "ref": float(result.ref_stats.two_qubit_gates),
+            "new": float(result.new_stats.two_qubit_gates),
+            "improvement_pct": _pct_change(
+                result.ref_stats.two_qubit_gates, result.new_stats.two_qubit_gates
+            ),
+        },
+        "depth": {
+            "ref": float(result.ref_stats.depth),
+            "new": float(result.new_stats.depth),
+            "improvement_pct": _pct_change(
+                result.ref_stats.depth, result.new_stats.depth
+            ),
+        },
+        "sim_time": {
+            "ref": float(result.sim_time_ref),
+            "new": float(result.sim_time_new),
+            "improvement_pct": _pct_change(
+                result.sim_time_ref, result.sim_time_new
+            ),
+        },
+    }
+
     return Decision(
         better=better,
         meets_fidelity=meets_fidelity,
         cost_ref=cost_ref,
         cost_new=cost_new,
         fidelity=f,
+        fidelity_source=fidelity_source,
         weights=weights,
+        pareto=pareto,
     )

--- a/src/gpd/core/quantum_benchmarks.py
+++ b/src/gpd/core/quantum_benchmarks.py
@@ -1,0 +1,224 @@
+"""Quantum circuit benchmark verification for GPD agents.
+
+Provides fidelity metrics (unitary process fidelity, average state fidelity),
+circuit cost analysis, and a Pareto-frontier decision engine for evaluating
+whether a newly derived quantum circuit improves on a reference.
+
+Requires: qiskit (optional dependency group 'quantum').
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass, field
+
+
+def _qiskit_available() -> bool:
+    try:
+        from qiskit import QuantumCircuit  # noqa: F401
+        from qiskit.quantum_info import Operator, Statevector  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@dataclass(frozen=True)
+class CircuitStats:
+    total_gates: int
+    two_qubit_gates: int
+    single_qubit_gates: int
+    depth: int
+    counts: dict[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "total_gates": self.total_gates,
+            "two_qubit_gates": self.two_qubit_gates,
+            "single_qubit_gates": self.single_qubit_gates,
+            "depth": self.depth,
+            "counts": dict(self.counts),
+        }
+
+
+TWO_QUBIT_GATE_NAMES = frozenset(
+    {"cx", "cz", "swap", "cry", "crx", "cp", "rxx", "ryy", "rzz", "iswap", "ecr"}
+)
+
+
+def circuit_stats(qc: object) -> CircuitStats:
+    """Extract gate counts and depth from a Qiskit QuantumCircuit."""
+    if not _qiskit_available():
+        raise RuntimeError("qiskit is required for circuit_stats")
+    counts = qc.count_ops()  # type: ignore[union-attr]
+    total = int(sum(counts.values()))
+    twoq = int(sum(counts.get(k, 0) for k in TWO_QUBIT_GATE_NAMES))
+    return CircuitStats(
+        total_gates=total,
+        two_qubit_gates=twoq,
+        single_qubit_gates=total - twoq,
+        depth=int(qc.depth()),  # type: ignore[union-attr]
+        counts={k: int(v) for k, v in counts.items()},
+    )
+
+
+def unitary_fidelity(qc1: object, qc2: object, *, max_qubits: int = 5) -> float | None:
+    """Process fidelity via unitary overlap: F = |Tr(U1^dag U2)| / 2^n.
+
+    Returns None if circuits are too large or qiskit is unavailable.
+    """
+    if not _qiskit_available():
+        return None
+    import numpy as np
+    from qiskit.quantum_info import Operator
+
+    n = qc1.num_qubits  # type: ignore[union-attr]
+    if n != qc2.num_qubits or n > max_qubits:  # type: ignore[union-attr]
+        return None
+    u1 = Operator(qc1).data
+    u2 = Operator(qc2).data
+    overlap = np.trace(np.conjugate(u1.T) @ u2)
+    return float(np.abs(overlap) / (2**n))
+
+
+def average_state_fidelity(
+    qc1: object, qc2: object, *, trials: int = 64, seed: int | None = 123
+) -> float | None:
+    """Average state fidelity over Haar-random input states.
+
+    Returns None if qiskit is unavailable or qubit counts mismatch.
+    """
+    if not _qiskit_available():
+        return None
+    import numpy as np
+    from qiskit.quantum_info import Statevector
+
+    if qc1.num_qubits != qc2.num_qubits:  # type: ignore[union-attr]
+        return None
+    n = qc1.num_qubits  # type: ignore[union-attr]
+    rng = np.random.default_rng(seed)
+    d = 2**n
+    acc = 0.0
+    for _ in range(trials):
+        v = rng.normal(size=d) + 1j * rng.normal(size=d)
+        v = v / np.linalg.norm(v)
+        sv = Statevector(v)
+        psi1 = Statevector(sv).evolve(qc1).data
+        psi2 = Statevector(sv).evolve(qc2).data
+        acc += float(np.abs(np.vdot(psi1, psi2)) ** 2)
+    return acc / trials
+
+
+def time_simulation(qc: object, *, reps: int = 3) -> float:
+    """Average simulation time in seconds using statevector evolution."""
+    if not _qiskit_available():
+        return math.nan
+    from qiskit.quantum_info import Statevector
+
+    start = time.perf_counter()
+    for _ in range(reps):
+        Statevector.from_instruction(qc)
+    end = time.perf_counter()
+    return (end - start) / reps
+
+
+@dataclass
+class ComparisonResult:
+    ref_stats: CircuitStats
+    new_stats: CircuitStats
+    unitary_fidelity: float | None
+    avg_state_fidelity: float | None
+    sim_time_ref: float
+    sim_time_new: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ref": self.ref_stats.to_dict(),
+            "new": self.new_stats.to_dict(),
+            "unitary_fidelity": self.unitary_fidelity,
+            "avg_state_fidelity": self.avg_state_fidelity,
+            "sim_time_ref_sec": self.sim_time_ref,
+            "sim_time_new_sec": self.sim_time_new,
+        }
+
+
+def compare_circuits(qc_ref: object, qc_new: object, *, sim_reps: int = 3) -> ComparisonResult:
+    """Compare two Qiskit QuantumCircuits on stats, fidelity, and timing."""
+    return ComparisonResult(
+        ref_stats=circuit_stats(qc_ref),
+        new_stats=circuit_stats(qc_new),
+        unitary_fidelity=unitary_fidelity(qc_ref, qc_new),
+        avg_state_fidelity=average_state_fidelity(qc_ref, qc_new),
+        sim_time_ref=time_simulation(qc_ref, reps=sim_reps),
+        sim_time_new=time_simulation(qc_new, reps=sim_reps),
+    )
+
+
+@dataclass(frozen=True)
+class CostWeights:
+    twoq: float = 2.0
+    depth: float = 1.0
+    time: float = 1.0
+
+
+@dataclass
+class Decision:
+    better: bool
+    meets_fidelity: bool
+    cost_ref: float
+    cost_new: float
+    fidelity: float | None
+    weights: CostWeights
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "better": self.better,
+            "meets_fidelity": self.meets_fidelity,
+            "cost_ref": self.cost_ref,
+            "cost_new": self.cost_new,
+            "fidelity": self.fidelity,
+            "weights": {"twoq": self.weights.twoq, "depth": self.weights.depth, "time": self.weights.time},
+        }
+
+
+def decide_better(
+    result: ComparisonResult,
+    *,
+    fidelity_threshold: float = 0.999,
+    weights: CostWeights | None = None,
+) -> Decision:
+    """Decide whether 'new' circuit beats 'ref' on a weighted cost metric.
+
+    New wins if: avg_state_fidelity >= threshold AND cost_new < cost_ref.
+    Cost = w_twoq * two_qubit_gates + w_depth * depth + w_time * sim_time.
+    """
+    if weights is None:
+        weights = CostWeights()
+
+    f = result.avg_state_fidelity
+    if f is None:
+        f = result.unitary_fidelity
+
+    cost_ref = (
+        weights.twoq * result.ref_stats.two_qubit_gates
+        + weights.depth * result.ref_stats.depth
+        + weights.time * result.sim_time_ref
+    )
+    cost_new = (
+        weights.twoq * result.new_stats.two_qubit_gates
+        + weights.depth * result.new_stats.depth
+        + weights.time * result.sim_time_new
+    )
+
+    meets_fidelity = (f is None) or (f >= fidelity_threshold)
+    better = meets_fidelity and (cost_new < cost_ref)
+
+    return Decision(
+        better=better,
+        meets_fidelity=meets_fidelity,
+        cost_ref=cost_ref,
+        cost_new=cost_new,
+        fidelity=f,
+        weights=weights,
+    )

--- a/src/gpd/core/quantum_benchmarks.py
+++ b/src/gpd/core/quantum_benchmarks.py
@@ -211,7 +211,7 @@ def decide_better(
         + weights.time * result.sim_time_new
     )
 
-    meets_fidelity = (f is None) or (f >= fidelity_threshold)
+    meets_fidelity = (f is not None) and (f >= fidelity_threshold)
     better = meets_fidelity and (cost_new < cost_ref)
 
     return Decision(

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -72,6 +72,13 @@ _BUILTIN_SERVERS: dict[str, _ServerDef] = {
         "optional": True,
         "module_check": "arxiv_mcp_server",
     },
+    "gpd-quantum-benchmark": {
+        "command": _PYTHON_COMMAND_SENTINEL,
+        "args": ["-m", "gpd.mcp.servers.quantum_benchmark_server"],
+        "env": {"LOG_LEVEL": "${LOG_LEVEL:-WARNING}"},
+        "optional": True,
+        "module_check": "qiskit",
+    },
 }
 
 _PUBLIC_BOOTSTRAP_PREREQUISITE = "Install GPD before enabling built-in MCP servers."
@@ -235,6 +242,24 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "tool": "search_papers",
             "input": {"query": "quantum field theory", "max_results": 1},
             "expect": "contains paper",
+        },
+    },
+    "gpd-quantum-benchmark": {
+        "description": (
+            "Optional quantum circuit benchmark verification. Available only when the optional qiskit dependency "
+            "is installed via the 'quantum' extras group. Tools for comparing quantum circuits on gate "
+            "counts, fidelity metrics, and simulation time, with a Pareto-frontier decision engine."
+        ),
+        "capabilities": [
+            "compare_circuits",
+            "decide_better",
+            "circuit_stats",
+        ],
+        "registry_prefix": "gpd_quantum_benchmark",
+        "health_check": {
+            "tool": "circuit_stats",
+            "input": {"qasm": "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[1];\nh q[0];"},
+            "expect": "contains total_gates",
         },
     },
 }

--- a/src/gpd/mcp/servers/quantum_benchmark_server.py
+++ b/src/gpd/mcp/servers/quantum_benchmark_server.py
@@ -1,0 +1,154 @@
+"""MCP server for GPD quantum circuit benchmarking.
+
+Exposes circuit comparison and decision tools so solver agents can
+verify newly derived quantum circuits against reference implementations.
+
+Usage:
+    python -m gpd.mcp.servers.quantum_benchmark_server
+    # or via entry point:
+    gpd-mcp-quantum-benchmark
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+from gpd.mcp.servers import (
+    configure_mcp_logging,
+    stable_mcp_error,
+    stable_mcp_response,
+    tighten_registered_tool_contracts,
+)
+
+logger = configure_mcp_logging("gpd-quantum-benchmark")
+
+mcp = FastMCP("gpd-quantum-benchmark")
+
+
+def _check_qiskit() -> str | None:
+    """Return error message if qiskit is not importable, else None."""
+    try:
+        from qiskit import QuantumCircuit  # noqa: F401
+
+        return None
+    except ImportError:
+        return "qiskit is not installed. Install with: pip install get-physics-done[quantum]"
+
+
+@mcp.tool()
+def compare_circuits(
+    ref_qasm: str,
+    new_qasm: str,
+    sim_reps: int = 3,
+) -> dict[str, object]:
+    """Compare two quantum circuits on gate counts, fidelity, and simulation time.
+
+    Accepts OpenQASM 2.0 strings for the reference and new circuits.
+    Returns stats for both circuits plus unitary and average state fidelity.
+
+    Args:
+        ref_qasm: OpenQASM 2.0 string for the reference circuit
+        new_qasm: OpenQASM 2.0 string for the new/optimized circuit
+        sim_reps: Number of simulation repetitions for timing (default 3)
+    """
+    err = _check_qiskit()
+    if err:
+        return stable_mcp_error(err)
+
+    from qiskit import QuantumCircuit
+
+    from gpd.core.quantum_benchmarks import compare_circuits as _compare
+
+    try:
+        qc_ref = QuantumCircuit.from_qasm_str(ref_qasm)
+        qc_new = QuantumCircuit.from_qasm_str(new_qasm)
+    except Exception as e:
+        return stable_mcp_error(f"Failed to parse QASM: {e}")
+
+    result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
+    return stable_mcp_response(result.to_dict())
+
+
+@mcp.tool()
+def decide_better(
+    ref_qasm: str,
+    new_qasm: str,
+    fidelity_threshold: float = 0.999,
+    weight_twoq: float = 2.0,
+    weight_depth: float = 1.0,
+    weight_time: float = 1.0,
+    sim_reps: int = 3,
+) -> dict[str, object]:
+    """Decide whether a new quantum circuit improves on a reference.
+
+    Runs full comparison then applies the Pareto-frontier decision engine.
+    New wins if fidelity >= threshold AND weighted cost is lower.
+    Cost = weight_twoq * two_qubit_gates + weight_depth * depth + weight_time * sim_time.
+
+    Args:
+        ref_qasm: OpenQASM 2.0 string for the reference circuit
+        new_qasm: OpenQASM 2.0 string for the new/optimized circuit
+        fidelity_threshold: Minimum fidelity to accept the new circuit (default 0.999)
+        weight_twoq: Cost weight for two-qubit gates (default 2.0)
+        weight_depth: Cost weight for circuit depth (default 1.0)
+        weight_time: Cost weight for simulation time (default 1.0)
+        sim_reps: Number of simulation repetitions for timing (default 3)
+    """
+    err = _check_qiskit()
+    if err:
+        return stable_mcp_error(err)
+
+    from qiskit import QuantumCircuit
+
+    from gpd.core.quantum_benchmarks import CostWeights
+    from gpd.core.quantum_benchmarks import compare_circuits as _compare
+    from gpd.core.quantum_benchmarks import decide_better as _decide
+
+    try:
+        qc_ref = QuantumCircuit.from_qasm_str(ref_qasm)
+        qc_new = QuantumCircuit.from_qasm_str(new_qasm)
+    except Exception as e:
+        return stable_mcp_error(f"Failed to parse QASM: {e}")
+
+    result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
+    weights = CostWeights(twoq=weight_twoq, depth=weight_depth, time=weight_time)
+    decision = _decide(result, fidelity_threshold=fidelity_threshold, weights=weights)
+
+    payload = decision.to_dict()
+    payload["comparison"] = result.to_dict()
+    return stable_mcp_response(payload)
+
+
+@mcp.tool()
+def circuit_stats(
+    qasm: str,
+) -> dict[str, object]:
+    """Get gate counts, depth, and circuit statistics for a quantum circuit.
+
+    Args:
+        qasm: OpenQASM 2.0 string for the circuit to analyze
+    """
+    err = _check_qiskit()
+    if err:
+        return stable_mcp_error(err)
+
+    from qiskit import QuantumCircuit
+
+    from gpd.core.quantum_benchmarks import circuit_stats as _stats
+
+    try:
+        qc = QuantumCircuit.from_qasm_str(qasm)
+    except Exception as e:
+        return stable_mcp_error(f"Failed to parse QASM: {e}")
+
+    stats = _stats(qc)
+    return stable_mcp_response(stats.to_dict())
+
+
+def main() -> None:
+    tighten_registered_tool_contracts(mcp)
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gpd/mcp/servers/quantum_benchmark_server.py
+++ b/src/gpd/mcp/servers/quantum_benchmark_server.py
@@ -35,6 +35,34 @@ def _check_qiskit() -> str | None:
         return "qiskit is not installed. Install with: pip install get-physics-done[quantum]"
 
 
+def _parse_qasm(qasm_str: str) -> object:
+    """Parse an OpenQASM string, attempting QASM 3 then QASM 2.
+
+    Falls back through: qiskit.qasm3.loads -> qiskit.qasm2.loads -> QuantumCircuit.from_qasm_str.
+    """
+    from qiskit import QuantumCircuit
+
+    # Try QASM 3 first (only if the module is available).
+    try:
+        import qiskit.qasm3
+        return qiskit.qasm3.loads(qasm_str)
+    except ImportError:
+        pass
+    except (ValueError, qiskit.qasm3.QASM3ExporterError if hasattr(qiskit, 'qasm3') else Exception):
+        logger.debug("QASM 3 parse failed, falling back to QASM 2")
+
+    # Try QASM 2 (only if the module is available).
+    try:
+        import qiskit.qasm2
+        return qiskit.qasm2.loads(qasm_str)
+    except ImportError:
+        pass
+    except (ValueError, Exception) as e:
+        logger.debug("QASM 2 parse failed (%s), falling back to legacy", e)
+
+    return QuantumCircuit.from_qasm_str(qasm_str)
+
+
 @mcp.tool()
 def compare_circuits(
     ref_qasm: str,
@@ -43,12 +71,12 @@ def compare_circuits(
 ) -> dict[str, object]:
     """Compare two quantum circuits on gate counts, fidelity, and simulation time.
 
-    Accepts OpenQASM 2.0 strings for the reference and new circuits.
+    Accepts OpenQASM 2.0 or 3.0 strings for the reference and new circuits.
     Returns stats for both circuits plus unitary and average state fidelity.
 
     Args:
-        ref_qasm: OpenQASM 2.0 string for the reference circuit
-        new_qasm: OpenQASM 2.0 string for the new/optimized circuit
+        ref_qasm: OpenQASM string for the reference circuit
+        new_qasm: OpenQASM string for the new/optimized circuit
         sim_reps: Number of simulation repetitions for timing (default 3)
     """
     err = _check_qiskit()
@@ -57,13 +85,11 @@ def compare_circuits(
     if sim_reps < 1:
         return stable_mcp_error("sim_reps must be >= 1")
 
-    from qiskit import QuantumCircuit
-
     from gpd.core.quantum_benchmarks import compare_circuits as _compare
 
     try:
-        qc_ref = QuantumCircuit.from_qasm_str(ref_qasm)
-        qc_new = QuantumCircuit.from_qasm_str(new_qasm)
+        qc_ref = _parse_qasm(ref_qasm)
+        qc_new = _parse_qasm(new_qasm)
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 
@@ -81,7 +107,7 @@ def decide_better(
     fidelity_threshold: float = 0.999,
     weight_twoq: float = 2.0,
     weight_depth: float = 1.0,
-    weight_time: float = 1.0,
+    weight_time: float = 0.0,
     sim_reps: int = 3,
 ) -> dict[str, object]:
     """Decide whether a new quantum circuit improves on a reference.
@@ -91,12 +117,12 @@ def decide_better(
     Cost = weight_twoq * two_qubit_gates + weight_depth * depth + weight_time * sim_time.
 
     Args:
-        ref_qasm: OpenQASM 2.0 string for the reference circuit
-        new_qasm: OpenQASM 2.0 string for the new/optimized circuit
+        ref_qasm: OpenQASM string for the reference circuit
+        new_qasm: OpenQASM string for the new/optimized circuit
         fidelity_threshold: Minimum fidelity to accept the new circuit (default 0.999)
         weight_twoq: Cost weight for two-qubit gates (default 2.0)
         weight_depth: Cost weight for circuit depth (default 1.0)
-        weight_time: Cost weight for simulation time (default 1.0)
+        weight_time: Cost weight for simulation time (default 0.0, informational only)
         sim_reps: Number of simulation repetitions for timing (default 3)
     """
     err = _check_qiskit()
@@ -105,15 +131,13 @@ def decide_better(
     if sim_reps < 1:
         return stable_mcp_error("sim_reps must be >= 1")
 
-    from qiskit import QuantumCircuit
-
     from gpd.core.quantum_benchmarks import CostWeights
     from gpd.core.quantum_benchmarks import compare_circuits as _compare
     from gpd.core.quantum_benchmarks import decide_better as _decide
 
     try:
-        qc_ref = QuantumCircuit.from_qasm_str(ref_qasm)
-        qc_new = QuantumCircuit.from_qasm_str(new_qasm)
+        qc_ref = _parse_qasm(ref_qasm)
+        qc_new = _parse_qasm(new_qasm)
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 
@@ -126,6 +150,7 @@ def decide_better(
 
     payload = decision.to_dict()
     payload["comparison"] = result.to_dict()
+    payload["rationale"] = decision.rationale(fidelity_threshold=fidelity_threshold)
     return stable_mcp_response(payload)
 
 
@@ -136,18 +161,16 @@ def circuit_stats(
     """Get gate counts, depth, and circuit statistics for a quantum circuit.
 
     Args:
-        qasm: OpenQASM 2.0 string for the circuit to analyze
+        qasm: OpenQASM string for the circuit to analyze
     """
     err = _check_qiskit()
     if err:
         return stable_mcp_error(err)
 
-    from qiskit import QuantumCircuit
-
     from gpd.core.quantum_benchmarks import circuit_stats as _stats
 
     try:
-        qc = QuantumCircuit.from_qasm_str(qasm)
+        qc = _parse_qasm(qasm)
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 

--- a/src/gpd/mcp/servers/quantum_benchmark_server.py
+++ b/src/gpd/mcp/servers/quantum_benchmark_server.py
@@ -48,7 +48,7 @@ def _parse_qasm(qasm_str: str) -> object:
         return qiskit.qasm3.loads(qasm_str)
     except ImportError:
         pass
-    except (ValueError, qiskit.qasm3.QASM3ExporterError if hasattr(qiskit, 'qasm3') else Exception):
+    except (ValueError, qiskit.qasm3.QASM3ImporterError if hasattr(qiskit, 'qasm3') else Exception):
         logger.debug("QASM 3 parse failed, falling back to QASM 2")
 
     # Try QASM 2 (only if the module is available).

--- a/src/gpd/mcp/servers/quantum_benchmark_server.py
+++ b/src/gpd/mcp/servers/quantum_benchmark_server.py
@@ -54,6 +54,8 @@ def compare_circuits(
     err = _check_qiskit()
     if err:
         return stable_mcp_error(err)
+    if sim_reps < 1:
+        return stable_mcp_error("sim_reps must be >= 1")
 
     from qiskit import QuantumCircuit
 
@@ -65,7 +67,10 @@ def compare_circuits(
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 
-    result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
+    try:
+        result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
+    except Exception as e:
+        return stable_mcp_error(f"Benchmark comparison failed: {e}")
     return stable_mcp_response(result.to_dict())
 
 
@@ -97,6 +102,8 @@ def decide_better(
     err = _check_qiskit()
     if err:
         return stable_mcp_error(err)
+    if sim_reps < 1:
+        return stable_mcp_error("sim_reps must be >= 1")
 
     from qiskit import QuantumCircuit
 
@@ -110,9 +117,12 @@ def decide_better(
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 
-    result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
-    weights = CostWeights(twoq=weight_twoq, depth=weight_depth, time=weight_time)
-    decision = _decide(result, fidelity_threshold=fidelity_threshold, weights=weights)
+    try:
+        result = _compare(qc_ref, qc_new, sim_reps=sim_reps)
+        weights = CostWeights(twoq=weight_twoq, depth=weight_depth, time=weight_time)
+        decision = _decide(result, fidelity_threshold=fidelity_threshold, weights=weights)
+    except Exception as e:
+        return stable_mcp_error(f"Decision evaluation failed: {e}")
 
     payload = decision.to_dict()
     payload["comparison"] = result.to_dict()
@@ -141,7 +151,10 @@ def circuit_stats(
     except Exception as e:
         return stable_mcp_error(f"Failed to parse QASM: {e}")
 
-    stats = _stats(qc)
+    try:
+        stats = _stats(qc)
+    except Exception as e:
+        return stable_mcp_error(f"Circuit stats failed: {e}")
     return stable_mcp_response(stats.to_dict())
 
 

--- a/tests/mcp/test_quantum_benchmark_server.py
+++ b/tests/mcp/test_quantum_benchmark_server.py
@@ -59,6 +59,7 @@ class TestDecisionEngine:
         assert decision.better is True
         assert decision.meets_fidelity is True
         assert decision.cost_new < decision.cost_ref
+        assert decision.fidelity_source == "avg_state"
 
     def test_new_loses_low_fidelity(self):
         result = self._make_result(avg_f=0.95)
@@ -73,11 +74,12 @@ class TestDecisionEngine:
         assert decision.meets_fidelity is True
         assert decision.cost_new > decision.cost_ref
 
-    def test_fallback_to_unitary_fidelity(self):
+    def test_no_fallback_to_unitary_fidelity(self):
         result = self._make_result(avg_f=None, unitary_f=0.9999)
         decision = decide_better(result)
-        assert decision.better is True
-        assert decision.fidelity == 0.9999
+        assert decision.better is False
+        assert decision.fidelity is None
+        assert decision.fidelity_source == "none"
 
     def test_no_fidelity_fails_closed(self):
         result = self._make_result(avg_f=None, unitary_f=None)
@@ -101,6 +103,38 @@ class TestDecisionEngine:
         assert "better" in d
         assert "weights" in d
         assert d["weights"]["twoq"] == 2.0
+        assert d["fidelity_source"] == "avg_state"
+        assert "pareto" in d
+        assert "two_qubit_gates" in d["pareto"]
+        assert "depth" in d["pareto"]
+        assert "sim_time" in d["pareto"]
+
+    def test_pareto_improvement_pct(self):
+        result = self._make_result(ref_twoq=6, new_twoq=3, ref_depth=10, new_depth=8)
+        decision = decide_better(result)
+        pareto = decision.pareto
+        assert pareto["two_qubit_gates"]["improvement_pct"] == pytest.approx(-50.0)
+        assert pareto["depth"]["improvement_pct"] == pytest.approx(-20.0)
+
+    def test_rationale_winner(self):
+        result = self._make_result()
+        decision = decide_better(result)
+        text = decision.rationale(fidelity_threshold=0.999)
+        assert "WINNER" in text
+        assert "avg_state" in text
+
+    def test_rationale_rejected_fidelity(self):
+        result = self._make_result(avg_f=0.95)
+        decision = decide_better(result, fidelity_threshold=0.999)
+        text = decision.rationale(fidelity_threshold=0.999)
+        assert "REJECTED" in text
+        assert "Fidelity below threshold" in text
+
+    def test_rationale_no_fidelity(self):
+        result = self._make_result(avg_f=None, unitary_f=None)
+        decision = decide_better(result)
+        text = decision.rationale()
+        assert "No fidelity data available" in text
 
 
 class TestMCPToolsWithoutQiskit:
@@ -111,21 +145,24 @@ class TestMCPToolsWithoutQiskit:
             from gpd.mcp.servers.quantum_benchmark_server import compare_circuits
 
             result = compare_circuits("", "")
-            assert "error" in result
+            assert "error" in str(result).lower() or "iserror" in str(result).lower()
+            assert "qiskit not installed" in str(result)
 
     def test_decide_better_no_qiskit(self):
         with patch("gpd.mcp.servers.quantum_benchmark_server._check_qiskit", return_value="qiskit not installed"):
             from gpd.mcp.servers.quantum_benchmark_server import decide_better as mcp_decide
 
             result = mcp_decide("", "")
-            assert "error" in result
+            assert "error" in str(result).lower() or "iserror" in str(result).lower()
+            assert "qiskit not installed" in str(result)
 
     def test_circuit_stats_no_qiskit(self):
         with patch("gpd.mcp.servers.quantum_benchmark_server._check_qiskit", return_value="qiskit not installed"):
             from gpd.mcp.servers.quantum_benchmark_server import circuit_stats
 
             result = circuit_stats("")
-            assert "error" in result
+            assert "error" in str(result).lower() or "iserror" in str(result).lower()
+            assert "qiskit not installed" in str(result)
 
 
 class TestCircuitStats:

--- a/tests/mcp/test_quantum_benchmark_server.py
+++ b/tests/mcp/test_quantum_benchmark_server.py
@@ -79,10 +79,11 @@ class TestDecisionEngine:
         assert decision.better is True
         assert decision.fidelity == 0.9999
 
-    def test_no_fidelity_proceeds_with_cost(self):
+    def test_no_fidelity_fails_closed(self):
         result = self._make_result(avg_f=None, unitary_f=None)
         decision = decide_better(result)
-        assert decision.better is True
+        assert decision.better is False
+        assert decision.meets_fidelity is False
         assert decision.fidelity is None
 
     def test_custom_weights(self):

--- a/tests/mcp/test_quantum_benchmark_server.py
+++ b/tests/mcp/test_quantum_benchmark_server.py
@@ -1,0 +1,174 @@
+"""Tests for the quantum benchmark MCP server.
+
+Tests the MCP tool functions directly. When qiskit is not installed,
+verifies graceful error handling.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from gpd.core.quantum_benchmarks import (
+    CircuitStats,
+    ComparisonResult,
+    CostWeights,
+    decide_better,
+)
+
+
+class TestDecisionEngine:
+    """Test the decide_better logic without qiskit."""
+
+    def _make_result(
+        self,
+        ref_twoq: int = 6,
+        new_twoq: int = 3,
+        ref_depth: int = 10,
+        new_depth: int = 8,
+        ref_time: float = 0.1,
+        new_time: float = 0.05,
+        unitary_f: float | None = 1.0,
+        avg_f: float | None = 0.9995,
+    ) -> ComparisonResult:
+        return ComparisonResult(
+            ref_stats=CircuitStats(
+                total_gates=20,
+                two_qubit_gates=ref_twoq,
+                single_qubit_gates=14,
+                depth=ref_depth,
+                counts={"cx": ref_twoq, "h": 14},
+            ),
+            new_stats=CircuitStats(
+                total_gates=15,
+                two_qubit_gates=new_twoq,
+                single_qubit_gates=12,
+                depth=new_depth,
+                counts={"cz": new_twoq, "h": 12},
+            ),
+            unitary_fidelity=unitary_f,
+            avg_state_fidelity=avg_f,
+            sim_time_ref=ref_time,
+            sim_time_new=new_time,
+        )
+
+    def test_new_wins_lower_cost_high_fidelity(self):
+        result = self._make_result()
+        decision = decide_better(result)
+        assert decision.better is True
+        assert decision.meets_fidelity is True
+        assert decision.cost_new < decision.cost_ref
+
+    def test_new_loses_low_fidelity(self):
+        result = self._make_result(avg_f=0.95)
+        decision = decide_better(result, fidelity_threshold=0.999)
+        assert decision.better is False
+        assert decision.meets_fidelity is False
+
+    def test_new_loses_higher_cost(self):
+        result = self._make_result(new_twoq=10, new_depth=15, new_time=0.5)
+        decision = decide_better(result)
+        assert decision.better is False
+        assert decision.meets_fidelity is True
+        assert decision.cost_new > decision.cost_ref
+
+    def test_fallback_to_unitary_fidelity(self):
+        result = self._make_result(avg_f=None, unitary_f=0.9999)
+        decision = decide_better(result)
+        assert decision.better is True
+        assert decision.fidelity == 0.9999
+
+    def test_no_fidelity_proceeds_with_cost(self):
+        result = self._make_result(avg_f=None, unitary_f=None)
+        decision = decide_better(result)
+        assert decision.better is True
+        assert decision.fidelity is None
+
+    def test_custom_weights(self):
+        result = self._make_result(new_twoq=6, new_depth=5, new_time=0.01)
+        weights = CostWeights(twoq=0.0, depth=10.0, time=0.0)
+        decision = decide_better(result, weights=weights)
+        assert decision.better is True
+        assert decision.cost_ref == 100.0
+        assert decision.cost_new == 50.0
+
+    def test_decision_to_dict(self):
+        result = self._make_result()
+        decision = decide_better(result)
+        d = decision.to_dict()
+        assert "better" in d
+        assert "weights" in d
+        assert d["weights"]["twoq"] == 2.0
+
+
+class TestMCPToolsWithoutQiskit:
+    """Test MCP tools gracefully handle missing qiskit."""
+
+    def test_compare_circuits_no_qiskit(self):
+        with patch("gpd.mcp.servers.quantum_benchmark_server._check_qiskit", return_value="qiskit not installed"):
+            from gpd.mcp.servers.quantum_benchmark_server import compare_circuits
+
+            result = compare_circuits("", "")
+            assert "error" in result
+
+    def test_decide_better_no_qiskit(self):
+        with patch("gpd.mcp.servers.quantum_benchmark_server._check_qiskit", return_value="qiskit not installed"):
+            from gpd.mcp.servers.quantum_benchmark_server import decide_better as mcp_decide
+
+            result = mcp_decide("", "")
+            assert "error" in result
+
+    def test_circuit_stats_no_qiskit(self):
+        with patch("gpd.mcp.servers.quantum_benchmark_server._check_qiskit", return_value="qiskit not installed"):
+            from gpd.mcp.servers.quantum_benchmark_server import circuit_stats
+
+            result = circuit_stats("")
+            assert "error" in result
+
+
+class TestCircuitStats:
+    """Test CircuitStats dataclass."""
+
+    def test_to_dict(self):
+        stats = CircuitStats(
+            total_gates=10,
+            two_qubit_gates=3,
+            single_qubit_gates=7,
+            depth=5,
+            counts={"cx": 3, "h": 7},
+        )
+        d = stats.to_dict()
+        assert d["total_gates"] == 10
+        assert d["two_qubit_gates"] == 3
+        assert d["depth"] == 5
+        assert d["counts"] == {"cx": 3, "h": 7}
+
+    def test_frozen(self):
+        stats = CircuitStats(
+            total_gates=10,
+            two_qubit_gates=3,
+            single_qubit_gates=7,
+            depth=5,
+        )
+        with pytest.raises(AttributeError):
+            stats.total_gates = 20  # type: ignore[misc]
+
+
+class TestComparisonResult:
+    """Test ComparisonResult serialization."""
+
+    def test_to_dict(self):
+        result = ComparisonResult(
+            ref_stats=CircuitStats(10, 3, 7, 5, {"cx": 3}),
+            new_stats=CircuitStats(8, 2, 6, 4, {"cz": 2}),
+            unitary_fidelity=0.999,
+            avg_state_fidelity=0.998,
+            sim_time_ref=0.1,
+            sim_time_new=0.05,
+        )
+        d = result.to_dict()
+        assert d["unitary_fidelity"] == 0.999
+        assert d["sim_time_ref_sec"] == 0.1
+        assert "ref" in d
+        assert "new" in d

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -353,13 +353,10 @@ class TestBuiltinServerDescriptors:
 
         target_python = "/opt/gpd/python3.11"
         current_python = "/usr/bin/python3.9"
-        observed: dict[str, object] = {}
+        all_calls: list[list[object]] = []
 
         def fake_run(command, *, check, stdout, stderr):
-            observed["command"] = command
-            observed["check"] = check
-            observed["stdout"] = stdout
-            observed["stderr"] = stderr
+            all_calls.append(command)
             return SimpleNamespace(returncode=0 if command[0] == target_python else 1)
 
         monkeypatch.setattr(builtin_servers.sys, "executable", current_python)
@@ -368,10 +365,11 @@ class TestBuiltinServerDescriptors:
         servers = builtin_servers.build_mcp_servers_dict(python_path=target_python)
 
         assert "gpd-arxiv" in servers
-        assert observed["command"][0] == target_python
-        assert observed["command"][2].startswith("import importlib.util")
-        assert observed["command"][3] == "arxiv_mcp_server"
-        assert observed["check"] is False
+        module_names_checked = [cmd[3] for cmd in all_calls if len(cmd) > 3]
+        assert "arxiv_mcp_server" in module_names_checked
+        assert "qiskit" in module_names_checked
+        assert all(cmd[0] == target_python for cmd in all_calls)
+        assert all(cmd[2].startswith("import importlib.util") for cmd in all_calls if len(cmd) > 2)
 
 
 class TestMcpServerRunner:

--- a/tests/test_metadata_consistency.py
+++ b/tests/test_metadata_consistency.py
@@ -312,7 +312,10 @@ def test_arxiv_descriptor_tracks_optional_dependency_surface() -> None:
     dependencies: list[str] = project["dependencies"]
     optional = project.get("optional-dependencies", {})
     assert not any(item.startswith("arxiv-mcp-server") for item in dependencies)
-    assert optional == {"arxiv": ["arxiv-mcp-server>=0.4.11"]}
+    assert "arxiv" in optional
+    assert optional["arxiv"] == ["arxiv-mcp-server>=0.4.11"]
+    assert "quantum" in optional
+    assert optional["quantum"] == ["qiskit>=1.0", "numpy>=1.24"]
 
     descriptor = build_public_descriptors()["gpd-arxiv"]
     assert descriptor["prerequisites"] == ["Install GPD before enabling built-in MCP servers."]

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -416,7 +416,10 @@ def test_public_runtime_dependency_surface_stays_curated() -> None:
     optional = project.get("optional-dependencies", {})
 
     assert _normalized_dependency_names(dependencies) == _expected_runtime_dependency_names()
-    assert optional == {"arxiv": ["arxiv-mcp-server>=0.4.11"]}
+    assert optional == {
+        "arxiv": ["arxiv-mcp-server>=0.4.11"],
+        "quantum": ["qiskit>=1.0", "numpy>=1.24"],
+    }
 
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -490,6 +490,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "execnet"
 version = "2.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -634,6 +643,10 @@ dependencies = [
 arxiv = [
     { name = "arxiv-mcp-server" },
 ]
+quantum = [
+    { name = "numpy" },
+    { name = "qiskit" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -648,14 +661,16 @@ requires-dist = [
     { name = "arxiv-mcp-server", marker = "extra == 'arxiv'", specifier = ">=0.4.11" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
+    { name = "numpy", marker = "extra == 'quantum'", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pybtex", specifier = ">=0.25.1" },
     { name = "pydantic", specifier = ">=2.12" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "qiskit", marker = "extra == 'quantum'", specifier = ">=1.0" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "typer", specifier = ">=0.24.1" },
 ]
-provides-extras = ["arxiv"]
+provides-extras = ["arxiv", "quantum"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1027,6 +1042,85 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/9f/b8cef5bffa569759033adda9481211426f12f53299629b410340795c2514/numpy-2.4.4.tar.gz", hash = "sha256:2d390634c5182175533585cc89f3608a4682ccb173cc9bb940b2881c8d6f8fa0", size = 20731587, upload-time = "2026-03-29T13:22:01.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c6/4218570d8c8ecc9704b5157a3348e486e84ef4be0ed3e38218ab473c83d2/numpy-2.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f983334aea213c99992053ede6168500e5f086ce74fbc4acc3f2b00f5762e9db", size = 16976799, upload-time = "2026-03-29T13:18:15.438Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/92/b4d922c4a5f5dab9ed44e6153908a5c665b71acf183a83b93b690996e39b/numpy-2.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:72944b19f2324114e9dc86a159787333b77874143efcf89a5167ef83cfee8af0", size = 14971552, upload-time = "2026-03-29T13:18:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/dc/df98c095978fa6ee7b9a9387d1d58cbb3d232d0e69ad169a4ce784bde4fd/numpy-2.4.4-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:86b6f55f5a352b48d7fbfd2dbc3d5b780b2d79f4d3c121f33eb6efb22e9a2015", size = 5476566, upload-time = "2026-03-29T13:18:21.532Z" },
+    { url = "https://files.pythonhosted.org/packages/28/34/b3fdcec6e725409223dd27356bdf5a3c2cc2282e428218ecc9cb7acc9763/numpy-2.4.4-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:ba1f4fc670ed79f876f70082eff4f9583c15fb9a4b89d6188412de4d18ae2f40", size = 6806482, upload-time = "2026-03-29T13:18:23.634Z" },
+    { url = "https://files.pythonhosted.org/packages/68/62/63417c13aa35d57bee1337c67446761dc25ea6543130cf868eace6e8157b/numpy-2.4.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a87ec22c87be071b6bdbd27920b129b94f2fc964358ce38f3822635a3e2e03d", size = 15973376, upload-time = "2026-03-29T13:18:26.677Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c5/9fcb7e0e69cef59cf10c746b84f7d58b08bc66a6b7d459783c5a4f6101a6/numpy-2.4.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df3775294accfdd75f32c74ae39fcba920c9a378a2fc18a12b6820aa8c1fb502", size = 16925137, upload-time = "2026-03-29T13:18:30.14Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/43/80020edacb3f84b9efdd1591120a4296462c23fd8db0dde1666f6ef66f13/numpy-2.4.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0d4e437e295f18ec29bc79daf55e8a47a9113df44d66f702f02a293d93a2d6dd", size = 17329414, upload-time = "2026-03-29T13:18:33.733Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/06/af0658593b18a5f73532d377188b964f239eb0894e664a6c12f484472f97/numpy-2.4.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6aa3236c78803afbcb255045fbef97a9e25a1f6c9888357d205ddc42f4d6eba5", size = 18658397, upload-time = "2026-03-29T13:18:37.511Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ce/13a09ed65f5d0ce5c7dd0669250374c6e379910f97af2c08c57b0608eee4/numpy-2.4.4-cp311-cp311-win32.whl", hash = "sha256:30caa73029a225b2d40d9fae193e008e24b2026b7ee1a867b7ee8d96ca1a448e", size = 6239499, upload-time = "2026-03-29T13:18:40.372Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/63/05d193dbb4b5eec1eca73822d80da98b511f8328ad4ae3ca4caf0f4db91d/numpy-2.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:6bbe4eb67390b0a0265a2c25458f6b90a409d5d069f1041e6aff1e27e3d9a79e", size = 12614257, upload-time = "2026-03-29T13:18:42.95Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c5/8168052f080c26fa984c413305012be54741c9d0d74abd7fbeeccae3889f/numpy-2.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:fcfe2045fd2e8f3cb0ce9d4ba6dba6333b8fa05bb8a4939c908cd43322d14c7e", size = 10486775, upload-time = "2026-03-29T13:18:45.835Z" },
+    { url = "https://files.pythonhosted.org/packages/28/05/32396bec30fb2263770ee910142f49c1476d08e8ad41abf8403806b520ce/numpy-2.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15716cfef24d3a9762e3acdf87e27f58dc823d1348f765bbea6bef8c639bfa1b", size = 16689272, upload-time = "2026-03-29T13:18:49.223Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/f3/a983d28637bfcd763a9c7aafdb6d5c0ebf3d487d1e1459ffdb57e2f01117/numpy-2.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23cbfd4c17357c81021f21540da84ee282b9c8fba38a03b7b9d09ba6b951421e", size = 14699573, upload-time = "2026-03-29T13:18:52.629Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/fd/e5ecca1e78c05106d98028114f5c00d3eddb41207686b2b7de3e477b0e22/numpy-2.4.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:8b3b60bb7cba2c8c81837661c488637eee696f59a877788a396d33150c35d842", size = 5204782, upload-time = "2026-03-29T13:18:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/702a4594413c1a8632092beae8aba00f1d67947389369b3777aed783fdca/numpy-2.4.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:e4a010c27ff6f210ff4c6ef34394cd61470d01014439b192ec22552ee867f2a8", size = 6552038, upload-time = "2026-03-29T13:18:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/37/eed308a8f56cba4d1fdf467a4fc67ef4ff4bf1c888f5fc980481890104b1/numpy-2.4.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f9e75681b59ddaa5e659898085ae0eaea229d054f2ac0c7e563a62205a700121", size = 15670666, upload-time = "2026-03-29T13:19:00.341Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0d/0e3ecece05b7a7e87ab9fb587855548da437a061326fff64a223b6dcb78a/numpy-2.4.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:81f4a14bee47aec54f883e0cad2d73986640c1590eb9bfaaba7ad17394481e6e", size = 16645480, upload-time = "2026-03-29T13:19:03.63Z" },
+    { url = "https://files.pythonhosted.org/packages/34/49/f2312c154b82a286758ee2f1743336d50651f8b5195db18cdb63675ff649/numpy-2.4.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:62d6b0f03b694173f9fcb1fb317f7222fd0b0b103e784c6549f5e53a27718c44", size = 17020036, upload-time = "2026-03-29T13:19:07.428Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e9/736d17bd77f1b0ec4f9901aaec129c00d59f5d84d5e79bba540ef12c2330/numpy-2.4.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbc356aae7adf9e6336d336b9c8111d390a05df88f1805573ebb0807bd06fd1d", size = 18368643, upload-time = "2026-03-29T13:19:10.775Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f6/d417977c5f519b17c8a5c3bc9e8304b0908b0e21136fe43bf628a1343914/numpy-2.4.4-cp312-cp312-win32.whl", hash = "sha256:0d35aea54ad1d420c812bfa0385c71cd7cc5bcf7c65fed95fc2cd02fe8c79827", size = 5961117, upload-time = "2026-03-29T13:19:13.464Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5b/e1deebf88ff431b01b7406ca3583ab2bbb90972bbe1c568732e49c844f7e/numpy-2.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:b5f0362dc928a6ecd9db58868fca5e48485205e3855957bdedea308f8672ea4a", size = 12320584, upload-time = "2026-03-29T13:19:16.155Z" },
+    { url = "https://files.pythonhosted.org/packages/58/89/e4e856ac82a68c3ed64486a544977d0e7bdd18b8da75b78a577ca31c4395/numpy-2.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:846300f379b5b12cc769334464656bc882e0735d27d9726568bc932fdc49d5ec", size = 10221450, upload-time = "2026-03-29T13:19:18.994Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d0a583ce4fefcc3308806a749a536c201ed6b5ad6e1322e227ee4848979d/numpy-2.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:08f2e31ed5e6f04b118e49821397f12767934cfdd12a1ce86a058f91e004ee50", size = 16684933, upload-time = "2026-03-29T13:19:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2b7a48fbb745d344742c0277f01286dead15f3f68e4f359fbfcf7b48f70f/numpy-2.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e823b8b6edc81e747526f70f71a9c0a07ac4e7ad13020aa736bb7c9d67196115", size = 14694532, upload-time = "2026-03-29T13:19:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/87/499737bfba066b4a3bebff24a8f1c5b2dee410b209bc6668c9be692580f0/numpy-2.4.4-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:4a19d9dba1a76618dd86b164d608566f393f8ec6ac7c44f0cc879011c45e65af", size = 5199661, upload-time = "2026-03-29T13:19:28.31Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/da/464d551604320d1491bc345efed99b4b7034143a85787aab78d5691d5a0e/numpy-2.4.4-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d2a8490669bfe99a233298348acc2d824d496dee0e66e31b66a6022c2ad74a5c", size = 6547539, upload-time = "2026-03-29T13:19:30.97Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/90/8d23e3b0dafd024bf31bdec225b3bb5c2dbfa6912f8a53b8659f21216cbf/numpy-2.4.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45dbed2ab436a9e826e302fcdcbe9133f9b0006e5af7168afb8963a6520da103", size = 15668806, upload-time = "2026-03-29T13:19:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/73/a9d864e42a01896bb5974475438f16086be9ba1f0d19d0bb7a07427c4a8b/numpy-2.4.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c901b15172510173f5cb310eae652908340f8dede90fff9e3bf6c0d8dfd92f83", size = 16632682, upload-time = "2026-03-29T13:19:37.336Z" },
+    { url = "https://files.pythonhosted.org/packages/34/fb/14570d65c3bde4e202a031210475ae9cde9b7686a2e7dc97ee67d2833b35/numpy-2.4.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:99d838547ace2c4aace6c4f76e879ddfe02bb58a80c1549928477862b7a6d6ed", size = 17019810, upload-time = "2026-03-29T13:19:40.963Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/77/2ba9d87081fd41f6d640c83f26fb7351e536b7ce6dd9061b6af5904e8e46/numpy-2.4.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0aec54fd785890ecca25a6003fd9a5aed47ad607bbac5cd64f836ad8666f4959", size = 18357394, upload-time = "2026-03-29T13:19:44.859Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/23/52666c9a41708b0853fa3b1a12c90da38c507a3074883823126d4e9d5b30/numpy-2.4.4-cp313-cp313-win32.whl", hash = "sha256:07077278157d02f65c43b1b26a3886bce886f95d20aabd11f87932750dfb14ed", size = 5959556, upload-time = "2026-03-29T13:19:47.661Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fb/48649b4971cde70d817cf97a2a2fdc0b4d8308569f1dd2f2611959d2e0cf/numpy-2.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:5c70f1cc1c4efbe316a572e2d8b9b9cc44e89b95f79ca3331553fbb63716e2bf", size = 12317311, upload-time = "2026-03-29T13:19:50.67Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/d8/11490cddd564eb4de97b4579ef6bfe6a736cc07e94c1598590ae25415e01/numpy-2.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:ef4059d6e5152fa1a39f888e344c73fdc926e1b2dd58c771d67b0acfbf2aa67d", size = 10222060, upload-time = "2026-03-29T13:19:54.229Z" },
+    { url = "https://files.pythonhosted.org/packages/99/5d/dab4339177a905aad3e2221c915b35202f1ec30d750dd2e5e9d9a72b804b/numpy-2.4.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4bbc7f303d125971f60ec0aaad5e12c62d0d2c925f0ab1273debd0e4ba37aba5", size = 14822302, upload-time = "2026-03-29T13:19:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/e4/0564a65e7d3d97562ed6f9b0fd0fb0a6f559ee444092f105938b50043876/numpy-2.4.4-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:4d6d57903571f86180eb98f8f0c839fa9ebbfb031356d87f1361be91e433f5b7", size = 5327407, upload-time = "2026-03-29T13:20:00.601Z" },
+    { url = "https://files.pythonhosted.org/packages/29/8d/35a3a6ce5ad371afa58b4700f1c820f8f279948cca32524e0a695b0ded83/numpy-2.4.4-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:4636de7fd195197b7535f231b5de9e4b36d2c440b6e566d2e4e4746e6af0ca93", size = 6647631, upload-time = "2026-03-29T13:20:02.855Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/da/477731acbd5a58a946c736edfdabb2ac5b34c3d08d1ba1a7b437fa0884df/numpy-2.4.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ad2e2ef14e0b04e544ea2fa0a36463f847f113d314aa02e5b402fdf910ef309e", size = 15727691, upload-time = "2026-03-29T13:20:06.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/db/338535d9b152beabeb511579598418ba0212ce77cf9718edd70262cc4370/numpy-2.4.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a285b3b96f951841799528cd1f4f01cd70e7e0204b4abebac9463eecfcf2a40", size = 16681241, upload-time = "2026-03-29T13:20:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a9/ad248e8f58beb7a0219b413c9c7d8151c5d285f7f946c3e26695bdbbe2df/numpy-2.4.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f8474c4241bc18b750be2abea9d7a9ec84f46ef861dbacf86a4f6e043401f79e", size = 17085767, upload-time = "2026-03-29T13:20:13.126Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/1a/3b88ccd3694681356f70da841630e4725a7264d6a885c8d442a697e1146b/numpy-2.4.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4e874c976154687c1f71715b034739b45c7711bec81db01914770373d125e392", size = 18403169, upload-time = "2026-03-29T13:20:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c9/fcfd5d0639222c6eac7f304829b04892ef51c96a75d479214d77e3ce6e33/numpy-2.4.4-cp313-cp313t-win32.whl", hash = "sha256:9c585a1790d5436a5374bac930dad6ed244c046ed91b2b2a3634eb2971d21008", size = 6083477, upload-time = "2026-03-29T13:20:20.195Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e3/3938a61d1c538aaec8ed6fd6323f57b0c2d2d2219512434c5c878db76553/numpy-2.4.4-cp313-cp313t-win_amd64.whl", hash = "sha256:93e15038125dc1e5345d9b5b68aa7f996ec33b98118d18c6ca0d0b7d6198b7e8", size = 12457487, upload-time = "2026-03-29T13:20:22.946Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6a/7e345032cc60501721ef94e0e30b60f6b0bd601f9174ebd36389a2b86d40/numpy-2.4.4-cp313-cp313t-win_arm64.whl", hash = "sha256:0dfd3f9d3adbe2920b68b5cd3d51444e13a10792ec7154cd0a2f6e74d4ab3233", size = 10292002, upload-time = "2026-03-29T13:20:25.909Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/06/c54062f85f673dd5c04cbe2f14c3acb8c8b95e3384869bb8cc9bff8cb9df/numpy-2.4.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f169b9a863d34f5d11b8698ead99febeaa17a13ca044961aa8e2662a6c7766a0", size = 16684353, upload-time = "2026-03-29T13:20:29.504Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/39/8a320264a84404c74cc7e79715de85d6130fa07a0898f67fb5cd5bd79908/numpy-2.4.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2483e4584a1cb3092da4470b38866634bafb223cbcd551ee047633fd2584599a", size = 14704914, upload-time = "2026-03-29T13:20:33.547Z" },
+    { url = "https://files.pythonhosted.org/packages/91/fb/287076b2614e1d1044235f50f03748f31fa287e3dbe6abeb35cdfa351eca/numpy-2.4.4-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:2d19e6e2095506d1736b7d80595e0f252d76b89f5e715c35e06e937679ea7d7a", size = 5210005, upload-time = "2026-03-29T13:20:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/63/eb/fcc338595309910de6ecabfcef2419a9ce24399680bfb149421fa2df1280/numpy-2.4.4-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:6a246d5914aa1c820c9443ddcee9c02bec3e203b0c080349533fae17727dfd1b", size = 6544974, upload-time = "2026-03-29T13:20:39.014Z" },
+    { url = "https://files.pythonhosted.org/packages/44/5d/e7e9044032a716cdfaa3fba27a8e874bf1c5f1912a1ddd4ed071bf8a14a6/numpy-2.4.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:989824e9faf85f96ec9c7761cd8d29c531ad857bfa1daa930cba85baaecf1a9a", size = 15684591, upload-time = "2026-03-29T13:20:42.146Z" },
+    { url = "https://files.pythonhosted.org/packages/98/7c/21252050676612625449b4807d6b695b9ce8a7c9e1c197ee6216c8a65c7c/numpy-2.4.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:27a8d92cd10f1382a67d7cf4db7ce18341b66438bdd9f691d7b0e48d104c2a9d", size = 16637700, upload-time = "2026-03-29T13:20:46.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/29/56d2bbef9465db24ef25393383d761a1af4f446a1df9b8cded4fe3a5a5d7/numpy-2.4.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e44319a2953c738205bf3354537979eaa3998ed673395b964c1176083dd46252", size = 17035781, upload-time = "2026-03-29T13:20:50.242Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2b/a35a6d7589d21f44cea7d0a98de5ddcbb3d421b2622a5c96b1edf18707c3/numpy-2.4.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e892aff75639bbef0d2a2cfd55535510df26ff92f63c92cd84ef8d4ba5a5557f", size = 18362959, upload-time = "2026-03-29T13:20:54.019Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/d52ec581f2390e0f5f85cbfd80fb83d965fc15e9f0e1aec2195faa142cde/numpy-2.4.4-cp314-cp314-win32.whl", hash = "sha256:1378871da56ca8943c2ba674530924bb8ca40cd228358a3b5f302ad60cf875fc", size = 6008768, upload-time = "2026-03-29T13:20:56.912Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/22/4cc31a62a6c7b74a8730e31a4274c5dc80e005751e277a2ce38e675e4923/numpy-2.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:715d1c092715954784bc79e1174fc2a90093dc4dc84ea15eb14dad8abdcdeb74", size = 12449181, upload-time = "2026-03-29T13:20:59.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/2e/14cda6f4d8e396c612d1bf97f22958e92148801d7e4f110cabebdc0eef4b/numpy-2.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:2c194dd721e54ecad9ad387c1d35e63dce5c4450c6dc7dd5611283dda239aabb", size = 10496035, upload-time = "2026-03-29T13:21:02.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/8fed8c8d848d7ecea092dc3469643f9d10bc3a134a815a3b033da1d2039b/numpy-2.4.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2aa0613a5177c264ff5921051a5719d20095ea586ca88cc802c5c218d1c67d3e", size = 14824958, upload-time = "2026-03-29T13:21:05.671Z" },
+    { url = "https://files.pythonhosted.org/packages/05/1a/d8007a5138c179c2bf33ef44503e83d70434d2642877ee8fbb230e7c0548/numpy-2.4.4-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:42c16925aa5a02362f986765f9ebabf20de75cdefdca827d14315c568dcab113", size = 5330020, upload-time = "2026-03-29T13:21:08.635Z" },
+    { url = "https://files.pythonhosted.org/packages/99/64/ffb99ac6ae93faf117bcbd5c7ba48a7f45364a33e8e458545d3633615dda/numpy-2.4.4-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:874f200b2a981c647340f841730fc3a2b54c9d940566a3c4149099591e2c4c3d", size = 6650758, upload-time = "2026-03-29T13:21:10.949Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6e/795cc078b78a384052e73b2f6281ff7a700e9bf53bcce2ee579d4f6dd879/numpy-2.4.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c9b39d38a9bd2ae1becd7eac1303d031c5c110ad31f2b319c6e7d98b135c934d", size = 15729948, upload-time = "2026-03-29T13:21:14.047Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/86/2acbda8cc2af5f3d7bfc791192863b9e3e19674da7b5e533fded124d1299/numpy-2.4.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b268594bccac7d7cf5844c7732e3f20c50921d94e36d7ec9b79e9857694b1b2f", size = 16679325, upload-time = "2026-03-29T13:21:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/cafd83018f4aa55e0ac6fa92aa066c0a1877b77a615ceff1711c260ffae8/numpy-2.4.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac6b31e35612a26483e20750126d30d0941f949426974cace8e6b5c58a3657b0", size = 17084883, upload-time = "2026-03-29T13:21:21.106Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/85/a42548db84e65ece46ab2caea3d3f78b416a47af387fcbb47ec28e660dc2/numpy-2.4.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8e3ed142f2728df44263aaf5fb1f5b0b99f4070c553a0d7f033be65338329150", size = 18403474, upload-time = "2026-03-29T13:21:24.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/ad/483d9e262f4b831000062e5d8a45e342166ec8aaa1195264982bca267e62/numpy-2.4.4-cp314-cp314t-win32.whl", hash = "sha256:dddbbd259598d7240b18c9d87c56a9d2fb3b02fe266f49a7c101532e78c1d871", size = 6155500, upload-time = "2026-03-29T13:21:28.205Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/03/2fc4e14c7bd4ff2964b74ba90ecb8552540b6315f201df70f137faa5c589/numpy-2.4.4-cp314-cp314t-win_amd64.whl", hash = "sha256:a7164afb23be6e37ad90b2f10426149fd75aee07ca55653d2aa41e66c4ef697e", size = 12637755, upload-time = "2026-03-29T13:21:31.107Z" },
+    { url = "https://files.pythonhosted.org/packages/58/78/548fb8e07b1a341746bfbecb32f2c268470f45fa028aacdbd10d9bc73aab/numpy-2.4.4-cp314-cp314t-win_arm64.whl", hash = "sha256:ba203255017337d39f89bdd58417f03c4426f12beed0440cfd933cb15f8669c7", size = 10566643, upload-time = "2026-03-29T13:21:34.339Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/33/8fae8f964a4f63ed528264ddf25d2b683d0b663e3cba26961eb838a7c1bd/numpy-2.4.4-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:58c8b5929fcb8287cbd6f0a3fae19c6e03a5c48402ae792962ac465224a629a4", size = 16854491, upload-time = "2026-03-29T13:21:38.03Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d0/1aabee441380b981cf8cdda3ae7a46aa827d1b5a8cce84d14598bc94d6d9/numpy-2.4.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:eea7ac5d2dce4189771cedb559c738a71512768210dc4e4753b107a2048b3d0e", size = 14895830, upload-time = "2026-03-29T13:21:41.509Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b8/aafb0d1065416894fccf4df6b49ef22b8db045187949545bced89c034b8e/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:51fc224f7ca4d92656d5a5eb315f12eb5fe2c97a66249aa7b5f562528a3be38c", size = 5400927, upload-time = "2026-03-29T13:21:44.747Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/77/063baa20b08b431038c7f9ff5435540c7b7265c78cf56012a483019ca72d/numpy-2.4.4-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:28a650663f7314afc3e6ec620f44f333c386aad9f6fc472030865dc0ebb26ee3", size = 6715557, upload-time = "2026-03-29T13:21:47.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a8/379542d45a14f149444c5c4c4e7714707239ce9cc1de8c2803958889da14/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:19710a9ca9992d7174e9c52f643d4272dcd1558c5f7af7f6f8190f633bd651a7", size = 15804253, upload-time = "2026-03-29T13:21:50.753Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/c8/f0a45426d6d21e7ea3310a15cf90c43a14d9232c31a837702dba437f3373/numpy-2.4.4-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b2aec6af35c113b05695ebb5749a787acd63cafc83086a05771d1e1cd1e555f", size = 16753552, upload-time = "2026-03-29T13:21:54.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/74/f4c001f4714c3ad9ce037e18cf2b9c64871a84951eaa0baf683a9ca9301c/numpy-2.4.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f2cf083b324a467e1ab358c105f6cad5ea950f50524668a80c486ff1db24e119", size = 12509075, upload-time = "2026-03-29T13:21:57.644Z" },
 ]
 
 [[package]]
@@ -1603,6 +1697,29 @@ wheels = [
 ]
 
 [[package]]
+name = "qiskit"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "numpy" },
+    { name = "rustworkx" },
+    { name = "scipy" },
+    { name = "stevedore" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/82/7a90609d283f8707d46e1a6771e16462922789223817b6e7033490dffcaa/qiskit-2.4.1.tar.gz", hash = "sha256:90203e0241184642fc4a55cf88e20633d412b00d0aa89e3af780648744e508cf", size = 4081678, upload-time = "2026-04-24T20:34:14.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/08/f9f3d0e6f51059b0da75aba5e3dee08a4ab85c1518b1efcc56c46db800e7/qiskit-2.4.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:421c4649418d96b8996b798f7984b29e53343ed7c13ebde38dad3af5625ea1c0", size = 9350133, upload-time = "2026-04-24T22:41:34.805Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ad/2bef5daf53bb18b735ec278ee3a98b83fe10167ea156e62fb562f0141404/qiskit-2.4.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b0d14760caf84b9ce81b9380005947d028e993c8752e7f68a372b533a129a4bc", size = 8328821, upload-time = "2026-04-24T20:34:03.32Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/86/ed5929218f7943d33f37229406b42a413c1fd40c1312fe628371cc8ef563/qiskit-2.4.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:90ffe85b64d197e42cc90f21dd086bedd0609658e407f9a82b1ce3e3b4145eed", size = 8626333, upload-time = "2026-04-24T20:34:06.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c9/a7e3150e327c4328fbd66d42f72b6ecac201c6d75729c62972b2b5964101/qiskit-2.4.1-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:3314f8fe5742a1cb7bd67f9fe8302647fc78ffe9b20f22b30ee4a6c2d0d6d411", size = 9679264, upload-time = "2026-04-24T22:41:37.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f8/c1b00ac0843089771152e650c6143825746c9c85d4dac855207e15c9e26e/qiskit-2.4.1-cp310-abi3-manylinux_2_28_s390x.whl", hash = "sha256:a46572a39c3fbb01561e97e2ac7ec3afe29e96090e8d8040e90c2059ab5b3055", size = 9187719, upload-time = "2026-04-24T22:41:40.925Z" },
+    { url = "https://files.pythonhosted.org/packages/90/e8/9f1859218193ed89aef5d54b5385d891e808ff8830667bbc490d85507afd/qiskit-2.4.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:bb85390b4d6878ecc28fb54b78b128a24642a42eb3a5a58c4b144ee0730fece7", size = 9319379, upload-time = "2026-04-24T20:34:09.075Z" },
+    { url = "https://files.pythonhosted.org/packages/11/6a/c9065d0f74178275963b44e57fd93530ed36089682f918553c3bceb9a8ba/qiskit-2.4.1-cp310-abi3-win_amd64.whl", hash = "sha256:91c8c8b0582a8d0dc46c0d3fd37896b2facfd99c54671ac557da9f643114e5e3", size = 9108769, upload-time = "2026-04-24T20:34:11.888Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1778,6 +1895,99 @@ wheels = [
 ]
 
 [[package]]
+name = "rustworkx"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/b0/66d96f02120f79eeed86b5c5be04029b6821155f31ed4907a4e9f1460671/rustworkx-0.17.1.tar.gz", hash = "sha256:59ea01b4e603daffa4e8827316c1641eef18ae9032f0b1b14aa0181687e3108e", size = 399407, upload-time = "2025-09-15T16:29:46.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/24/8972ed631fa05fdec05a7bb7f1fc0f8e78ee761ab37e8a93d1ed396ba060/rustworkx-0.17.1-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c08fb8db041db052da404839b064ebfb47dcce04ba9a3e2eb79d0c65ab011da4", size = 2257491, upload-time = "2025-08-13T01:43:31.466Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/7b6bbae5e0487ee42072dc6a46edf5db9731a0701ed648db22121fb7490c/rustworkx-0.17.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:4ef8e327dadf6500edd76fedb83f6d888b9266c58bcdbffd5a40c33835c9dd26", size = 2040175, upload-time = "2025-08-13T01:43:33.762Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ea/c17fb9428c8f0dcc605596f9561627a5b9ef629d356204ee5088cfcf52c6/rustworkx-0.17.1-cp39-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b809e0aa2927c68574b196f993233e269980918101b0dd235289c4f3ddb2115", size = 2324771, upload-time = "2025-08-13T01:43:35.553Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/40/ec8b3b8b0f8c0b768690c454b8dcc2781b4f2c767f9f1215539c7909e35b/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7e82c46a92fb0fd478b7372e15ca524c287485fdecaed37b8bb68f4df2720f2", size = 2068584, upload-time = "2025-08-13T01:43:37.261Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/22/713b900d320d06ce8677e71bba0ec5df0037f1d83270bff5db3b271c10d7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42170075d8a7319e89ff63062c2f1d1116ced37b6f044f3bf36d10b60a107aa4", size = 2380949, upload-time = "2025-08-13T01:52:17.435Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4b/54be84b3b41a19caf0718a2b6bb280dde98c8626c809c969f16aad17458f/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65cba97fa95470239e2d65eb4db1613f78e4396af9f790ff771b0e5476bfd887", size = 2562069, upload-time = "2025-08-13T02:09:27.222Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/281bb21d091ab4e36cf377088366d55d0875fa2347b3189c580ec62b44c7/rustworkx-0.17.1-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:246cc252053f89e36209535b9c58755960197e6ae08d48d3973760141c62ac95", size = 2221186, upload-time = "2025-08-13T01:43:38.598Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2d/30a941a21b81e9db50c4c3ef8a64c5ee1c8eea3a90506ca0326ce39d021f/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c10d25e9f0e87d6a273d1ea390b636b4fb3fede2094bf0cb3fe565d696a91b48", size = 2123510, upload-time = "2025-08-13T01:43:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ef/c9199e4b6336ee5a9f1979c11b5779c5cf9ab6f8386e0b9a96c8ffba7009/rustworkx-0.17.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:48784a673cf8d04f3cd246fa6b53fd1ccc4d83304503463bd561c153517bccc1", size = 2302783, upload-time = "2025-08-13T01:43:42.073Z" },
+    { url = "https://files.pythonhosted.org/packages/30/3d/a49ab633e99fca4ccbb9c9f4bd41904186c175ebc25c530435529f71c480/rustworkx-0.17.1-cp39-abi3-win32.whl", hash = "sha256:5dbc567833ff0a8ad4580a4fe4bde92c186d36b4c45fca755fb1792e4fafe9b5", size = 1931541, upload-time = "2025-08-13T01:43:43.415Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ec/cee878c1879b91ab8dc7d564535d011307839a2fea79d2a650413edf53be/rustworkx-0.17.1-cp39-abi3-win_amd64.whl", hash = "sha256:d0a48fb62adabd549f9f02927c3a159b51bf654c7388a12fc16d45452d5703ea", size = 2055049, upload-time = "2025-08-13T01:43:44.926Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/83/333afb452af6f0fd70414dc04f898647ee1423979ce02efa75c3b0f2c28e/scipy-1.17.1-cp314-cp314-macosx_10_14_x86_64.whl", hash = "sha256:a48a72c77a310327f6a3a920092fa2b8fd03d7deaa60f093038f22d98e096717", size = 31584510, upload-time = "2026-02-23T00:21:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a6/d05a85fd51daeb2e4ea71d102f15b34fedca8e931af02594193ae4fd25f7/scipy-1.17.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:45abad819184f07240d8a696117a7aacd39787af9e0b719d00285549ed19a1e9", size = 28170131, upload-time = "2026-02-23T00:21:05.888Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7b/8624a203326675d7746a254083a187398090a179335b2e4a20e2ddc46e83/scipy-1.17.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3fd1fcdab3ea951b610dc4cef356d416d5802991e7e32b5254828d342f7b7e0b", size = 20342032, upload-time = "2026-02-23T00:21:09.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/35/2c342897c00775d688d8ff3987aced3426858fd89d5a0e26e020b660b301/scipy-1.17.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:7bdf2da170b67fdf10bca777614b1c7d96ae3ca5794fd9587dce41eb2966e866", size = 22678766, upload-time = "2026-02-23T00:21:14.313Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f2/7cdb8eb308a1a6ae1e19f945913c82c23c0c442a462a46480ce487fdc0ac/scipy-1.17.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:adb2642e060a6549c343603a3851ba76ef0b74cc8c079a9a58121c7ec9fe2350", size = 32957007, upload-time = "2026-02-23T00:21:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2e/7eea398450457ecb54e18e9d10110993fa65561c4f3add5e8eccd2b9cd41/scipy-1.17.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eee2cfda04c00a857206a4330f0c5e3e56535494e30ca445eb19ec624ae75118", size = 35221333, upload-time = "2026-02-23T00:21:25.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5b8509d03b77f093a0d52e606d3c4f79e8b06d1d38c441dacb1e26cacf46/scipy-1.17.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d2650c1fb97e184d12d8ba010493ee7b322864f7d3d00d3f9bb97d9c21de4068", size = 35042066, upload-time = "2026-02-23T00:21:31.358Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/18f80fb99df40b4070328d5ae5c596f2f00fffb50167e31439e932f29e7d/scipy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:08b900519463543aa604a06bec02461558a6e1cef8fdbb8098f77a48a83c8118", size = 37612763, upload-time = "2026-02-23T00:21:37.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/39/f0e8ea762a764a9dc52aa7dabcfad51a354819de1f0d4652b6a1122424d6/scipy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:3877ac408e14da24a6196de0ddcace62092bfc12a83823e92e49e40747e52c19", size = 37290984, upload-time = "2026-02-23T00:22:35.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/56/fe201e3b0f93d1a8bcf75d3379affd228a63d7e2d80ab45467a74b494947/scipy-1.17.1-cp314-cp314-win_arm64.whl", hash = "sha256:f8885db0bc2bffa59d5c1b72fad7a6a92d3e80e7257f967dd81abb553a90d293", size = 25192877, upload-time = "2026-02-23T00:22:39.798Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ad/f8c414e121f82e02d76f310f16db9899c4fcde36710329502a6b2a3c0392/scipy-1.17.1-cp314-cp314t-macosx_10_14_x86_64.whl", hash = "sha256:1cc682cea2ae55524432f3cdff9e9a3be743d52a7443d0cba9017c23c87ae2f6", size = 31949750, upload-time = "2026-02-23T00:21:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/b0/c741e8865d61b67c81e255f4f0a832846c064e426636cd7de84e74d209be/scipy-1.17.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:2040ad4d1795a0ae89bfc7e8429677f365d45aa9fd5e4587cf1ea737f927b4a1", size = 28585858, upload-time = "2026-02-23T00:21:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/3985219c6177866628fa7c2595bfd23f193ceebbe472c98a08824b9466ff/scipy-1.17.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:131f5aaea57602008f9822e2115029b55d4b5f7c070287699fe45c661d051e39", size = 20757723, upload-time = "2026-02-23T00:21:52.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/19/2a04aa25050d656d6f7b9e7b685cc83d6957fb101665bfd9369ca6534563/scipy-1.17.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:9cdc1a2fcfd5c52cfb3045feb399f7b3ce822abdde3a193a6b9a60b3cb5854ca", size = 23043098, upload-time = "2026-02-23T00:21:56.185Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f1/3383beb9b5d0dbddd030335bf8a8b32d4317185efe495374f134d8be6cce/scipy-1.17.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e3dcd57ab780c741fde8dc68619de988b966db759a3c3152e8e9142c26295ad", size = 33030397, upload-time = "2026-02-23T00:22:01.404Z" },
+    { url = "https://files.pythonhosted.org/packages/41/68/8f21e8a65a5a03f25a79165ec9d2b28c00e66dc80546cf5eb803aeeff35b/scipy-1.17.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9956e4d4f4a301ebf6cde39850333a6b6110799d470dbbb1e25326ac447f52a", size = 35281163, upload-time = "2026-02-23T00:22:07.024Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/c8a5e19479554007a5632ed7529e665c315ae7492b4f946b0deb39870e39/scipy-1.17.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:a4328d245944d09fd639771de275701ccadf5f781ba0ff092ad141e017eccda4", size = 35116291, upload-time = "2026-02-23T00:22:12.585Z" },
+    { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
+    { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1825,6 +2035,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `gpd-quantum-benchmark` MCP server exposing `compare_circuits`, `decide_better`, and `circuit_stats` tools for agents to verify quantum circuit derivations against references
- Core logic in `src/gpd/core/quantum_benchmarks.py` with typed dataclasses (CircuitStats, ComparisonResult, Decision) and Pareto-frontier cost analysis
- Optional dependency via `[quantum]` extras group (qiskit + numpy) — server gracefully errors when qiskit is absent

## Test plan

- [x] 13 unit tests covering decision engine logic, dataclass serialization, and graceful missing-qiskit handling
- [x] All 120 relevant integration tests pass (metadata consistency, release consistency, tool contract visibility, runtime abstraction boundaries)
- [x] Ruff lint passes on all new/modified files
- [ ] CI `tests` workflow (will verify on PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional quantum benchmarking: new gpd-quantum-benchmark MCP server with tools to compare circuits, decide the better circuit, and report circuit statistics; optional quantum dependencies and a console entry included.

* **Bug Fixes & Improvements**
  * Multiple docs, health-check, portability, citation, and state/reporting improvements; added --answer flag.

* **Tests**
  * New and updated tests covering the quantum benchmark tools/server and related behaviors.

* **Chores**
  * Updated .gitignore and CHANGELOG.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psi-oss/get-physics-done/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->