### PR TITLE
RES-867: persist preferred byline + affiliations in ~/.gpd/profile.json

### DIFF
--- a/src/gpd/core/constants.py
+++ b/src/gpd/core/constants.py
@@ -70,6 +70,7 @@ __all__ = [
     "PUBLICATION_MANUSCRIPT_DIR_NAME",
     "PUBLICATION_REVIEW_DIR_NAME",
     "PUBLICATION_PROOF_REVIEW_DIR_NAME",
+    "PROFILE_FILENAME",
     "PROJECT_FILENAME",
     "ProjectLayout",
     "RECOMMENDED_PYTHON_VERSION",
@@ -319,6 +320,9 @@ PATTERNS_BY_DOMAIN_DIR = "patterns-by-domain"
 
 HOME_DATA_DIR_NAME = ".gpd"
 """Hidden home-directory data root for cross-project caches and managed runtime state."""
+
+PROFILE_FILENAME = "profile.json"
+"""User author-profile file (name, affiliations, email, ORCID) at the data root."""
 
 
 # ─── Environment Variable Names ──────────────────────────────────────────────

--- a/src/gpd/core/profile.py
+++ b/src/gpd/core/profile.py
@@ -64,7 +64,9 @@ class AuthorProfile(BaseModel):
     def _name_required(cls, value: object) -> str:
         if value is None:
             raise ValueError("author name is required")
-        text = str(value).strip()
+        if not isinstance(value, str):
+            raise ValueError("author name must be a string")
+        text = value.strip()
         if not text:
             raise ValueError("author name must not be empty")
         return text
@@ -80,7 +82,9 @@ class AuthorProfile(BaseModel):
         for entry in value:
             if entry is None:
                 continue
-            text = str(entry).strip()
+            if not isinstance(entry, str):
+                raise ValueError("affiliations must be a list of strings")
+            text = entry.strip()
             if text:
                 cleaned.append(text)
         return cleaned
@@ -90,7 +94,9 @@ class AuthorProfile(BaseModel):
     def _normalize_optional_string(cls, value: object) -> str:
         if value is None:
             return ""
-        return str(value).strip()
+        if not isinstance(value, str):
+            raise ValueError("must be a string")
+        return value.strip()
 
 
 class Profile(BaseModel):

--- a/src/gpd/core/profile.py
+++ b/src/gpd/core/profile.py
@@ -1,0 +1,188 @@
+"""User author-profile helpers.
+
+The profile holds the user's preferred byline + affiliations so paper drafts
+do not require re-entering that information on every run. It lives outside
+any single project at ``~/.gpd/profile.json`` (or ``$GPD_DATA_DIR/profile.json``)
+and is read by the paper-writer skill when populating the per-paper config.
+
+The file is advisory only: a missing or malformed profile falls back silently
+to the existing per-paper prompt flow. There is no migration of existing
+per-paper ``authors[]`` — those continue to work untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import ValidationError as PydanticValidationError
+
+from gpd.core.constants import (
+    ENV_DATA_DIR,
+    HOME_DATA_DIR_NAME,
+    PROFILE_FILENAME,
+)
+from gpd.core.utils import atomic_write, file_lock, safe_read_file
+
+__all__ = [
+    "AuthorProfile",
+    "Profile",
+    "ProfileError",
+    "load_profile",
+    "profile_path",
+    "save_profile",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProfileError(ValueError):
+    """Raised when a profile file is structurally invalid (not for missing files)."""
+
+
+class AuthorProfile(BaseModel):
+    """One author entry: at minimum a non-empty name.
+
+    ``affiliations`` is a list because real papers carry dual-affiliations
+    (e.g. university + national lab); supporting ``0..n`` here avoids a v2
+    schema migration when users with multiple affiliations show up.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    name: str
+    affiliations: list[str] = Field(default_factory=list)
+    email: str = ""
+    orcid: str = ""
+
+    @field_validator("name", mode="before")
+    @classmethod
+    def _name_required(cls, value: object) -> str:
+        if value is None:
+            raise ValueError("author name is required")
+        text = str(value).strip()
+        if not text:
+            raise ValueError("author name must not be empty")
+        return text
+
+    @field_validator("affiliations", mode="before")
+    @classmethod
+    def _normalize_affiliations(cls, value: object) -> list[str]:
+        if value is None:
+            return []
+        if not isinstance(value, list):
+            raise ValueError("affiliations must be a list of strings")
+        cleaned: list[str] = []
+        for entry in value:
+            if entry is None:
+                continue
+            text = str(entry).strip()
+            if text:
+                cleaned.append(text)
+        return cleaned
+
+    @field_validator("email", "orcid", mode="before")
+    @classmethod
+    def _normalize_optional_string(cls, value: object) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
+class Profile(BaseModel):
+    """Top-level profile schema. ``authors`` may be empty when the user has
+    not yet filled in their byline; callers treat that as "no preference"."""
+
+    model_config = ConfigDict(frozen=True, extra="ignore")
+
+    schema_version: int = 1
+    authors: list[AuthorProfile] = Field(default_factory=list)
+
+    @field_validator("schema_version", mode="before")
+    @classmethod
+    def _check_schema_version(cls, value: object) -> int:
+        if value is None:
+            return 1
+        if type(value) is not int:
+            raise ValueError("schema_version must be an integer")
+        if value < 1:
+            raise ValueError("schema_version must be >= 1")
+        # Reject future-version files rather than silently lose unknown fields.
+        if value > 1:
+            raise ValueError(
+                f"profile.json schema_version={value} is newer than this build supports (max=1)"
+            )
+        return value
+
+
+def _data_root(explicit_data_dir: Path | None = None) -> Path:
+    """Resolve the GPD data root with the same precedence as recent_projects_root.
+
+    Precedence: explicit > ``GPD_DATA_DIR`` env > ``~/.gpd``.
+    """
+    if explicit_data_dir is not None:
+        return explicit_data_dir.expanduser()
+    env_dir = os.environ.get(ENV_DATA_DIR, "").strip()
+    if env_dir:
+        return Path(env_dir).expanduser()
+    return Path.home() / HOME_DATA_DIR_NAME
+
+
+def profile_path(data_root: Path | None = None) -> Path:
+    """Return the ``profile.json`` path under the resolved data root."""
+    return _data_root(data_root) / PROFILE_FILENAME
+
+
+def load_profile(data_root: Path | None = None) -> Profile:
+    """Read the profile from disk.
+
+    Returns an empty ``Profile`` when the file is missing or malformed.
+    A malformed file is logged as a warning so a partial save by another
+    process (e.g. the desktop Settings UI mid-write) doesn't crash callers.
+    """
+    path = profile_path(data_root)
+    raw = safe_read_file(path)
+    if raw is None:
+        return Profile()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("profile.json at %s is not valid JSON; ignoring invalid profile", path)
+        return Profile()
+    if not isinstance(data, dict):
+        logger.warning("profile.json at %s is not a JSON object; ignoring", path)
+        return Profile()
+    try:
+        return Profile.model_validate(data)
+    except PydanticValidationError:
+        logger.warning(
+            "profile.json at %s failed schema validation; ignoring invalid profile", path
+        )
+        return Profile()
+
+
+def save_profile(profile: Profile, data_root: Path | None = None) -> Path:
+    """Persist the profile atomically under a file lock.
+
+    Returns the path written. Creates the data root directory if needed.
+    On POSIX, enforces mode ``0o600`` on the written file because the profile
+    holds personal identifiers (name, email, ORCID, affiliations) that should
+    not be group/world-readable by default. Windows file ACLs are left to the
+    OS defaults; ``os.chmod`` would be a no-op there.
+    """
+    if not isinstance(profile, Profile):
+        raise ProfileError("save_profile requires a Profile instance")
+    path = profile_path(data_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with file_lock(path):
+        atomic_write(path, profile.model_dump_json(indent=2) + "\n")
+    if os.name == "posix":
+        try:
+            path.chmod(0o600)
+        except OSError:
+            logger.warning("profile.json at %s: could not enforce 0o600 permissions", path)
+    return path

--- a/src/gpd/specs/templates/paper/paper-config-schema.md
+++ b/src/gpd/specs/templates/paper/paper-config-schema.md
@@ -63,7 +63,7 @@ Create this JSON before asking the builder to emit `${PAPER_DIR}/{topic_specific
 ## Required Fields
 
 - `title`: non-empty string
-- `authors`: array of objects with `name`; `email` and `affiliation` are optional strings. When the user has filled in a saved profile, prefer `gpd.core.profile.load_profile()` for defaults rather than prompting per paper.
+- `authors`: array of objects with `name`; `email` and `affiliation` are optional strings
 - `abstract`: non-empty string
 - `sections`: array of section objects
 

--- a/src/gpd/specs/templates/paper/paper-config-schema.md
+++ b/src/gpd/specs/templates/paper/paper-config-schema.md
@@ -63,7 +63,7 @@ Create this JSON before asking the builder to emit `${PAPER_DIR}/{topic_specific
 ## Required Fields
 
 - `title`: non-empty string
-- `authors`: array of objects with `name`; `email` and `affiliation` are optional strings
+- `authors`: array of objects with `name`; `email` and `affiliation` are optional strings. When the user has filled in a saved profile, prefer `gpd.core.profile.load_profile()` for defaults rather than prompting per paper.
 - `abstract`: non-empty string
 - `sections`: array of section objects
 

--- a/src/gpd/specs/workflows/write-paper/outline-scaffold.md
+++ b/src/gpd/specs/workflows/write-paper/outline-scaffold.md
@@ -128,6 +128,15 @@ defines manuscript build truth and local compiler runs are smoke checks. For
 `templates/paper/paper-config-schema.md`, set a short underscore
 `output_filename`, and run `gpd paper-build` before drafting.
 
+When authoring `${PAPER_DIR}/PAPER-CONFIG.json` for a fresh bootstrap, pre-fill
+`authors` from the user's saved profile when one exists: read
+`~/.gpd/profile.json` (or `${GPD_DATA_DIR}/profile.json` if that env var is set)
+via `gpd.core.profile.load_profile()`; if it returns at least one author, map
+each `AuthorProfile` to a paper-config `authors[]` entry (`name` and `email` map
+directly; map the first `affiliations` entry to the singular `affiliation`
+field, or join multiple with `"; "`). Only ask the user for the byline when the
+profile is empty or missing.
+
 For `resume_existing_manuscript`, do not probe the builder with throwaway `/tmp`
 configs or create optional `${PAPER_DIR}/PAPER-CONFIG.json` when an accepted
 entrypoint exists. Read the schema only for real builder repair; if unclear or

--- a/src/gpd/specs/workflows/write-paper/outline-scaffold.md
+++ b/src/gpd/specs/workflows/write-paper/outline-scaffold.md
@@ -133,9 +133,9 @@ When authoring `${PAPER_DIR}/PAPER-CONFIG.json` for a fresh bootstrap, pre-fill
 `~/.gpd/profile.json` (or `${GPD_DATA_DIR}/profile.json` if that env var is set)
 via `gpd.core.profile.load_profile()`; if it returns at least one author, map
 each `AuthorProfile` to a paper-config `authors[]` entry (`name` and `email` map
-directly; map the first `affiliations` entry to the singular `affiliation`
-field, or join multiple with `"; "`). Only ask the user for the byline when the
-profile is empty or missing.
+directly; map every `affiliations` entry to the singular `affiliation` field —
+when one entry exists, use it as-is; when multiple exist, join them with
+`"; "`). Only ask the user for the byline when the profile is empty or missing.
 
 For `resume_existing_manuscript`, do not probe the builder with throwaway `/tmp`
 configs or create optional `${PAPER_DIR}/PAPER-CONFIG.json` when an accepted

--- a/src/gpd/specs/workflows/write-paper/outline-scaffold.md
+++ b/src/gpd/specs/workflows/write-paper/outline-scaffold.md
@@ -128,14 +128,11 @@ defines manuscript build truth and local compiler runs are smoke checks. For
 `templates/paper/paper-config-schema.md`, set a short underscore
 `output_filename`, and run `gpd paper-build` before drafting.
 
-When authoring `${PAPER_DIR}/PAPER-CONFIG.json` for a fresh bootstrap, pre-fill
-`authors` from the user's saved profile when one exists: read
-`~/.gpd/profile.json` (or `${GPD_DATA_DIR}/profile.json` if that env var is set)
-via `gpd.core.profile.load_profile()`; if it returns at least one author, map
-each `AuthorProfile` to a paper-config `authors[]` entry (`name` and `email` map
-directly; map every `affiliations` entry to the singular `affiliation` field —
-when one entry exists, use it as-is; when multiple exist, join them with
-`"; "`). Only ask the user for the byline when the profile is empty or missing.
+For fresh bootstrap, pre-fill `authors` via `gpd.core.profile.load_profile()`
+(reads `~/.gpd/profile.json`; `GPD_DATA_DIR` env overrides the base dir). Map
+each `AuthorProfile` to an `authors[]` entry: `name`/`email` directly,
+`affiliations` joined with `"; "` into the singular `affiliation`. Prompt the
+user only when the profile is empty.
 
 For `resume_existing_manuscript`, do not probe the builder with throwaway `/tmp`
 configs or create optional `${PAPER_DIR}/PAPER-CONFIG.json` when an accepted

--- a/tests/core/test_profile.py
+++ b/tests/core/test_profile.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from gpd.core.profile import (
     AuthorProfile,
@@ -154,7 +155,7 @@ class TestSaveProfileValidation:
 
 class TestAuthorProfileValidation:
     def test_name_is_required(self) -> None:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValidationError):
             AuthorProfile(name="")
 
     def test_name_stripped(self) -> None:

--- a/tests/core/test_profile.py
+++ b/tests/core/test_profile.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gpd.core.profile import (
+    AuthorProfile,
+    Profile,
+    ProfileError,
+    load_profile,
+    profile_path,
+    save_profile,
+)
+
+
+class TestProfilePathResolution:
+    def test_prefers_explicit_data_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        explicit = tmp_path / "explicit-data"
+        monkeypatch.setenv("GPD_DATA_DIR", str(tmp_path / "ignored"))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        assert profile_path(explicit) == explicit / "profile.json"
+
+    def test_uses_data_dir_env(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        data_dir = tmp_path / "data"
+        monkeypatch.setenv("GPD_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "home")
+
+        assert profile_path() == data_dir / "profile.json"
+
+    def test_defaults_to_home_gpd_dir(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.delenv("GPD_DATA_DIR", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        assert profile_path() == fake_home / ".gpd" / "profile.json"
+
+
+class TestLoadProfileMissingOrEmpty:
+    def test_returns_empty_when_file_missing(self, tmp_path: Path) -> None:
+        loaded = load_profile(tmp_path)
+
+        assert loaded == Profile()
+        assert loaded.authors == []
+        assert loaded.schema_version == 1
+
+    def test_returns_empty_on_invalid_json(self, tmp_path: Path) -> None:
+        (tmp_path / "profile.json").write_text("{ not valid json", encoding="utf-8")
+
+        loaded = load_profile(tmp_path)
+
+        assert loaded.authors == []
+
+    def test_returns_empty_when_root_is_not_object(self, tmp_path: Path) -> None:
+        (tmp_path / "profile.json").write_text('["array-root-not-allowed"]', encoding="utf-8")
+
+        loaded = load_profile(tmp_path)
+
+        assert loaded.authors == []
+
+    def test_returns_empty_on_schema_validation_failure(self, tmp_path: Path) -> None:
+        # author missing required name
+        (tmp_path / "profile.json").write_text(
+            json.dumps({"schema_version": 1, "authors": [{"affiliations": []}]}),
+            encoding="utf-8",
+        )
+
+        loaded = load_profile(tmp_path)
+
+        assert loaded.authors == []
+
+    def test_returns_empty_on_future_schema_version(self, tmp_path: Path) -> None:
+        (tmp_path / "profile.json").write_text(
+            json.dumps({"schema_version": 99, "authors": []}),
+            encoding="utf-8",
+        )
+
+        loaded = load_profile(tmp_path)
+
+        # Future-version files don't crash callers; they fall back to empty.
+        assert loaded.authors == []
+
+
+class TestSaveProfileRoundTrip:
+    def test_round_trip_minimal_author(self, tmp_path: Path) -> None:
+        profile = Profile(
+            authors=[AuthorProfile(name="Alex Maloney-Mendelsohn")],
+        )
+
+        save_profile(profile, tmp_path)
+        loaded = load_profile(tmp_path)
+
+        assert loaded.authors == [AuthorProfile(name="Alex Maloney-Mendelsohn")]
+        assert loaded.schema_version == 1
+
+    def test_round_trip_full_author(self, tmp_path: Path) -> None:
+        profile = Profile(
+            authors=[
+                AuthorProfile(
+                    name="Alex Maloney-Mendelsohn",
+                    affiliations=["Physical Superintelligence PBC", "MIT"],
+                    email="alex@psi.inc",
+                    orcid="0000-0002-1825-0097",
+                ),
+            ],
+        )
+
+        save_profile(profile, tmp_path)
+        loaded = load_profile(tmp_path)
+
+        assert loaded == profile
+
+    def test_round_trip_multi_author(self, tmp_path: Path) -> None:
+        profile = Profile(
+            authors=[
+                AuthorProfile(name="Alex", affiliations=["PSI"]),
+                AuthorProfile(name="Cameron", affiliations=["PSI"]),
+            ],
+        )
+
+        save_profile(profile, tmp_path)
+        loaded = load_profile(tmp_path)
+
+        assert [a.name for a in loaded.authors] == ["Alex", "Cameron"]
+
+    def test_save_creates_parent_dir(self, tmp_path: Path) -> None:
+        nested = tmp_path / "does" / "not" / "exist"
+        profile = Profile(authors=[AuthorProfile(name="Alex")])
+
+        path = save_profile(profile, nested)
+
+        assert path == nested / "profile.json"
+        assert path.exists()
+
+    def test_save_is_atomic_overwrite(self, tmp_path: Path) -> None:
+        first = Profile(authors=[AuthorProfile(name="Alex")])
+        second = Profile(authors=[AuthorProfile(name="Cameron")])
+
+        save_profile(first, tmp_path)
+        save_profile(second, tmp_path)
+
+        loaded = load_profile(tmp_path)
+        assert loaded.authors == [AuthorProfile(name="Cameron")]
+
+
+class TestSaveProfileValidation:
+    def test_rejects_non_profile_input(self, tmp_path: Path) -> None:
+        with pytest.raises(ProfileError):
+            save_profile({"schema_version": 1, "authors": []}, tmp_path)  # type: ignore[arg-type]
+
+
+class TestAuthorProfileValidation:
+    def test_name_is_required(self) -> None:
+        with pytest.raises(ValueError):
+            AuthorProfile(name="")
+
+    def test_name_stripped(self) -> None:
+        author = AuthorProfile(name="  Alex  ")
+        assert author.name == "Alex"
+
+    def test_affiliations_strip_empties(self) -> None:
+        author = AuthorProfile(name="Alex", affiliations=["PSI", "", "  ", "MIT"])
+        assert author.affiliations == ["PSI", "MIT"]
+
+    def test_optional_strings_default_empty(self) -> None:
+        author = AuthorProfile(name="Alex")
+        assert author.email == ""
+        assert author.orcid == ""


### PR DESCRIPTION
Adds a small core helper (gpd.core.profile) that reads and writes a user profile file at ~/.gpd/profile.json so the user's preferred byline and affiliations stick across paper drafts instead of needing to be re-entered each time. The file is optional and advisory only, so a missing or malformed profile just falls back to the existing per-paper prompt flow with no regression. The desktop Settings UI in gpd-app writes the file directly, and the write-paper workflow now pre-fills authors in PAPER-CONFIG.json from the saved profile when one exists. Schema is versioned and rejects future versions so partial writes never crash callers, and authors is a list now so multi-author records work without a future migration. Tests cover round-trip, missing file, malformed JSON, schema validation, future schema version, and per-author validation. Closes RES-867.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user profile system to store/manage author name, email, affiliations, and ORCID. Profiles are persisted in the user data directory (default ~/.gpd or configured location) with validation, normalization, atomic saving, file-permission safeguards, and safe loading that tolerates missing or malformed data.

* **Documentation**
  * Paper creation workflow now pre-fills author details from the user profile and prompts when none are available.

* **Tests**
  * Added tests covering profile resolution, validation, load/save round-trips, atomic overwrite, and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psi-oss/get-physics-done/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->