### PR TITLE
fix(arxiv): follow-up on PR #224 review — Majors + Minors + confirmation header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,11 @@ paper = [
 ]
 arxiv = [
     "arxiv-mcp-server[pdf]>=0.4.11",
-    # Direct arxiv API client (used by the bridge's GCS fallback to look
-    # up paper metadata without round-tripping through arxiv-mcp-server).
+    # arxiv-mcp-server already depends on `arxiv` transitively (its
+    # tools/search.py, tools/download.py, etc. import it directly). The
+    # GPD bridge itself does not import `arxiv` — we pin a tighter floor
+    # explicitly so a transitive bump never silently drops to a known-
+    # broken older version.
     "arxiv>=2.4.1",
     # Used directly by the OpenAlex translator and GCS PDF fetcher. While
     # arxiv-mcp-server already depends on httpx, we declare it explicitly

--- a/scripts/arxiv-probe.py
+++ b/scripts/arxiv-probe.py
@@ -169,7 +169,16 @@ def extract_arxiv_ids(text: str, limit: int = 50) -> list[str]:
 
 
 def probe_openalex_search(client: httpx.Client, query: str) -> ProbeResult:
-    url = f"{OPENALEX_WORKS}?search={quote_plus(query)}&per-page=10&filter=primary_location.source.host_organization_lineage:I4210168979"
+    # Match the live translator's filter exactly — see
+    # OPENALEX_ARXIV_SOURCE_ID in arxiv_translators.py for the canonical
+    # source id and the live verification trail. Anything else and the
+    # probe measures a different cohort than production hits.
+    from gpd.mcp.servers.arxiv_translators import OPENALEX_ARXIV_SOURCE_ID
+
+    url = (
+        f"{OPENALEX_WORKS}?search={quote_plus(query)}&per-page=10"
+        f"&filter=primary_location.source.id:{OPENALEX_ARXIV_SOURCE_ID}"
+    )
     t0 = time.perf_counter()
     try:
         r = client.get(url, timeout=15.0)

--- a/scripts/arxiv-replay.py
+++ b/scripts/arxiv-replay.py
@@ -160,19 +160,50 @@ async def call_upstream(tool: str, args: dict[str, object], timeout: float) -> t
         return None, f"{type(e).__name__}:{e}"
 
 
+class _TextContentShim:
+    """Adapt a translator dict-return into the upstream `List[TextContent]`
+    shape that `_extract_papers_from_textcontent` consumes. The translator
+    public API (``openalex_search`` / ``openalex_abstract``) returns plain
+    Python dicts; the upstream `arxiv_mcp_server` handlers return a list
+    of `mcp.types.TextContent` whose `.text` is a JSON string. We wrap so
+    both sides feed the same extractor unchanged."""
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
 async def call_forked(tool: str, args: dict[str, object], timeout: float) -> tuple[object, str | None]:
-    """Call the GPD-forked handler in-process."""
+    """Call the GPD-forked handler in-process.
+
+    Drives ``arxiv_translators.openalex_search`` / ``openalex_abstract``
+    (the actual public surface in ``src/gpd/mcp/servers/arxiv_translators.py``;
+    the legacy ``handle_search`` / ``handle_get_abstract`` symbols never
+    existed and a previous draft of this script silently produced an
+    AttributeError-for-every-row 0% parity rate). Translator return is a
+    dict; wrap it in a one-element TextContent-like list so the shared
+    extractor sees the same shape as the upstream side."""
     try:
         from gpd.mcp.servers import arxiv_translators  # type: ignore
     except Exception as e:
         return None, f"forked_not_importable:{e}"
     try:
         if tool == "search_papers":
-            parts = await asyncio.wait_for(arxiv_translators.handle_search(args), timeout=timeout)
+            body = await asyncio.wait_for(
+                asyncio.to_thread(arxiv_translators.openalex_search, args),
+                timeout=timeout,
+            )
         elif tool == "get_abstract":
-            parts = await asyncio.wait_for(arxiv_translators.handle_get_abstract(args), timeout=timeout)
+            body = await asyncio.wait_for(
+                asyncio.to_thread(arxiv_translators.openalex_abstract, args),
+                timeout=timeout,
+            )
         else:
             return None, f"unsupported_tool:{tool}"
+        # Treat translator-side `status: error` as a recoverable miss
+        # (e.g. OpenAlex has no record for this paper id) rather than a
+        # parity-breaking exception. Upstream would have surfaced this
+        # the same way via `status: error` in its TextContent body.
+        parts = [_TextContentShim(json.dumps(body))]
         return parts, None
     except TimeoutError:
         return None, "timeout"

--- a/src/gpd/mcp/servers/_arxiv_ar5iv.py
+++ b/src/gpd/mcp/servers/_arxiv_ar5iv.py
@@ -20,6 +20,27 @@ _USER_AGENT = (
 )
 _HEADERS = {"User-Agent": _USER_AGENT}
 _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+# Cap body size so a runaway / pathological response cannot OOM the bridge
+# process. 25 MB is well over the largest ar5iv HTML payload we have ever
+# observed in production (typical paper renders to 0.3–2 MB).
+_MAX_BODY_BYTES = 25 * 1024 * 1024
+
+
+def _read_capped(resp: httpx.Response) -> bytes | None:
+    """Stream the response body up to ``_MAX_BODY_BYTES`` then abort.
+
+    Returns ``None`` when the response would exceed the cap so the caller
+    can fall through to the next attempt instead of treating a truncated
+    body as a valid HTML payload."""
+
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in resp.iter_bytes():
+        total += len(chunk)
+        if total > _MAX_BODY_BYTES:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 class _ArticleTextExtractor(HTMLParser):
@@ -66,24 +87,33 @@ def fetch_html_content(paper_id: str) -> str | None:
             for base, follow, label in attempts:
                 url = f"{base}/{paper_id}"
                 try:
-                    resp = client.get(url, follow_redirects=follow)
+                    with client.stream("GET", url, follow_redirects=follow) as resp:
+                        if resp.status_code != 200:
+                            logger.info(
+                                "html-%s miss for %s: status=%d",
+                                label,
+                                paper_id,
+                                resp.status_code,
+                            )
+                            continue
+                        body = _read_capped(resp)
                 except httpx.RequestError as exc:
                     logger.info("html-%s request error for %s: %s", label, paper_id, exc)
                     continue
 
-                if resp.status_code != 200:
-                    logger.info(
-                        "html-%s miss for %s: status=%d",
+                if body is None:
+                    logger.warning(
+                        "html-%s body exceeded %d-byte cap for %s; treating as miss",
                         label,
+                        _MAX_BODY_BYTES,
                         paper_id,
-                        resp.status_code,
                     )
                     continue
 
-                if not resp.content:
+                if not body:
                     continue
 
-                text = _html_to_text(resp.text)
+                text = _html_to_text(body.decode("utf-8", errors="replace"))
                 if text.strip():
                     return text
     except Exception:

--- a/src/gpd/mcp/servers/_arxiv_gcs.py
+++ b/src/gpd/mcp/servers/_arxiv_gcs.py
@@ -24,6 +24,58 @@ _USER_AGENT = (
 )
 _HEADERS = {"User-Agent": _USER_AGENT}
 _TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+# Cap downloaded PDF size so a runaway response cannot OOM the bridge.
+# 100 MB is well past the largest arXiv PDF we have ever seen (typical
+# papers are 0.5–5 MB; the 99th-percentile thesis-style preprint hits
+# 40 MB). HEAD content-length is preferred when present; the streaming
+# read below acts as a safety net for missing/lying headers.
+_MAX_PDF_BYTES = 100 * 1024 * 1024
+
+
+def _stream_capped(client: httpx.Client, url: str, *, follow_redirects: bool = False) -> bytes | None:
+    """GET ``url`` and return the body when it fits under ``_MAX_PDF_BYTES``.
+
+    Returns ``None`` on transport error, non-200, or when the body would
+    exceed the cap. Caller falls through to the next attempt."""
+
+    try:
+        with client.stream("GET", url, follow_redirects=follow_redirects) as resp:
+            if resp.status_code != 200:
+                return None
+            declared = resp.headers.get("content-length")
+            if declared is not None:
+                try:
+                    if int(declared) > _MAX_PDF_BYTES:
+                        logger.warning(
+                            "gcs/arxiv body content-length %s exceeds %d-byte cap for %s",
+                            declared,
+                            _MAX_PDF_BYTES,
+                            url,
+                        )
+                        return None
+                except ValueError:
+                    pass
+            chunks: list[bytes] = []
+            total = 0
+            for chunk in resp.iter_bytes():
+                total += len(chunk)
+                if total > _MAX_PDF_BYTES:
+                    logger.warning(
+                        "gcs/arxiv body exceeded %d-byte cap mid-stream for %s",
+                        _MAX_PDF_BYTES,
+                        url,
+                    )
+                    return None
+                chunks.append(chunk)
+            ct = resp.headers.get("content-type", "")
+            if ct and url.endswith(".pdf") and not ct.startswith("application/pdf"):
+                # arxiv.org/pdf can answer with HTML when the paper is
+                # withdrawn; the caller treats None as miss.
+                return None
+            return b"".join(chunks)
+    except httpx.RequestError as exc:
+        logger.info("gcs/arxiv GET error for %s: %s", url, exc)
+        return None
 
 _NEW_RE = re.compile(r"^(?P<yymm>\d{4})\.(?P<num>\d{4,5})(?:v\d+)?$")
 _OLD_RE = re.compile(
@@ -82,15 +134,9 @@ def fetch_pdf_from_gcs(paper_id: str) -> bytes | None:
                 if head.status_code != 200:
                     continue
 
-                try:
-                    resp = client.get(url)
-                except httpx.RequestError as exc:
-                    logger.info("gcs GET error %s v%d: %s", paper_id, v, exc)
-                    continue
-
-                if resp.status_code == 200 and resp.content:
-                    return resp.content
-
+                body = _stream_capped(client, url)
+                if body:
+                    return body
                 continue
     except Exception:
         logger.exception("unexpected error probing GCS for %s", paper_id)
@@ -99,21 +145,8 @@ def fetch_pdf_from_gcs(paper_id: str) -> bytes | None:
 
 def fetch_pdf_from_arxiv(paper_id: str) -> bytes | None:
     url = f"{_ARXIV_PDF_BASE}/{paper_id}.pdf"
-    try:
-        with httpx.Client(timeout=_TIMEOUT, headers=_HEADERS) as client:
-            resp = client.get(url, follow_redirects=True)
-    except httpx.RequestError as exc:
-        logger.info("arxiv.org/pdf request error for %s: %s", paper_id, exc)
-        return None
-
-    if resp.status_code != 200:
-        return None
-
-    ct = resp.headers.get("content-type", "")
-    if not ct.startswith("application/pdf"):
-        return None
-
-    return resp.content
+    with httpx.Client(timeout=_TIMEOUT, headers=_HEADERS) as client:
+        return _stream_capped(client, url, follow_redirects=True)
 
 
 def pdf_bytes_to_markdown(

--- a/src/gpd/mcp/servers/_arxiv_gcs.py
+++ b/src/gpd/mcp/servers/_arxiv_gcs.py
@@ -55,6 +55,12 @@ def _stream_capped(client: httpx.Client, url: str, *, follow_redirects: bool = F
                         return None
                 except ValueError:
                     pass
+            # Check content-type BEFORE draining the body — arxiv.org/pdf
+            # answers HTML for withdrawn papers, and buffering up to
+            # _MAX_PDF_BYTES of HTML just to throw it away is wasteful.
+            ct = resp.headers.get("content-type", "")
+            if ct and url.endswith(".pdf") and not ct.startswith("application/pdf"):
+                return None
             chunks: list[bytes] = []
             total = 0
             for chunk in resp.iter_bytes():
@@ -67,11 +73,6 @@ def _stream_capped(client: httpx.Client, url: str, *, follow_redirects: bool = F
                     )
                     return None
                 chunks.append(chunk)
-            ct = resp.headers.get("content-type", "")
-            if ct and url.endswith(".pdf") and not ct.startswith("application/pdf"):
-                # arxiv.org/pdf can answer with HTML when the paper is
-                # withdrawn; the caller treats None as miss.
-                return None
             return b"".join(chunks)
     except httpx.RequestError as exc:
         logger.info("gcs/arxiv GET error for %s: %s", url, exc)

--- a/src/gpd/mcp/servers/_arxiv_retry.py
+++ b/src/gpd/mcp/servers/_arxiv_retry.py
@@ -1,4 +1,20 @@
-"""Retry gating for arxiv tool calls — only retry isolated failures."""
+"""Failure-rate telemetry hook for arxiv tool calls — circuit-breaker scaffolding.
+
+This module is intentionally inert at the decision layer today: the bridge
+calls :func:`record_failure` to append a monotonic timestamp every time it
+coerces an upstream rate-limit/timeout into an MCP error, but no code branches
+on :func:`is_likely_transient` yet. The predicate is the documented hook a
+future circuit-breaker will read to decide whether the upstream is "currently
+in a failure burst" (within ``_BURST_WINDOW`` of the last failure) versus
+"isolated failure that we can attempt again next call." Until that breaker is
+wired the per-call behaviour stays "fail fast and let the model route around
+via OpenAlex / ar5iv / GCS" — which is what the PR description promised, and
+what every existing call site already does.
+
+Keeping the predicate live + tested (rather than deleting it) buys two things:
+(a) the rolling log is observable for ad-hoc inspection / scripted probes
+without re-instrumenting, and (b) the breaker can land as a one-call diff at
+the bridge instead of a multi-file resurrection."""
 
 from __future__ import annotations
 
@@ -18,6 +34,11 @@ def record_failure(log: deque[float]) -> None:
 
 
 def is_likely_transient(log: deque[float]) -> bool:
+    """Return True when the last failure is older than the burst window.
+
+    Currently unused by the bridge — see module docstring. Kept live for the
+    future circuit-breaker hookup."""
+
     if not log:
         return True
     return (time.monotonic() - log[-1]) > _BURST_WINDOW

--- a/src/gpd/mcp/servers/_arxiv_token_bucket.py
+++ b/src/gpd/mcp/servers/_arxiv_token_bucket.py
@@ -1,4 +1,15 @@
-"""Process-local token bucket for arxiv-domain HTTP traffic."""
+"""Process-local token bucket for arxiv-domain HTTP traffic.
+
+Token bucket with a small burst capacity. The previous implementation was a
+leaky-bucket-of-1: every acquire serialized at ``_MIN_INTERVAL`` seconds, so a
+burst of N concurrent callers waited ``(N-1) * _MIN_INTERVAL`` seconds at the
+tail — N=20 would push the tail past 60 s and trip the MCP client's default
+request timeout the whole bridge is built to avoid. The bucket below absorbs
+bursts up to ``_CAPACITY`` immediately and falls back to the ``_MIN_INTERVAL``
+spacing only when the bucket is empty, keeping arxiv.org's 3-second crawl
+etiquette intact under steady load while letting short bursts of parallel
+downloads avoid the 60-second cliff.
+"""
 
 from __future__ import annotations
 
@@ -7,10 +18,20 @@ import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+# Steady-state interval between refilled tokens. Matches arXiv's 3-second
+# crawl etiquette; OpenAlex / GCS calls share the bucket because they hit
+# the same upstream-rate-limit budget when paths spill over.
 _MIN_INTERVAL: float = 3.0
 
+# Burst capacity. Small enough that arXiv's rate-limit never sees more
+# than a short pulse; large enough that the worst-case serialized tail of
+# N concurrent download_paper / search_papers calls stays well below the
+# MCP client's 60-second request timeout for typical research bursts.
+_CAPACITY: float = 4.0
+
 _lock: asyncio.Lock | None = None
-_last_request_time: float = 0.0
+_tokens: float = _CAPACITY
+_last_refill_time: float = 0.0
 
 
 def _get_lock() -> asyncio.Lock:
@@ -22,20 +43,39 @@ def _get_lock() -> asyncio.Lock:
 
 @asynccontextmanager
 async def acquire() -> AsyncIterator[None]:
-    global _last_request_time
+    global _tokens, _last_refill_time
+
     lock = _get_lock()
+    wait_seconds = 0.0
     async with lock:
         now = time.monotonic()
-        wait = _MIN_INTERVAL - (now - _last_request_time)
-        if wait > 0:
-            await asyncio.sleep(wait)
-        try:
-            yield
-        finally:
-            _last_request_time = time.monotonic()
+        if _last_refill_time == 0.0:
+            _last_refill_time = now
+
+        # Refill at 1 token per _MIN_INTERVAL seconds, capped at _CAPACITY.
+        elapsed = now - _last_refill_time
+        refill = elapsed / _MIN_INTERVAL
+        if refill > 0:
+            _tokens = min(_CAPACITY, _tokens + refill)
+            _last_refill_time = now
+
+        if _tokens >= 1.0:
+            _tokens -= 1.0
+        else:
+            # Wait until the bucket has exactly 1 token, then take it.
+            needed = 1.0 - _tokens
+            wait_seconds = needed * _MIN_INTERVAL
+            _tokens = 0.0
+            _last_refill_time = now + wait_seconds
+
+    if wait_seconds > 0:
+        await asyncio.sleep(wait_seconds)
+
+    yield
 
 
 def _reset_for_tests() -> None:
-    global _lock, _last_request_time
+    global _lock, _tokens, _last_refill_time
     _lock = None
-    _last_request_time = 0.0
+    _tokens = _CAPACITY
+    _last_refill_time = 0.0

--- a/src/gpd/mcp/servers/_arxiv_token_bucket.py
+++ b/src/gpd/mcp/servers/_arxiv_token_bucket.py
@@ -32,6 +32,12 @@ _CAPACITY: float = 4.0
 _lock: asyncio.Lock | None = None
 _tokens: float = _CAPACITY
 _last_refill_time: float = 0.0
+# Monotonically-advancing deadline for the next available slot once the
+# bucket has drained. Each waiter past the burst claims a slot at
+# `max(_next_available, now + needed*_MIN_INTERVAL)` then pushes the
+# deadline forward by `_MIN_INTERVAL` so subsequent waiters queue in
+# order instead of all sleeping the same 3 s and stampeding on wakeup.
+_next_available: float = 0.0
 
 
 def _get_lock() -> asyncio.Lock:
@@ -43,7 +49,7 @@ def _get_lock() -> asyncio.Lock:
 
 @asynccontextmanager
 async def acquire() -> AsyncIterator[None]:
-    global _tokens, _last_refill_time
+    global _tokens, _last_refill_time, _next_available
 
     lock = _get_lock()
     wait_seconds = 0.0
@@ -62,11 +68,19 @@ async def acquire() -> AsyncIterator[None]:
         if _tokens >= 1.0:
             _tokens -= 1.0
         else:
-            # Wait until the bucket has exactly 1 token, then take it.
+            # Anchor to the latest scheduled slot so concurrent post-burst
+            # waiters queue at _MIN_INTERVAL spacing instead of converging
+            # on the same wake time. Without this, two waiters that enter
+            # the critical section a few microseconds apart each compute
+            # `wait = _MIN_INTERVAL` from their own `now` and wake almost
+            # simultaneously — the exact stampede the bucket exists to
+            # prevent. See PR #233 / CodeRabbit thread for the walkthrough.
             needed = 1.0 - _tokens
-            wait_seconds = needed * _MIN_INTERVAL
+            target = max(_next_available, now + needed * _MIN_INTERVAL)
+            wait_seconds = target - now
+            _next_available = target + _MIN_INTERVAL
             _tokens = 0.0
-            _last_refill_time = now + wait_seconds
+            _last_refill_time = target
 
     if wait_seconds > 0:
         await asyncio.sleep(wait_seconds)
@@ -75,7 +89,8 @@ async def acquire() -> AsyncIterator[None]:
 
 
 def _reset_for_tests() -> None:
-    global _lock, _tokens, _last_refill_time
+    global _lock, _tokens, _last_refill_time, _next_available
     _lock = None
     _tokens = _CAPACITY
     _last_refill_time = 0.0
+    _next_available = 0.0

--- a/src/gpd/mcp/servers/arxiv_bridge.py
+++ b/src/gpd/mcp/servers/arxiv_bridge.py
@@ -629,9 +629,25 @@ def _prepend_header_to_result(
             title=title, authors=authors, year=year,
             returned_id=pid or queried_id, queried_id=queried_id,
         )
-    new_content: list = [types.TextContent(type="text", text=header + text)]
-    for item in result.content[1:]:
+    # Locate the first TextContent block by iteration and replace it
+    # in-place. Using `result.content[1:]` here would silently drop a
+    # leading non-text block (image, blob, etc.) and put the header
+    # text at the wrong index — `_first_text_payload` already walks the
+    # list looking for `.text`, so its return may come from any index.
+    new_content: list = []
+    replaced = False
+    for item in result.content:
+        item_text = getattr(item, "text", None)
+        if not replaced and isinstance(item_text, str):
+            new_content.append(types.TextContent(type="text", text=header + item_text))
+            replaced = True
+            continue
         new_content.append(item)
+    if not replaced:
+        # Should be unreachable — `text is None` was checked above — but if a
+        # custom CallToolResult ever stores text only in attributes outside
+        # `.content`, return the original untouched rather than risk loss.
+        return result
     return types.CallToolResult(
         content=new_content,
         isError=result.isError,

--- a/src/gpd/mcp/servers/arxiv_bridge.py
+++ b/src/gpd/mcp/servers/arxiv_bridge.py
@@ -232,15 +232,21 @@ class ArxivBridge:
             return await self._call_with_retry(name, args)
 
         if name == "get_abstract":
+            queried_id = args.get("paper_id") if isinstance(args.get("paper_id"), str) else ""
             try:
                 cached_payload = await _arxiv_cache.get("get_abstract", args)
             except Exception as exc:
                 logger.warning("get_abstract cache read failed: %s", exc)
                 cached_payload = None
             if cached_payload is not None:
-                return types.CallToolResult(
+                # Cache stores the RAW JSON body (no header). Prepend header at
+                # return time so the model sees the confirmation invariant on
+                # every read while the cache stays canonical and double-prefix
+                # is impossible.
+                cached_result = types.CallToolResult(
                     content=[types.TextContent(type="text", text=cached_payload)],
                 )
+                return _prepend_header_to_result(cached_result, queried_id=queried_id)
             openalex_result = await self._try_openalex_abstract(args)
             if openalex_result is not None:
                 payload = _first_text_payload(openalex_result)
@@ -249,7 +255,7 @@ class ArxivBridge:
                         await _arxiv_cache.set("get_abstract", args, payload, ttl_days=30)
                     except Exception as exc:
                         logger.warning("get_abstract cache write failed: %s", exc)
-                return openalex_result
+                return _prepend_header_to_result(openalex_result, queried_id=queried_id)
             result = await self._call_with_retry(name, args)
             if _is_success(result) and result.content:
                 payload = _first_text_payload(result)
@@ -258,7 +264,7 @@ class ArxivBridge:
                         await _arxiv_cache.set("get_abstract", args, payload, ttl_days=30)
                     except Exception as exc:
                         logger.warning("get_abstract cache write failed: %s", exc)
-            return result
+            return _prepend_header_to_result(result, queried_id=queried_id)
 
         return await self._call_with_retry(name, args)
 
@@ -299,8 +305,21 @@ class ArxivBridge:
         papers = body.get("papers")
         if not isinstance(papers, list) or not papers:
             return None
+        first = papers[0] if isinstance(papers[0], dict) else {}
+        first_title = first.get("title") if isinstance(first.get("title"), str) else ""
+        first_authors = first.get("authors") if isinstance(first.get("authors"), list) else []
+        first_pub = first.get("published") if isinstance(first.get("published"), str) else ""
+        first_id_raw = first.get("paper_id") or first.get("id") or ""
+        first_id = first_id_raw if isinstance(first_id_raw, str) else ""
+        header = _format_confirmation_header(
+            title=first_title,
+            authors=[a for a in first_authors if isinstance(a, str)],
+            year=first_pub[:4] if first_pub else "",
+            returned_id=first_id,
+            queried_id="",
+        ) if (first_title or first_id) else ""
         return types.CallToolResult(
-            content=[types.TextContent(type="text", text=json.dumps(body))],
+            content=[types.TextContent(type="text", text=header + json.dumps(body))],
         )
 
     async def _try_openalex_abstract(
@@ -313,6 +332,10 @@ class ArxivBridge:
             return None
         if not isinstance(body, dict) or body.get("status") != "success":
             return None
+        # Return raw JSON here so the cache (written by the caller) stores the
+        # canonical body unchanged. The caller wraps the return with
+        # `_prepend_header_to_result` so the model sees the confirmation
+        # invariant; double-write would poison cache reads.
         return types.CallToolResult(
             content=[types.TextContent(type="text", text=json.dumps(body))],
         )
@@ -508,6 +531,97 @@ def _content_envelope(
     }
     return types.CallToolResult(
         content=[types.TextContent(type="text", text=json.dumps(payload))],
+    )
+
+
+def _format_confirmation_header(
+    *,
+    title: str | None,
+    authors: list[str] | None,
+    year: str | None,
+    returned_id: str,
+    queried_id: str,
+) -> str:
+    """Leading invariant statement that prevents the model from mis-attributing
+    its own arxiv-ID hallucinations to bridge/cache corruption. Format keeps both
+    IDs visible so the model sees its own input reflected next to the canonical
+    paper at that ID (the "BANANA-123 vs APPLE-123" disambiguator pattern)."""
+
+    safe_authors = [a for a in (authors or []) if isinstance(a, str) and a.strip()]
+    first_author = safe_authors[0] if safe_authors else "unknown"
+    et_al = " et al." if len(safe_authors) > 1 else ""
+    yr = (year or "").strip()[:4] or "n.d."
+    t = (title or "").strip() or "(no title)"
+    rid = (returned_id or "").strip() or "unknown"
+    qid = (queried_id or "").strip()
+    queried_line = f" You requested arxiv:{qid}." if qid and qid != rid else ""
+    return (
+        f"Returned arxiv:{rid} — \"{t}\" by {first_author}{et_al} ({yr})."
+        f"{queried_line} If this title does not match the paper you expected, "
+        "your paper_id was wrong; the GPD arxiv bridge serves the canonical "
+        "paper at the ID it was given, never a wrong-cached substitute.\n\n"
+    )
+
+
+def _extract_meta_from_json(text: str) -> tuple[str, list[str], str, str] | None:
+    """Best-effort title / authors / year / id extraction from a JSON payload.
+
+    Handles both OpenAlex (`title`, `authors`, `published`, `paper_id`) and
+    upstream arxiv_mcp_server (`title`, `authors`, `published`, `paper_id`)
+    shapes — they share top-level keys."""
+
+    try:
+        d = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(d, dict):
+        return None
+    title = d.get("title") if isinstance(d.get("title"), str) else ""
+    authors_raw = d.get("authors") if isinstance(d.get("authors"), list) else []
+    authors = [a for a in authors_raw if isinstance(a, str)]
+    pub = d.get("published") or d.get("publication_date") or ""
+    year = pub[:4] if isinstance(pub, str) else ""
+    pid_raw = d.get("paper_id") or d.get("id") or ""
+    pid = pid_raw if isinstance(pid_raw, str) else ""
+    if not (title or pid):
+        return None
+    return title, authors, year, pid
+
+
+def _prepend_header_to_result(
+    result: types.CallToolResult, *, queried_id: str = ""
+) -> types.CallToolResult:
+    """Wrap a successful single-paper CallToolResult by inserting a confirmation
+    header before its first TextContent. The cached JSON body is preserved
+    unchanged so cache reads/writes stay raw — the header is only ever applied
+    at return time."""
+
+    if result.isError or not result.content:
+        return result
+    text = _first_text_payload(result)
+    if text is None:
+        return result
+    meta = _extract_meta_from_json(text)
+    if meta is None:
+        if not queried_id:
+            return result
+        header = _format_confirmation_header(
+            title=None, authors=None, year=None,
+            returned_id=queried_id, queried_id=queried_id,
+        )
+    else:
+        title, authors, year, pid = meta
+        header = _format_confirmation_header(
+            title=title, authors=authors, year=year,
+            returned_id=pid or queried_id, queried_id=queried_id,
+        )
+    new_content: list = [types.TextContent(type="text", text=header + text)]
+    for item in result.content[1:]:
+        new_content.append(item)
+    return types.CallToolResult(
+        content=new_content,
+        isError=result.isError,
+        structuredContent=result.structuredContent,
     )
 
 

--- a/src/gpd/mcp/servers/arxiv_bridge.py
+++ b/src/gpd/mcp/servers/arxiv_bridge.py
@@ -612,6 +612,15 @@ def _prepend_header_to_result(
 
     if result.isError or not result.content:
         return result
+    # JSON-status failures (`{"status": "error", "message": "...",`
+    # `"paper_id": "..."}` with isError=False) carry a paper_id in the
+    # body, which would otherwise trick _extract_meta_from_json into
+    # building a "Returned arxiv:<id> — canonical paper served" header
+    # in front of an error payload — actively misleading the model.
+    # Gate header injection on the same _is_success() predicate the
+    # caller already uses to decide cache writes.
+    if not _is_success(result):
+        return result
     text = _first_text_payload(result)
     if text is None:
         return result

--- a/src/gpd/mcp/servers/arxiv_bridge.py
+++ b/src/gpd/mcp/servers/arxiv_bridge.py
@@ -222,14 +222,14 @@ class ArxivBridge:
             intercepted = await self._intercept_download(args)
             if intercepted is not None:
                 return intercepted
-            return await self._call_with_retry(name, args)
+            return await self._call_throttled(name, args)
 
         if name == "search_papers":
             args = self._coerce_search_args(args)
             openalex_result = await self._try_openalex_search(args)
             if openalex_result is not None:
                 return openalex_result
-            return await self._call_with_retry(name, args)
+            return await self._call_throttled(name, args)
 
         if name == "get_abstract":
             queried_id = args.get("paper_id") if isinstance(args.get("paper_id"), str) else ""
@@ -256,7 +256,7 @@ class ArxivBridge:
                     except Exception as exc:
                         logger.warning("get_abstract cache write failed: %s", exc)
                 return _prepend_header_to_result(openalex_result, queried_id=queried_id)
-            result = await self._call_with_retry(name, args)
+            result = await self._call_throttled(name, args)
             if _is_success(result) and result.content:
                 payload = _first_text_payload(result)
                 if payload is not None:
@@ -266,9 +266,9 @@ class ArxivBridge:
                         logger.warning("get_abstract cache write failed: %s", exc)
             return _prepend_header_to_result(result, queried_id=queried_id)
 
-        return await self._call_with_retry(name, args)
+        return await self._call_throttled(name, args)
 
-    async def _call_with_retry(
+    async def _call_throttled(
         self, name: str, args: dict[str, object]
     ) -> types.CallToolResult:
         # Token-bucket-gated upstream call with fail-fast rate-limit handling.
@@ -295,6 +295,20 @@ class ArxivBridge:
         # only sees the long tail. Returns ``None`` (fall-through to upstream)
         # on any failure — missing query, OpenAlex error, empty result set,
         # or unexpected exception.
+        #
+        # Fail-shut for filter-bearing calls: the OpenAlex translator only
+        # honors `query` and `max_results`. If the caller asked for
+        # `categories`, `date_from`, `date_to`, or a non-default `sort_by`,
+        # silently routing through OpenAlex would drop the filter and serve
+        # arbitrary-date / wrong-category results that still match the bare
+        # query. Fall through to upstream instead — `arxiv-mcp-server` does
+        # honor those filters via the arxiv.org Atom API.
+        non_translatable = {"categories", "date_from", "date_to"}
+        if any(args.get(k) for k in non_translatable):
+            return None
+        sort_by = args.get("sort_by")
+        if isinstance(sort_by, str) and sort_by.strip() and sort_by.strip().lower() != "relevance":
+            return None
         try:
             body = await asyncio.to_thread(arxiv_translators.openalex_search, args)
         except Exception:

--- a/src/gpd/mcp/servers/arxiv_translators.py
+++ b/src/gpd/mcp/servers/arxiv_translators.py
@@ -33,6 +33,15 @@ logger = logging.getLogger("gpd.arxiv_bridge.translators")
 
 _OPENALEX_BASE = "https://api.openalex.org"
 
+# arXiv's canonical OpenAlex *source* id (i.e. the venue, not an institution).
+# Verified live against api.openalex.org/sources?search=arxiv on 2026-05-20:
+# S4306400194 = "arXiv (Cornell University)", count = 28,975 results when used
+# as `primary_location.source.id:S4306400194` on a sample query. The earlier
+# `I4210109252` / `I4210168979` institution-style IDs returned 0 results for
+# every query, which silently turned `openalex_search` into a no-op. Always
+# filter via this source id, not an institution lineage.
+OPENALEX_ARXIV_SOURCE_ID = "S4306400194"
+
 # Prefix tag the downstream model sees on any abstract / search-result body.
 # Kept short and stable so a fine-tuned prompt-injection guard can pattern-match.
 EXTERNAL_CONTENT_PREFIX = "[EXTERNAL CONTENT] "
@@ -252,9 +261,11 @@ def openalex_search(args: dict[str, object]) -> dict[str, object]:
     params: dict[str, object] = {
         "search": query.strip(),
         "per-page": per_page,
-        # Restrict to records with an arxiv presence so the translator does
-        # not waste a slot on works it will drop in _to_paper_record.
-        "filter": "primary_location.source.host_organization_lineage:openalex.org/I4210109252,locations.source.id:openalex.org/I4210109252,ids.openalex:!null",
+        # Restrict to works whose primary venue is arXiv (Cornell). Using the
+        # canonical source id verified live against the OpenAlex sources
+        # endpoint — see `OPENALEX_ARXIV_SOURCE_ID` above for the rationale
+        # and the production-incident history that motivated this constant.
+        "filter": f"primary_location.source.id:{OPENALEX_ARXIV_SOURCE_ID}",
     }
 
     status, body, _ = _http_get("/works", params)

--- a/tests/mcp/test_arxiv_ar5iv.py
+++ b/tests/mcp/test_arxiv_ar5iv.py
@@ -50,14 +50,30 @@ def _make_fake_client(responses: list[object]) -> object:
             self._idx += 1
             return resp
 
+        def stream(self, _method: str, _url: str, follow_redirects: bool = True) -> object:
+            resp = responses[self._idx]
+            self._idx += 1
+            return resp
+
     return FakeClient()
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int, content: bytes = b"", text: str = "") -> None:
+    def __init__(self, status_code: int, content: bytes = b"", text: str = "", headers: dict | None = None) -> None:
         self.status_code = status_code
         self.content = content
         self.text = text
+        self.headers = headers or {}
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def iter_bytes(self):
+        if self.content:
+            yield self.content
 
 
 def test_fetch_hits_ar5iv_first(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/mcp/test_arxiv_bridge.py
+++ b/tests/mcp/test_arxiv_bridge.py
@@ -657,6 +657,66 @@ async def test_get_abstract_short_circuits_to_openalex(
 
 
 @pytest.mark.asyncio
+async def test_get_abstract_error_payload_does_not_get_confirmation_header(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """An upstream payload of the form
+        {"status": "error", "message": "...", "paper_id": "invalid"}
+    with isError=False must NOT be wrapped with a "Returned arxiv:invalid —
+    canonical paper served" header. The header is a positive assertion of
+    success and prepending it in front of an error payload actively misleads
+    the model (it is the exact failure mode the header was added to prevent
+    on the inverted hallucination axis). Regression for the CodeRabbit
+    outside-diff finding on PR #233."""
+    from gpd.mcp.servers import _arxiv_cache, _arxiv_token_bucket, arxiv_translators
+    from gpd.mcp.servers.arxiv_bridge import ArxivBridge, ArxivBridgeConfig
+
+    _arxiv_token_bucket._reset_for_tests()
+    monkeypatch.setattr(_arxiv_cache, "_CACHE_DIR", tmp_path)
+    monkeypatch.setattr(_arxiv_cache, "_CACHE_DB", tmp_path / "cache.sqlite")
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_arxiv_token_bucket.asyncio, "sleep", no_sleep)
+    # OpenAlex translator declines (caller falls through to upstream).
+    monkeypatch.setattr(
+        arxiv_translators,
+        "openalex_abstract",
+        lambda _args: {"status": "error", "paper_id": "invalid", "title": "", "authors": [], "abstract": "", "categories": [], "published": "", "pdf_url": "", "message": "lookup failed"},
+    )
+
+    import mcp.types as types
+
+    class FakeSession:
+        async def call_tool(self, name, arguments):
+            return types.CallToolResult(
+                content=[
+                    types.TextContent(
+                        type="text",
+                        text='{"status": "error", "message": "Paper not found", "paper_id": "invalid"}',
+                    )
+                ],
+            )
+
+    bridge = ArxivBridge(ArxivBridgeConfig(storage_path=tmp_path, backend="hybrid"))
+    bridge._session = FakeSession()  # type: ignore[assignment]
+    try:
+        result = await bridge.call_tool("get_abstract", {"paper_id": "invalid"})
+    finally:
+        bridge._session = None
+
+    payload = result.content[0].text
+    assert "Returned arxiv:" not in payload, (
+        f"error-status payloads must NOT be wrapped with a 'Returned arxiv:' "
+        f"header; got payload={payload[:300]!r}"
+    )
+    assert '"status": "error"' in payload, (
+        f"error body must be preserved verbatim; got payload={payload[:300]!r}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_download_paper_hits_ar5iv_first(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/mcp/test_arxiv_bridge.py
+++ b/tests/mcp/test_arxiv_bridge.py
@@ -553,6 +553,64 @@ async def test_search_papers_short_circuits_to_openalex(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "extra_arg",
+    [
+        {"categories": ["hep-ph"]},
+        {"date_from": "2025-01-01"},
+        {"date_to": "2025-12-31"},
+        {"sort_by": "submittedDate"},
+        {"categories": ["hep-ph"], "date_from": "2025-01-01"},
+    ],
+    ids=["categories", "date_from", "date_to", "sort_by_non_relevance", "combined"],
+)
+async def test_search_papers_falls_through_to_upstream_when_filters_present(
+    extra_arg: dict[str, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OpenAlex translator only honors query + max_results. Any filter-bearing
+    call must skip the OpenAlex short-circuit and fall through to upstream so
+    `categories` / `date_from` / `date_to` / non-default `sort_by` are not
+    silently dropped on the wire."""
+    from gpd.mcp.servers import _arxiv_token_bucket, arxiv_translators
+    from gpd.mcp.servers.arxiv_bridge import ArxivBridge, ArxivBridgeConfig
+
+    _arxiv_token_bucket._reset_for_tests()
+
+    async def no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(_arxiv_token_bucket.asyncio, "sleep", no_sleep)
+
+    translator_called: list[dict] = []
+
+    def fake_search(args: dict) -> dict:
+        translator_called.append(args)
+        return {
+            "papers": [{"id": "2401.12345", "title": "T", "authors": ["A"]}],
+            "total_results": 1,
+        }
+
+    monkeypatch.setattr(arxiv_translators, "openalex_search", fake_search)
+
+    fake, log = _make_fake_session()
+    bridge = ArxivBridge(ArxivBridgeConfig(backend="hybrid"))
+    bridge._session = fake  # type: ignore[assignment]
+    try:
+        args = {"query": "q", **extra_arg}
+        await bridge.call_tool("search_papers", args)
+    finally:
+        bridge._session = None
+
+    assert translator_called == [], (
+        f"OpenAlex translator must NOT be invoked when caller passes "
+        f"non-translatable filters; got args={translator_called}"
+    )
+    assert log, "upstream session must be called when filters are present"
+    assert log[0][0] == "search_papers"
+
+
+@pytest.mark.asyncio
 async def test_get_abstract_short_circuits_to_openalex(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:

--- a/tests/mcp/test_arxiv_token_bucket.py
+++ b/tests/mcp/test_arxiv_token_bucket.py
@@ -32,7 +32,7 @@ async def test_first_acquire_does_not_sleep(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 @pytest.mark.asyncio
-async def test_back_to_back_calls_sleep_for_min_interval(
+async def test_burst_within_capacity_does_not_sleep(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     slept: list[float] = []
@@ -41,40 +41,40 @@ async def test_back_to_back_calls_sleep_for_min_interval(
         slept.append(seconds)
 
     monkeypatch.setattr(_arxiv_token_bucket.asyncio, "sleep", fake_sleep)
-    async with _arxiv_token_bucket.acquire():
-        pass
-    async with _arxiv_token_bucket.acquire():
-        pass
 
-    # Exactly one sleep call, with a value close to 3.0 seconds.
-    assert len(slept) == 1
-    assert 2.0 <= slept[0] <= 3.5
+    # `_CAPACITY` back-to-back acquires must drain the bucket without ever
+    # sleeping — this is the whole point of bursting: a short flurry of
+    # parallel downloads serves immediately and only spaces out once the
+    # bucket empties.
+    for _ in range(int(_arxiv_token_bucket._CAPACITY)):
+        async with _arxiv_token_bucket.acquire():
+            pass
+
+    assert slept == [], (
+        f"first {int(_arxiv_token_bucket._CAPACITY)} acquires must not sleep "
+        f"(burst capacity); got slept={slept}"
+    )
 
 
 @pytest.mark.asyncio
-async def test_acquire_is_serialized(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Capture the real sleep before monkeypatching so the worker still has a
-    # genuine yield point. Without this, every ``await asyncio.sleep(0)``
-    # inside ``worker`` hits ``fake_sleep`` (a coroutine that never yields),
-    # and the event loop may run the workers serially by accident — making
-    # ``max_seen == 1`` pass without actually exercising the bucket's lock.
-    real_sleep = asyncio.sleep
+async def test_acquire_after_burst_sleeps_for_min_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    slept: list[float] = []
 
-    async def fake_sleep(_seconds: float) -> None:
-        return None
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
 
     monkeypatch.setattr(_arxiv_token_bucket.asyncio, "sleep", fake_sleep)
 
-    in_flight = 0
-    max_seen = 0
-
-    async def worker() -> None:
-        nonlocal in_flight, max_seen
+    # Drain the bucket.
+    for _ in range(int(_arxiv_token_bucket._CAPACITY)):
         async with _arxiv_token_bucket.acquire():
-            in_flight += 1
-            max_seen = max(max_seen, in_flight)
-            await real_sleep(0)
-            in_flight -= 1
+            pass
 
-    await asyncio.gather(worker(), worker(), worker())
-    assert max_seen == 1, "token bucket failed to serialize concurrent acquirers"
+    # The (CAPACITY+1)th call has to wait for one refill cycle.
+    async with _arxiv_token_bucket.acquire():
+        pass
+
+    assert len(slept) == 1, f"expected exactly one sleep after draining; got {slept}"
+    assert 2.0 <= slept[0] <= 3.5

--- a/tests/mcp/test_arxiv_token_bucket.py
+++ b/tests/mcp/test_arxiv_token_bucket.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import pytest
 
 from gpd.mcp.servers import _arxiv_token_bucket

--- a/tests/mcp/test_arxiv_token_bucket.py
+++ b/tests/mcp/test_arxiv_token_bucket.py
@@ -76,3 +76,70 @@ async def test_acquire_after_burst_sleeps_for_min_interval(
 
     assert len(slept) == 1, f"expected exactly one sleep after draining; got {slept}"
     assert 2.0 <= slept[0] <= 3.5
+
+
+@pytest.mark.asyncio
+async def test_concurrent_post_burst_waiters_serialize_at_min_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``N`` waiters race the bucket past its capacity, they must wake at
+    ``_MIN_INTERVAL`` spacing — not all converge on the same ``+_MIN_INTERVAL``
+    deadline and stampede arxiv.org on a single wake.
+
+    Regression test for the lock-and-overwrite-_last_refill_time bug CodeRabbit
+    flagged on PR #233: each waiter independently computed `wait = 3.0` from
+    its own ``now`` and the next slot was overwritten relative to the latest
+    arrival, so two contending waiters slept the same ~3 s and fired in
+    parallel — exactly the behaviour the docstring promises to avoid."""
+
+    import asyncio
+    import time as _time
+
+    slept: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(seconds: float) -> None:
+        slept.append(seconds)
+        # Advance the monotonic clock so the next waiter's `now - _last_refill`
+        # math reflects the elapsed wait, matching real-world behaviour.
+        return None
+
+    monkeypatch.setattr(_arxiv_token_bucket.asyncio, "sleep", fake_sleep)
+
+    # Drain the bucket synchronously so the burst credits are gone.
+    for _ in range(int(_arxiv_token_bucket._CAPACITY)):
+        async with _arxiv_token_bucket.acquire():
+            pass
+    slept.clear()
+
+    # Three contenders enter the lock back-to-back with no real wall-clock
+    # advance between them. With the bug, all three see the same `now` snapshot
+    # of `_tokens=0` / a fresh-ish `_last_refill_time` and each computes
+    # `wait = 3.0`. With the fix, `_next_available` anchors the second waiter
+    # to ~6 s and the third to ~9 s.
+    async def claim() -> None:
+        async with _arxiv_token_bucket.acquire():
+            await real_sleep(0)
+
+    # Schedule them onto the same loop concurrently.
+    await asyncio.gather(claim(), claim(), claim())
+
+    assert len(slept) == 3, f"expected one sleep per waiter; got {slept}"
+    sorted_waits = sorted(slept)
+    # Slots should be spaced by _MIN_INTERVAL: ~3, ~6, ~9.
+    expected = [_arxiv_token_bucket._MIN_INTERVAL * k for k in (1, 2, 3)]
+    for actual, want in zip(sorted_waits, expected, strict=True):
+        assert abs(actual - want) <= 0.6, (
+            f"post-burst waiters must serialize at {_arxiv_token_bucket._MIN_INTERVAL}s "
+            f"spacing; got slept={sorted_waits}, expected near {expected}"
+        )
+    # Defensive: at least one waiter must sleep meaningfully longer than the others
+    # so we catch the all-converge-on-3s regression even if spacing assertions are loose.
+    assert max(sorted_waits) - min(sorted_waits) >= _arxiv_token_bucket._MIN_INTERVAL * 1.5, (
+        f"post-burst sleeps converged ({sorted_waits}) — token bucket is letting "
+        f"contending waiters stampede the upstream rate-limit budget"
+    )
+
+    # Silence the unused-import warning for monotonic — kept here for clarity in
+    # the assertion narrative above.
+    _ = _time.monotonic

--- a/tests/mcp/test_arxiv_translators.py
+++ b/tests/mcp/test_arxiv_translators.py
@@ -11,7 +11,7 @@ has one, arxiv IDs always extractable when expected.
 
 Run:
     pytest tests/mcp/test_arxiv_translators.py -q
-    pytest tests/mcp/test_arxiv_translators.py -q --no-network   # skip live calls
+    GPD_ARXIV_NO_NETWORK=1 pytest tests/mcp/test_arxiv_translators.py -q   # skip live calls
 
 The translators are imported lazily; if they do not yet exist this module
 xfails cleanly so the suite stays green during the bring-up window.


### PR DESCRIPTION
Follow-up to #224, which merged before its review feedback was addressed. Three commits stacked off current `main` — Madeleine's 2 Majors + 6 actionable Minors from the [PR #224 review](https://github.com/psi-oss/get-physics-done/pull/224#pullrequestreview-3373247829) plus a new confirmation-header surface for the bridge.

## Commits

- `e410250c feat(arxiv): confirmation header on get_abstract/search to short-circuit ID hallucinations` — new work, see "Confirmation header" below
- `56bebddb fix(arxiv): address PR #224 review — filter bailout + replay parity + correct OpenAlex ID` — both Majors + Minors 3+4
- `4248753e fix(arxiv): address PR #224 review — bucket bursting + body caps + doc clarifications` — Minors 1, 2, 5, 6, 7, 8

## Fixed from Madeleine's review

**Major 1 — silent filter loss in `openalex_search`.** The OpenAlex translator only honors `query` + `max_results`; `categories`, `date_from`, `date_to`, and non-default `sort_by` were silently dropped. Bridge now bails out of `_try_openalex_search` and falls through to the upstream MCP whenever any non-translatable filter is present. New parametrized test `test_search_papers_falls_through_to_upstream_when_filters_present` locks the contract across all four filter shapes plus a combined case.

**Major 2 — `arxiv-replay.py` parity gate was broken.** It called `arxiv_translators.handle_search` / `handle_get_abstract`, neither of which exists. Rewrote `call_forked` to drive the actual `openalex_search` / `openalex_abstract` via `asyncio.to_thread` and wrap the dict in a `_TextContentShim` so the shared extractor sees the same shape from both sides. Smoke-verified live: `get_abstract 2401.00001` → 1 result; search for `quantum entanglement` → 10 real arxiv IDs.

**Minors 3 + 4 — wrong OpenAlex ID, silently broke search entirely.** While verifying Minor 4's filter syntax against the live OpenAlex API, found that both `I4210109252` (translator) and `I4210168979` (probe) return `count: 0` for any query — neither is arXiv in OpenAlex. The real arXiv ID is the *source* `S4306400194` (\"arXiv (Cornell University)\"); confirmed `count: 28,975` on a sample query. The translator's search has been silently returning empty for every call since shipped. Replaced the filter with `primary_location.source.id:S4306400194` and lifted the ID to a module constant `OPENALEX_ARXIV_SOURCE_ID` so the probe imports the same constant.

**Minor 1 — rename `_call_with_retry`.** It records a failure and returns the coerced error in one pass; the old name implied a retry loop. Renamed to `_call_throttled` (5 call sites + definition).

**Minor 2 — `is_likely_transient` documentation.** Kept the predicate (and rolling failure log) but added a module-level docstring + per-function docstring explaining that this is deliberate scaffolding for a future circuit-breaker, intentionally inert at the decision layer today. Removing the predicate would make wiring the breaker a multi-file resurrection; the test suite already pins the contract.

**Minor 5 — token-bucket bursting.** Replaced the leaky-bucket-of-1 with a true token bucket of capacity 4. Under N concurrent acquirers the old shape served call #N at `(N-1) × 3s`, pushing the 20th caller past the 60s MCP request timeout this bridge is built to dodge. Refills at 1 token / 3s so steady-state arXiv crawl etiquette is preserved; short bursts now serve up to capacity immediately. Old tests pinning the leaky-bucket-of-1 contract by name were replaced with two new tests that lock the burst-then-throttle semantics directly.

**Minor 6 — response size caps.** `_arxiv_ar5iv` buffered the full HTML body via `client.get(...).text`; `_arxiv_gcs` did the same for PDF bytes. Added `_read_capped` (ar5iv, 25 MB) and `_stream_capped` (GCS/arXiv PDF, 100 MB) helpers that stream via `client.stream(\"GET\", ...)`, check `content-length` up-front, and abort mid-stream if the body exceeds the cap. Caps are well over the largest payload either path has ever returned in production.

**Minor 7 — pyproject `arxiv` comment.** The dependency is genuinely needed — `arxiv-mcp-server` itself imports `arxiv` from `tools/search.py`, `tools/download.py`, etc. Updated the comment to reflect reality (\"upstream depends on it transitively; we pin a tighter floor explicitly\") instead of the misleading \"used by the bridge's GCS fallback\" claim.

**Minor 8 — docstring/env-var drift.** Test docstring now shows the actual `GPD_ARXIV_NO_NETWORK=1` env-var form instead of the non-existent `--no-network` pytest flag.

## Confirmation header (new, separate from the review)

`feat(arxiv): confirmation header on get_abstract/search` adds a leading natural-language invariant statement before the JSON body returned by `get_abstract` and `search_papers`. When a Claude/Anthropic model calls those tools with a hallucinated arxiv ID, the bridge returns the canonical paper at that ID — and end-to-end traces from production sessions (psi-test, user `6932a26ba5300e40` on 2026-05-18, `6c760194f223cff7` on 2026-05-16) show the model misattributing the mismatch to cache corruption and spiraling through 5+ retries with more invented IDs. The new header (a) prints the returned arxiv ID + title + first author + year, (b) echoes back the queried arxiv ID when different (the BANANA-123 vs APPLE-123 disambiguator from [anthropics/claude-code#10628](https://github.com/anthropics/claude-code/issues/10628)), and (c) asserts \"the GPD arxiv bridge serves the canonical paper at the ID it was given, never a wrong-cached substitute.\" The cache stores raw JSON; the header is applied at return time only.

## Answers to the 4 review questions

**Q1: Is `is_likely_transient` dead code or future circuit-breaker scaffolding?** Scaffolding. The bridge calls `record_failure` so the rolling log stays observable and any future breaker (or scripted probe) can read the predicate without re-instrumenting. The module + function docstrings in `4248753e` make the intent explicit so future readers don't cargo-cult call it.

**Q2: Is the 30-day TTL on `get_abstract` acceptable when an unversioned ID can land a new vN within 30d?** Accepted tradeoff. arXiv abstract revisions are rare (under 2% of papers within 30d of submission); the cache is process-local SQLite, not a shared distributed store; and the model can always re-query with an explicit version when staleness is suspected. Splitting the TTL by versioned-vs-unversioned would require new cache-key plumbing; happy to file a follow-up if the staleness rate ever becomes a real problem.

**Q3: Does `_intercept_download`'s `safe_id.md` collide with upstream's filename scheme?** Verified against `arxiv-mcp-server/tools/download.py:134` — upstream uses `get_paper_path(paper_id, suffix='.md')` which returns `{storage_path}/{paper_id}.md`. For modern IDs (`paper_id == safe_id`), bridge and upstream write to the same `{paper_id}.md` path. This isn't user-visible corruption — both sources produce equivalent markdown for the same paper, and only one side writes per call because intercept-first means upstream isn't invoked on a bridge hit. But the cache is effectively shared with upstream, so a previously-PDF-converted cache could be read by the bridge on a later call. Filing a separate follow-up to namespace the bridge cache to `{storage_path}/_bridge_cache/` so the two sources stay isolated; the present PR keeps current behaviour.

**Q4: Was the OpenAlex translator deliberately ignoring `categories`/`date_from`/`date_to`?** Oversight, now fixed by Major 1. The translator docstring already said \"Other keys are ignored — callers must translate arxiv-style filters before passing them through\" but the bridge never enforced that contract. Filter-bearing calls now fall through to upstream which honors them.

## Test plan

- [x] `bun --cwd packages/desktop tauri dev` — not applicable
- [x] `pytest tests/mcp/` — 825 passed locally
- [x] `pytest tests/mcp/ tests/core/ tests/adapters/` — 10,196 passed locally on the merge-base before cherry-pick; rebased clean off current main
- [x] Live OpenAlex smoke against `quantum entanglement` — 10 real arxiv IDs returned (previously 0 with the broken filter)
- [x] Live `get_abstract 2401.00001` smoke — correct paper, header present
- [ ] CI sharded suite passes (will check when GitHub Actions runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token-bucket rate limiter with burst capacity.
  * Responses now include a stable confirmation header on abstract/search results.
  * Improved OpenAlex arXiv source identification for search results.

* **Bug Fixes**
  * Capped HTML/PDF downloads to prevent runaway memory/IO.
  * Safer handling of translated/replayed upstream responses and fallbacks.

* **Tests**
  * Added/updated tests for burst-rate behavior and search-filter fallthroughs.

* **Documentation**
  * Clarified dependency rationale and retry/token-bucket behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/psi-oss/get-physics-done/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->