### PR TITLE
feat(verification): executable SymPy verification oracle — 12 LaTeX-aware physics checks

### DIFF
--- a/infra/gpd-verification.json
+++ b/infra/gpd-verification.json
@@ -23,7 +23,9 @@
     "ode_check",
     "tensor_check",
     "integral_check",
-    "commutator_check"
+    "commutator_check",
+    "pde_check",
+    "matrix_check"
   ],
   "registry_prefix": "gpd_verification",
   "prerequisites": [

--- a/infra/gpd-verification.json
+++ b/infra/gpd-verification.json
@@ -17,7 +17,9 @@
     "limiting_case_check",
     "symmetry_check",
     "get_verification_coverage",
-    "conservation_check"
+    "conservation_check",
+    "equation_check",
+    "series_check"
   ],
   "registry_prefix": "gpd_verification",
   "prerequisites": [

--- a/infra/gpd-verification.json
+++ b/infra/gpd-verification.json
@@ -16,7 +16,8 @@
     "dimensional_check",
     "limiting_case_check",
     "symmetry_check",
-    "get_verification_coverage"
+    "get_verification_coverage",
+    "conservation_check"
   ],
   "registry_prefix": "gpd_verification",
   "prerequisites": [

--- a/infra/gpd-verification.json
+++ b/infra/gpd-verification.json
@@ -19,7 +19,9 @@
     "get_verification_coverage",
     "conservation_check",
     "equation_check",
-    "series_check"
+    "series_check",
+    "ode_check",
+    "tensor_check"
   ],
   "registry_prefix": "gpd_verification",
   "prerequisites": [

--- a/infra/gpd-verification.json
+++ b/infra/gpd-verification.json
@@ -21,7 +21,9 @@
     "equation_check",
     "series_check",
     "ode_check",
-    "tensor_check"
+    "tensor_check",
+    "integral_check",
+    "commutator_check"
   ],
   "registry_prefix": "gpd_verification",
   "prerequisites": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ dependencies = [
     "pybtex>=0.25.1",
     "Pillow>=12.1.1",
     "jinja2>=3.1.6",
+    # Computer-algebra backend for executable verification (limiting cases,
+    # symmetry transformations, symbolic identities) in the verification server.
+    "sympy>=1.13",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ dependencies = [
     # Computer-algebra backend for executable verification (limiting cases,
     # symmetry transformations, symbolic identities) in the verification server.
     "sympy>=1.13",
+    # Pure-Python LaTeX-math grammar backend used by SymPy's parse_latex so the
+    # verification server can accept LaTeX expressions (no antlr version pin).
+    "lark>=1.1",
 ]
 
 [project.optional-dependencies]

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -230,6 +230,8 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "series_check",
             "ode_check",
             "tensor_check",
+            "integral_check",
+            "commutator_check",
         ],
         "registry_prefix": "gpd_verification",
         "health_check": {

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -225,6 +225,7 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "limiting_case_check",
             "symmetry_check",
             "get_verification_coverage",
+            "conservation_check",
         ],
         "registry_prefix": "gpd_verification",
         "health_check": {

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -228,6 +228,8 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "conservation_check",
             "equation_check",
             "series_check",
+            "ode_check",
+            "tensor_check",
         ],
         "registry_prefix": "gpd_verification",
         "health_check": {

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -226,6 +226,8 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "symmetry_check",
             "get_verification_coverage",
             "conservation_check",
+            "equation_check",
+            "series_check",
         ],
         "registry_prefix": "gpd_verification",
         "health_check": {

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -232,6 +232,8 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "tensor_check",
             "integral_check",
             "commutator_check",
+            "pde_check",
+            "matrix_check",
         ],
         "registry_prefix": "gpd_verification",
         "health_check": {

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -33,11 +33,31 @@ _DEFAULT_TIMEOUT_S = 4.0
 # is not silently reinterpreted as a SymPy special function or constant.
 _FUNCTION_WHITELIST = frozenset(
     {
-        "sin", "cos", "tan", "cot", "sec", "csc",
-        "asin", "acos", "atan", "atan2",
-        "sinh", "cosh", "tanh", "asinh", "acosh", "atanh",
-        "exp", "log", "ln", "sqrt", "Abs", "re", "im",
-        "oo", "pi",
+        "sin",
+        "cos",
+        "tan",
+        "cot",
+        "sec",
+        "csc",
+        "asin",
+        "acos",
+        "atan",
+        "atan2",
+        "sinh",
+        "cosh",
+        "tanh",
+        "asinh",
+        "acosh",
+        "atanh",
+        "exp",
+        "log",
+        "ln",
+        "sqrt",
+        "Abs",
+        "re",
+        "im",
+        "oo",
+        "pi",
     }
 )
 
@@ -367,9 +387,7 @@ def _parse_plain(text: str, implicit: bool = False):
         if implicit:
             transformations = transformations + (implicit_multiplication_application,)
         local = {
-            name: sympy.Symbol(name)
-            for name in set(_IDENT.findall(normalized))
-            if name not in _FUNCTION_WHITELIST
+            name: sympy.Symbol(name) for name in set(_IDENT.findall(normalized)) if name not in _FUNCTION_WHITELIST
         }
         ok, value = run_with_timeout(
             lambda: parse_expr(
@@ -710,8 +728,6 @@ def check_dimensions(expression: str, symbol_dims: dict) -> dict:
         "lhs_dimensions": {k: int(v) if v == int(v) else str(v) for k, v in lhs_dims.items()},
         "rhs_dimensions": {k: int(v) if v == int(v) else str(v) for k, v in rhs_dims.items()},
         "detail": (
-            "both sides share the same dimensions"
-            if consistent
-            else "left and right sides have different dimensions"
+            "both sides share the same dimensions" if consistent else "left and right sides have different dimensions"
         ),
     }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -49,11 +49,91 @@ _UNSAFE = re.compile(
 _IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 _INF = re.compile(r"\b(?:infinity|infty|inf)\b", re.IGNORECASE)
 
+# ─── LaTeX support ─────────────────────────────────────────────────────────────
+#
+# Physics derivations are written in LaTeX, so the oracle also accepts LaTeX
+# expressions. They are parsed with SymPy's grammar-based lark backend (which
+# cannot execute code, unlike sympify). The lark grammar covers fractions,
+# powers, roots, subscripts, most Greek letters, and standard functions, but
+# rejects a handful of common macros (\hbar, \Omega, ...) and juxtaposed
+# superscripted products (``a^2 b^2``). Unsupported macros are rewritten to a
+# collision-free placeholder and substituted back; anything still unparseable
+# returns None (→ inconclusive), never a false PASS.
+
+# Macros lark rejects but that are common in physics → intended Symbol name.
+_LATEX_SYMBOL_FIXUPS = {r"\hbar": "hbar", r"\Omega": "Omega", r"\sigma": "sigma", r"\ell": "ell"}
+# Macros mapped to genuine SymPy constants rather than free symbols.
+_LATEX_CONST_FIXUPS = (r"\pi",)  # → sympy.pi
+# Supported single-token macros used as collision-free placeholders.
+_LATEX_PLACEHOLDERS = (r"\eta", r"\zeta", r"\xi", r"\chi", r"\kappa", r"\iota", r"\upsilon", r"\digamma")
+# Spacing / delimiter macros stripped before parsing.
+_LATEX_STRIP = (r"\left", r"\right", r"\quad", r"\qquad", r"\,", r"\;", r"\:", r"\!", r"\(", r"\)", r"\[", r"\]")
+# TeX constructs refused outright (environments / macro definitions / file IO).
+_LATEX_DANGEROUS = re.compile(
+    r"\\(?:input|include|def|csname|write|read|openin|catcode|immediate|loop|"
+    r"expandafter|newcommand|renewcommand|usepackage|begin|end)\b"
+)
+_LATEX_COMMAND = re.compile(r"\\[A-Za-z]+")
+# Arrow macros normalized to '->' when parsing a limit description.
+_LATEX_ARROW = re.compile(r"\\(?:to|rightarrow|longrightarrow|mapsto)\b")
+
 
 def _sympy():  # pragma: no cover - thin lazy import
     import sympy
 
     return sympy
+
+
+def _looks_like_latex(text: str) -> bool:
+    """Heuristic: does the string contain LaTeX math markup?"""
+    return bool(_LATEX_COMMAND.search(text)) or "^{" in text or "_{" in text
+
+
+def _parse_latex(text: str):
+    """Parse a LaTeX physics expression into a SymPy object, or ``None``.
+
+    Uses the grammar-based lark backend (no code execution), rewriting the
+    common lark-unsupported macros to placeholders and substituting them back.
+    """
+    cleaned = text.strip().strip("$").replace("&", " ")
+    if _LATEX_DANGEROUS.search(cleaned):
+        return None
+    for token in _LATEX_STRIP:
+        cleaned = cleaned.replace(token, " ")
+    if "=" in cleaned:
+        cleaned = cleaned.split("=")[-1].strip()
+    if not cleaned:
+        return None
+    try:
+        sympy = _sympy()
+        from sympy.parsing.latex import parse_latex
+    except Exception:  # noqa: BLE001 - sympy/lark unavailable → unparseable
+        return None
+
+    substitutions = {}
+    pool = [p for p in _LATEX_PLACEHOLDERS if p not in cleaned]
+    fixups = [(m, _LATEX_SYMBOL_FIXUPS[m]) for m in _LATEX_SYMBOL_FIXUPS]
+    fixups += [(m, None) for m in _LATEX_CONST_FIXUPS]
+    try:
+        for macro, name in fixups:
+            pattern = re.escape(macro) + r"(?![A-Za-z])"
+            if re.search(pattern, cleaned):
+                if not pool:
+                    return None
+                placeholder = pool.pop(0)
+                cleaned = re.sub(pattern, lambda _m, ph=placeholder: ph, cleaned)
+                target = sympy.pi if name is None else sympy.Symbol(name)
+                substitutions[sympy.Symbol(placeholder.lstrip("\\"))] = target
+    except Exception:  # noqa: BLE001
+        return None
+
+    ok, parsed = run_with_timeout(lambda: parse_latex(cleaned, backend="lark"))
+    if not ok or parsed is None:
+        return None
+    if not substitutions:
+        return parsed
+    ok2, substituted = run_with_timeout(lambda: parsed.subs(substitutions))
+    return substituted if ok2 else None
 
 
 def run_with_timeout(fn: Callable[[], object], timeout_s: float = _DEFAULT_TIMEOUT_S) -> tuple[bool, object]:
@@ -96,6 +176,8 @@ def safe_parse(text: str):
     raw = text.strip()
     if not raw or len(raw) > _MAX_EXPR_LEN:
         return None
+    if _looks_like_latex(raw):
+        return _parse_latex(raw)
     if _UNSAFE.search(raw):
         return None
     if "=" in raw:
@@ -158,18 +240,23 @@ def symbolic_equal(a, b, timeout_s: float = _DEFAULT_TIMEOUT_S):
 def parse_limit_target(description: str) -> tuple[str, str] | None:
     """Parse a limit description into ``(variable, point_text)`` or ``None``.
 
-    Accepts ``"hbar -> 0"``, ``"c -> infinity"``, and descriptive prefixes such
+    Accepts ``"hbar -> 0"``, ``"c -> infinity"``, LaTeX arrows/macros such as
+    ``r"\\hbar \\to 0"`` and ``r"c \\to \\infty"``, and descriptive prefixes such
     as ``"classical limit: hbar -> 0"`` (uses the last ``X -> Y`` occurrence).
     A composite ratio such as ``"v/c -> 0"`` is intentionally rejected because
     it is not a single limit variable.
     """
-    if not isinstance(description, str) or "->" not in description:
+    if not isinstance(description, str):
         return None
-    matches = re.findall(r"([A-Za-z_][A-Za-z0-9_/]*)\s*->\s*([^,;]+)", description)
+    normalized = _LATEX_ARROW.sub("->", description.replace("$", ""))
+    if "->" not in normalized:
+        return None
+    # An optional leading backslash lets LaTeX symbols (\hbar) match.
+    matches = re.findall(r"(\\?[A-Za-z_][A-Za-z0-9_/]*)\s*->\s*([^,;]+)", normalized)
     if not matches:
         return None
     var_raw, point_raw = matches[-1]
-    var = var_raw.strip()
+    var = var_raw.lstrip("\\").strip()
     if "/" in var or not var:
         return None
     return var, point_raw.strip()

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -599,3 +599,119 @@ def check_symmetry(expression: str, symmetry: str, timeout_s: float = _DEFAULT_T
         "invariant": invariant,
         "detail": f"expression is {classification} under {var_name} -> -{var_name}",
     }
+
+
+# ─── Dimensional analysis of real expressions ──────────────────────────────────
+
+
+class _DimError(Exception):
+    """Internal: a dimensional-analysis failure with a classified ``kind``."""
+
+    def __init__(self, message: str, kind: str) -> None:
+        super().__init__(message)
+        self.kind = kind  # "inconsistent" | "unknown" | "unsupported"
+
+
+def _nonzero(dims: dict) -> dict:
+    return {k: v for k, v in dims.items() if v != 0}
+
+
+def _parse_dimension_side(text: str):
+    """Parse one side of a dimensional equation (LaTeX or plain, implicit mult)."""
+    parsed = safe_parse(text)
+    if parsed is not None:
+        return parsed
+    if not _looks_like_latex(text):
+        return _parse_plain(text, implicit=True)
+    return None
+
+
+def dimension_vector(expr, symbol_dims: dict) -> dict:
+    """Return the base-dimension exponent map of ``expr``.
+
+    ``symbol_dims`` maps each free-symbol name to a base-exponent dict (e.g.
+    ``{"M": 1, "L": 2, "T": -2}``). Raises ``_DimError`` on an unknown symbol,
+    an inconsistent sum, or an unsupported node — the caller maps those to a
+    FAIL (inconsistent sum) or INCONCLUSIVE verdict.
+    """
+    sympy = _sympy()
+    if expr.is_Number or getattr(expr, "is_NumberSymbol", False):
+        return {}
+    if expr is sympy.I or expr is sympy.zoo or expr is sympy.nan or expr is sympy.oo:
+        return {}
+    if expr.is_Symbol:
+        name = str(expr)
+        if name in symbol_dims:
+            return dict(symbol_dims[name])
+        raise _DimError(f"no dimension provided for symbol '{name}'", "unknown")
+    if expr.is_Add:
+        vectors = [dimension_vector(arg, symbol_dims) for arg in expr.args]
+        base = _nonzero(vectors[0])
+        for vector in vectors[1:]:
+            if _nonzero(vector) != base:
+                raise _DimError("terms in a sum have inconsistent dimensions", "inconsistent")
+        return vectors[0]
+    if expr.is_Mul:
+        total: dict = {}
+        for factor in expr.args:
+            for key, value in dimension_vector(factor, symbol_dims).items():
+                total[key] = total.get(key, 0) + value
+        return total
+    if expr.is_Pow:
+        base, exponent = expr.args
+        if not (exponent.is_Number and exponent.is_rational):
+            raise _DimError("non-rational exponent in dimensional analysis", "unsupported")
+        return {key: value * exponent for key, value in dimension_vector(base, symbol_dims).items()}
+    if expr.is_Function:
+        for arg in expr.args:
+            if _nonzero(dimension_vector(arg, symbol_dims)):
+                raise _DimError(f"argument of {expr.func} must be dimensionless", "inconsistent")
+        return {}
+    if expr.is_constant():
+        return {}
+    raise _DimError(f"unsupported expression node {expr.func}", "unsupported")
+
+
+def check_dimensions(expression: str, symbol_dims: dict) -> dict:
+    """Verify dimensional homogeneity of ``LHS = RHS`` given symbol dimensions.
+
+    Returns an additive ``cas`` payload (pass/fail/inconclusive). A sum mixing
+    incompatible dimensions, or LHS dimensions differing from RHS, is a FAIL;
+    unknown symbols / unparseable sides are INCONCLUSIVE (never a false pass).
+    """
+    if "=" not in expression:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "expression must contain '=' to compare dimensions",
+        }
+    lhs_text, rhs_text = expression.split("=", 1)
+    lhs = _parse_dimension_side(lhs_text)
+    rhs = _parse_dimension_side(rhs_text)
+    if lhs is None or rhs is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "one or both sides are not machine-parseable",
+        }
+    try:
+        lhs_dims = _nonzero(dimension_vector(lhs, symbol_dims))
+        rhs_dims = _nonzero(dimension_vector(rhs, symbol_dims))
+    except _DimError as exc:
+        verdict = VERDICT_FAIL if exc.kind == "inconsistent" else VERDICT_INCONCLUSIVE
+        return {"attempted": exc.kind == "inconsistent", "verdict": verdict, "detail": str(exc)}
+    except Exception:  # noqa: BLE001 - any other failure → inconclusive, never pass
+        return {"attempted": False, "verdict": VERDICT_INCONCLUSIVE, "detail": "could not compute dimensions"}
+
+    consistent = lhs_dims == rhs_dims
+    return {
+        "attempted": True,
+        "verdict": VERDICT_PASS if consistent else VERDICT_FAIL,
+        "lhs_dimensions": {k: int(v) if v == int(v) else str(v) for k, v in lhs_dims.items()},
+        "rhs_dimensions": {k: int(v) if v == int(v) else str(v) for k, v in rhs_dims.items()},
+        "detail": (
+            "both sides share the same dimensions"
+            if consistent
+            else "left and right sides have different dimensions"
+        ),
+    }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -1302,3 +1302,146 @@ def check_commutator(
             else f"could not decide whether [{a}, {b}] matches the expected result"
         ),
     }
+
+
+# ─── PDE solution checking ─────────────────────────────────────────────────────
+
+
+def check_pde(
+    equation: str, solution: str, variables: list[str], function: str = "u", timeout_s: float = _DEFAULT_TIMEOUT_S
+) -> dict:
+    """Verify a candidate ``solution`` satisfies a PDE by substitution.
+
+    Partial derivatives of ``function`` use subscript notation — each letter
+    after ``_`` is one differentiation w.r.t. that variable: ``u_t``, ``u_xx``,
+    ``u_xt`` (mixed). The equation may be a residual or ``LHS = RHS``, e.g. the
+    heat equation ``"u_t = alpha * u_xx"``. Substitutes the solution and its
+    partials and simplifies the residual: zero → pass, nonzero → fail.
+    """
+    sol = safe_parse(solution)
+    if sol is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "solution is not machine-parseable"}
+    sympy = _sympy()
+    var_syms: dict[str, object] = {}
+    for name in variables:
+        if not isinstance(name, str) or not name.isidentifier():
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"invalid variable name '{name}'"}
+        var_syms[name] = sympy.Symbol(name)
+
+    lhs_text, rhs_text = (equation.split("=", 1) + ["0"])[:2] if "=" in equation else (equation, "0")
+    pattern = re.compile(
+        r"(?<![A-Za-z0-9_])" + re.escape(function) + r"(?:_(?P<sub>[A-Za-z]+))?(?![A-Za-z0-9_])"
+    )
+    subscripts: set[str] = set()
+
+    def _to_placeholder(match: re.Match[str]) -> str:
+        sub = match.group("sub") or ""
+        subscripts.add(sub)
+        return f"PDEDERIV_{sub or 'BASE'}"
+
+    lhs_mod = pattern.sub(_to_placeholder, lhs_text)
+    rhs_mod = pattern.sub(_to_placeholder, rhs_text)
+    if not subscripts:
+        return {
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": f"function '{function}' (optionally subscripted) not found in the equation",
+        }
+
+    lhs_expr = _parse_plain(lhs_mod)
+    rhs_expr = _parse_plain(rhs_mod)
+    if lhs_expr is None or rhs_expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "equation is not machine-parseable"}
+
+    substitutions = {}
+    for sub in subscripts:
+        if not sub:
+            derivative = sol
+        else:
+            diff_args = []
+            for char in sub:
+                if char not in var_syms:
+                    return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"subscript variable '{char}' is not in variables"}
+                diff_args.append(var_syms[char])
+            ok, derivative = run_with_timeout(lambda args=diff_args: sympy.diff(sol, *args), timeout_s)
+            if not ok:
+                return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not differentiate the solution"}
+        substitutions[sympy.Symbol(f"PDEDERIV_{sub or 'BASE'}")] = derivative
+
+    ok, residual = run_with_timeout(lambda: sympy.simplify((lhs_expr - rhs_expr).subs(substitutions)), timeout_s)
+    if not ok:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not simplify the residual"}
+    is_zero = symbolic_equal(residual, sympy.Integer(0), timeout_s)
+    if is_zero is True:
+        return {"verdict": VERDICT_PASS, "residual": "0", "detail": "solution satisfies the PDE"}
+    if is_zero is False:
+        return {"verdict": VERDICT_FAIL, "residual": str(residual), "detail": "solution does NOT satisfy the PDE"}
+    return {"verdict": VERDICT_INCONCLUSIVE, "residual": str(residual), "detail": "could not determine whether the residual vanishes"}
+
+
+# ─── Matrix property checking ──────────────────────────────────────────────────
+
+_MATRIX_DIFFS = {
+    "symmetric": lambda m, eye: m - m.T,
+    "antisymmetric": lambda m, eye: m + m.T,
+    "skew-symmetric": lambda m, eye: m + m.T,
+    "hermitian": lambda m, eye: m - m.H,
+    "anti-hermitian": lambda m, eye: m + m.H,
+    "unitary": lambda m, eye: m.H * m - eye,
+    "orthogonal": lambda m, eye: m.T * m - eye,
+    "idempotent": lambda m, eye: m * m - m,
+    "projection": lambda m, eye: m * m - m,
+    "involutory": lambda m, eye: m * m - eye,
+    "normal": lambda m, eye: m.H * m - m * m.H,
+}
+_MATRIX_NEEDS_SQUARE = {
+    "hermitian", "anti-hermitian", "unitary", "orthogonal", "idempotent", "projection", "involutory", "normal"
+}
+
+
+def check_matrix(rows: list[list[str]], prop: str, timeout_s: float = _DEFAULT_TIMEOUT_S) -> dict:
+    """Verify a structural property of a matrix (entries are expression strings).
+
+    ``prop`` is one of symmetric / antisymmetric / hermitian / anti-hermitian /
+    unitary / orthogonal / idempotent (projection) / involutory / normal. ``I``
+    in entries is the imaginary unit (e.g. Pauli ``Y = [[0, -I], [I, 0]]``).
+    Returns pass/fail; unparseable entries or an undecidable comparison →
+    inconclusive.
+    """
+    sympy = _sympy()
+    parsed: list[list[object]] = []
+    for row in rows:
+        if not isinstance(row, list) or not row:
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "matrix must be a non-empty list of rows"}
+        parsed_row = []
+        for cell in row:
+            entry = safe_parse(cell) if isinstance(cell, str) else None
+            if entry is None:
+                return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"matrix entry '{cell}' is not machine-parseable"}
+            parsed_row.append(entry.subs(sympy.Symbol("I"), sympy.I))
+        parsed.append(parsed_row)
+    if any(len(row) != len(parsed[0]) for row in parsed):
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "matrix rows have differing lengths"}
+
+    matrix = sympy.Matrix(parsed)
+    key = prop.strip().lower().replace(" ", "-").replace("_", "-")
+    if key == "antihermitian":
+        key = "anti-hermitian"
+    if key not in _MATRIX_DIFFS:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"unknown matrix property '{prop}'"}
+    square = matrix.rows == matrix.cols
+    if key in _MATRIX_NEEDS_SQUARE and not square:
+        return {"verdict": VERDICT_FAIL, "shape": f"{matrix.rows}x{matrix.cols}", "detail": f"matrix is not square, so it cannot be {prop}"}
+
+    eye = sympy.eye(matrix.rows) if square else None
+    ok, difference = run_with_timeout(lambda: _MATRIX_DIFFS[key](matrix, eye).applyfunc(sympy.simplify), timeout_s)
+    if not ok:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not evaluate the matrix property"}
+    zero = difference.is_zero_matrix
+    return {
+        "verdict": VERDICT_PASS if zero is True else VERDICT_FAIL if zero is False else VERDICT_INCONCLUSIVE,
+        "property": prop,
+        "shape": f"{matrix.rows}x{matrix.cols}",
+        "detail": (
+            f"matrix is {prop}" if zero is True else f"matrix is NOT {prop}" if zero is False else f"could not decide whether the matrix is {prop}"
+        ),
+    }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -544,12 +544,63 @@ def _pick_variable(free_names: list[str], preferred: tuple[str, ...]) -> str | N
     return None
 
 
+def _scale_symmetry(expr, free_names: list[str], timeout_s: float) -> dict:
+    """Classify scale behavior via Euler's homogeneity theorem.
+
+    Under ``v -> lambda v``, ``f -> lambda^n f`` iff ``v df/dv = n f`` with ``n``
+    constant. Reports the homogeneity degree ``n`` in the chosen variable;
+    scale-invariant means ``n == 0``.
+    """
+    var_name = _pick_variable(free_names, _PARITY_VARS)
+    if var_name is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "could not unambiguously identify a single variable to scale",
+        }
+    sympy = _sympy()
+    var = sympy.Symbol(var_name)
+    ok, ratio = run_with_timeout(lambda: sympy.simplify(var * expr.diff(var) / expr), timeout_s)
+    if not ok:
+        return {
+            "attempted": True,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "transformation": f"{var_name} -> lambda*{var_name}",
+            "detail": f"could not compute the scaling degree ({ratio})",
+        }
+    if ratio.free_symbols:
+        return {
+            "attempted": True,
+            "verdict": VERDICT_COMPUTED,
+            "transformation": f"{var_name} -> lambda*{var_name}",
+            "classification": f"not scale-homogeneous in {var_name}",
+            "invariant": False,
+            "detail": f"expression is not homogeneous under {var_name} -> lambda*{var_name}",
+        }
+    degree = sympy.nsimplify(ratio) if ratio.is_Float else ratio
+    invariant = degree == 0
+    return {
+        "attempted": True,
+        "verdict": VERDICT_COMPUTED,
+        "transformation": f"{var_name} -> lambda*{var_name}",
+        "scale_degree": str(degree),
+        "classification": f"homogeneous of degree {degree} in {var_name}",
+        "invariant": bool(invariant),
+        "detail": (
+            f"expression is scale-invariant in {var_name} (degree 0)"
+            if invariant
+            else f"expression scales as lambda^{degree} under {var_name} -> lambda*{var_name}"
+        ),
+    }
+
+
 def check_symmetry(expression: str, symmetry: str, timeout_s: float = _DEFAULT_TIMEOUT_S) -> dict:
-    """Execute a coordinate-reflection symmetry check where one is well-defined.
+    """Execute a symmetry check where one is well-defined.
 
     Handles parity (``x -> -x``) and time-reversal (``t -> -t``) by substitution
-    and classifies the expression as invariant (even) / odd / neither. Other
-    symmetries (gauge, Lorentz, ...) have no single-substitution test and return
+    (classifying even / odd / neither), and scale / dilation via Euler's
+    homogeneity theorem (reporting the homogeneity degree). Other symmetries
+    (gauge, Lorentz, ...) have no sound single-expression test and return
     inconclusive so the structural ``status`` field still drives those.
     """
     name = symmetry.lower().replace("_", " ").replace("-", " ")
@@ -566,11 +617,13 @@ def check_symmetry(expression: str, symmetry: str, timeout_s: float = _DEFAULT_T
         var_name = _pick_variable(free_names, _PARITY_VARS)
     elif "time" in name and "revers" in name:
         var_name = _pick_variable(free_names, _TIME_VARS)
+    elif "scale" in name or "dilat" in name:
+        return _scale_symmetry(expr, free_names, timeout_s)
     else:
         return {
             "attempted": False,
             "verdict": VERDICT_INCONCLUSIVE,
-            "detail": "no single-substitution transformation defined for this symmetry",
+            "detail": "no executable transformation defined for this symmetry",
         }
 
     if var_name is None:
@@ -923,3 +976,176 @@ def check_series(
         result["verdict"] = VERDICT_COMPUTED
         result["detail"] = "equality undecidable — review computed_series vs expected"
     return result
+
+
+# ─── ODE solution checking ─────────────────────────────────────────────────────
+
+# function + primes, as a whole token: y, y', y'' ...
+def _derivative_pattern(function: str) -> re.Pattern[str]:
+    return re.compile(r"(?<![A-Za-z0-9_])" + re.escape(function) + r"(?P<p>'*)(?![A-Za-z0-9_])")
+
+
+def check_ode(
+    equation: str, solution: str, variable: str = "x", function: str = "y", timeout_s: float = _DEFAULT_TIMEOUT_S
+) -> dict:
+    """Verify a candidate ``solution`` satisfies an ODE by substitution.
+
+    The ODE uses prime notation for derivatives of ``function`` (``y``, ``y'``,
+    ``y''`` …) and may be a residual or an ``LHS = RHS`` equation, e.g.
+    ``"y'' + omega**2 * y = 0"``. Substitutes the solution and its derivatives
+    and simplifies the residual: zero → pass, provably nonzero → fail.
+    Unparseable input or an undecidable residual → inconclusive.
+    """
+    sol = safe_parse(solution)
+    if sol is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "solution is not machine-parseable"}
+    lhs_text, rhs_text = (equation.split("=", 1) + ["0"])[:2] if "=" in equation else (equation, "0")
+
+    pattern = _derivative_pattern(function)
+    orders: set[int] = set()
+
+    def _to_placeholder(match: re.Match[str]) -> str:
+        order = len(match.group("p"))
+        orders.add(order)
+        return f"DERIVPLACE{order}"
+
+    lhs_mod = pattern.sub(_to_placeholder, lhs_text)
+    rhs_mod = pattern.sub(_to_placeholder, rhs_text)
+    if not orders:
+        return {
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": f"function '{function}' (optionally primed) not found in the equation",
+        }
+
+    lhs_expr = _parse_plain(lhs_mod)
+    rhs_expr = _parse_plain(rhs_mod)
+    if lhs_expr is None or rhs_expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "equation is not machine-parseable"}
+
+    sympy = _sympy()
+    var = sympy.Symbol(variable)
+    substitutions = {}
+    for order in orders:
+        ok, derivative = run_with_timeout(lambda o=order: sympy.diff(sol, var, o), timeout_s)
+        if not ok:
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not differentiate the solution"}
+        substitutions[sympy.Symbol(f"DERIVPLACE{order}")] = derivative
+
+    ok, residual = run_with_timeout(lambda: sympy.simplify((lhs_expr - rhs_expr).subs(substitutions)), timeout_s)
+    if not ok:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not simplify the residual"}
+
+    is_zero = symbolic_equal(residual, _sympy().Integer(0), timeout_s)
+    if is_zero is True:
+        return {"verdict": VERDICT_PASS, "residual": "0", "detail": "solution satisfies the differential equation"}
+    if is_zero is False:
+        return {
+            "verdict": VERDICT_FAIL,
+            "residual": str(residual),
+            "detail": "solution does NOT satisfy the equation (residual is nonzero)",
+        }
+    return {
+        "verdict": VERDICT_INCONCLUSIVE,
+        "residual": str(residual),
+        "detail": "could not determine whether the residual vanishes",
+    }
+
+
+# ─── Tensor index / contraction consistency ────────────────────────────────────
+
+_INDEX_TOKEN = re.compile(r"\\?[A-Za-z][A-Za-z0-9]*")
+_UPPER_BRACED = re.compile(r"\^\{([^}]*)\}")
+_LOWER_BRACED = re.compile(r"_\{([^}]*)\}")
+_UPPER_SINGLE = re.compile(r"\^(\\?[A-Za-z][A-Za-z0-9]*)")
+_LOWER_SINGLE = re.compile(r"_(\\?[A-Za-z][A-Za-z0-9]*)")
+
+
+def _index_tokens(text: str) -> list[str]:
+    return [re.sub(r"[^A-Za-z0-9]", "", tok) for tok in _INDEX_TOKEN.findall(text)]
+
+
+def _term_indices(term: str) -> tuple[list[str], list[str]]:
+    uppers: list[str] = []
+    lowers: list[str] = []
+    for match in _UPPER_BRACED.finditer(term):
+        uppers += _index_tokens(match.group(1))
+    for match in _LOWER_BRACED.finditer(term):
+        lowers += _index_tokens(match.group(1))
+    stripped = re.sub(r"[\^_]\{[^}]*\}", " ", term)
+    for match in _UPPER_SINGLE.finditer(stripped):
+        uppers += _index_tokens(match.group(1))
+    for match in _LOWER_SINGLE.finditer(stripped):
+        lowers += _index_tokens(match.group(1))
+    return [u for u in uppers if u], [low for low in lowers if low]
+
+
+def _analyze_term(term: str) -> tuple[dict[str, str] | None, str | None]:
+    """Return (free-index map name->position, error) for one term."""
+    uppers, lowers = _term_indices(term)
+    names = set(uppers) | set(lowers)
+    free: dict[str, str] = {}
+    for name in names:
+        up, down = uppers.count(name), lowers.count(name)
+        total = up + down
+        if total == 1:
+            free[name] = "upper" if up else "lower"
+        elif total == 2 and up == 1 and down == 1:
+            continue  # valid contraction
+        else:
+            position = "upper" if up >= 2 else "lower" if down >= 2 else "mixed"
+            if total > 2:
+                return None, f"index '{name}' appears {total} times (max 2 for a valid contraction)"
+            return None, f"index '{name}' is repeated in the same ({position}) position — cannot contract"
+    return free, None
+
+
+def _split_terms(side: str) -> list[str]:
+    return [t.strip() for t in re.split(r"[+\-]", side) if t.strip()]
+
+
+def check_tensor_indices(equation: str) -> dict:
+    """Check free/dummy index consistency of a tensor equation.
+
+    Each side is a sum of terms with indices written ``^{...}`` (upper) /
+    ``_{...}`` (lower), space- or backslash-separated. Verifies that every term
+    in a side carries the same free indices (in the same up/down position), that
+    the two sides match, and that repeated indices are valid one-up/one-down
+    contractions. Returns pass/fail; unparseable input → inconclusive.
+    """
+    if "=" not in equation:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "equation must contain '=' to compare index structure"}
+    left, right = equation.split("=", 1)
+    left_terms, right_terms = _split_terms(left), _split_terms(right)
+    if not left_terms or not right_terms:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not parse terms on both sides"}
+
+    issues: list[str] = []
+
+    def _side_free(terms: list[str], label: str) -> dict[str, str] | None:
+        side_free: dict[str, str] | None = None
+        for term in terms:
+            free, error = _analyze_term(term)
+            if error is not None:
+                issues.append(f"{label} term '{term}': {error}")
+                continue
+            if side_free is None:
+                side_free = free
+            elif free != side_free:
+                issues.append(f"{label} term '{term}' has free indices {free}, expected {side_free}")
+        return side_free
+
+    left_free = _side_free(left_terms, "LHS")
+    right_free = _side_free(right_terms, "RHS")
+
+    if left_free is not None and right_free is not None and left_free != right_free:
+        issues.append(f"LHS free indices {left_free} differ from RHS {right_free}")
+
+    free_repr = sorted(f"{name}({pos})" for name, pos in (left_free or {}).items())
+    if issues:
+        return {"verdict": VERDICT_FAIL, "free_indices": free_repr, "issues": issues, "detail": "index structure is inconsistent"}
+    return {
+        "verdict": VERDICT_PASS,
+        "free_indices": free_repr,
+        "issues": [],
+        "detail": "index structure is consistent across all terms and both sides",
+    }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -77,6 +77,20 @@ _LATEX_COMMAND = re.compile(r"\\[A-Za-z]+")
 # Arrow macros normalized to '->' when parsing a limit description.
 _LATEX_ARROW = re.compile(r"\\(?:to|rightarrow|longrightarrow|mapsto)\b")
 
+# ── delatexify fallback (for LaTeX the lark grammar rejects, e.g. a^2 b^2) ──
+# Differential-operator notation cannot be faithfully turned into algebra, so we
+# refuse it outright rather than risk a wrong verdict.
+_DELATEX_DERIVATIVE = re.compile(r"\\partial|\\nabla|\\frac\s*\{\s*d\b")
+# Literal macro → plain-token rewrites applied before structural conversion.
+_DELATEX_REPLACERS = (
+    (r"\cdot", "*"),
+    (r"\times", "*"),
+    (r"\div", "/"),
+    (r"\ln", "log"),
+    (r"\lg", "log"),
+    (r"\infty", "oo"),
+)
+
 
 def _sympy():  # pragma: no cover - thin lazy import
     import sympy
@@ -92,8 +106,11 @@ def _looks_like_latex(text: str) -> bool:
 def _parse_latex(text: str):
     """Parse a LaTeX physics expression into a SymPy object, or ``None``.
 
-    Uses the grammar-based lark backend (no code execution), rewriting the
-    common lark-unsupported macros to placeholders and substituting them back.
+    Primary path is SymPy's grammar-based lark backend. When lark rejects the
+    input (e.g. juxtaposed superscript products ``a^2 b^2``), a conservative
+    delatexify fallback converts the LaTeX to a plain infix string and parses it
+    with implicit multiplication. Differential-operator notation is refused so
+    the fallback can never fabricate algebra from a derivative.
     """
     cleaned = text.strip().strip("$").replace("&", " ")
     if _LATEX_DANGEROUS.search(cleaned):
@@ -104,6 +121,14 @@ def _parse_latex(text: str):
         cleaned = cleaned.split("=")[-1].strip()
     if not cleaned:
         return None
+    result = _latex_via_lark(cleaned)
+    if result is not None:
+        return result
+    return _latex_via_delatexify(cleaned)
+
+
+def _latex_via_lark(cleaned: str):
+    """Parse cleaned LaTeX with the lark backend (+ macro fixups), or ``None``."""
     try:
         sympy = _sympy()
         from sympy.parsing.latex import parse_latex
@@ -134,6 +159,141 @@ def _parse_latex(text: str):
         return parsed
     ok2, substituted = run_with_timeout(lambda: parsed.subs(substitutions))
     return substituted if ok2 else None
+
+
+def _latex_via_delatexify(cleaned: str):
+    """Fallback: convert LaTeX to a plain infix string and parse it."""
+    plain = _delatexify(cleaned)
+    if plain is None:
+        return None
+    return _parse_plain(plain, implicit=True)
+
+
+def _match_brace(s: str, start: int) -> int:
+    """Return the index of the ``}`` matching the ``{`` at ``start``, or -1."""
+    depth = 0
+    for idx in range(start, len(s)):
+        ch = s[idx]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return idx
+    return -1
+
+
+def _latex_frac(s: str) -> str | None:
+    """Rewrite ``\\frac{A}{B}`` → ``((A)/(B))`` (brace-matched, nesting-safe)."""
+    for _ in range(200):
+        i = s.find(r"\frac")
+        if i == -1:
+            return s
+        j = i + len(r"\frac")
+        while j < len(s) and s[j] == " ":
+            j += 1
+        if j >= len(s) or s[j] != "{":
+            return None
+        a_end = _match_brace(s, j)
+        if a_end == -1:
+            return None
+        k = a_end + 1
+        while k < len(s) and s[k] == " ":
+            k += 1
+        if k >= len(s) or s[k] != "{":
+            return None
+        b_end = _match_brace(s, k)
+        if b_end == -1:
+            return None
+        s = s[:i] + "((" + s[j + 1 : a_end] + ")/(" + s[k + 1 : b_end] + "))" + s[b_end + 1 :]
+    return None
+
+
+def _latex_sqrt(s: str) -> str | None:
+    """Rewrite ``\\sqrt{A}`` → ``sqrt((A))`` and ``\\sqrt[n]{A}`` → ``((A)**(1/(n)))``."""
+    for _ in range(200):
+        i = s.find(r"\sqrt")
+        if i == -1:
+            return s
+        j = i + len(r"\sqrt")
+        while j < len(s) and s[j] == " ":
+            j += 1
+        root = None
+        if j < len(s) and s[j] == "[":
+            close = s.find("]", j)
+            if close == -1:
+                return None
+            root = s[j + 1 : close]
+            j = close + 1
+            while j < len(s) and s[j] == " ":
+                j += 1
+        if j >= len(s) or s[j] != "{":
+            return None
+        end = _match_brace(s, j)
+        if end == -1:
+            return None
+        inner = s[j + 1 : end]
+        rep = f"(({inner})**(1/({root})))" if root else f"sqrt(({inner}))"
+        s = s[:i] + rep + s[end + 1 :]
+    return None
+
+
+def _latex_braced(s: str, op: str, prefix: str, suffix: str) -> str | None:
+    """Rewrite ``op{...}`` (e.g. ``^{...}``) → ``prefix...suffix`` (brace-matched)."""
+    pattern = re.compile(re.escape(op) + r"\{")
+    for _ in range(200):
+        match = pattern.search(s)
+        if not match:
+            return s
+        brace = match.end() - 1
+        end = _match_brace(s, brace)
+        if end == -1:
+            return None
+        s = s[: match.start()] + prefix + s[brace + 1 : end] + suffix + s[end + 1 :]
+    return None
+
+
+def _latex_subscript(s: str) -> str | None:
+    """Rewrite ``a_{bc}`` → ``a_bc`` (subscripts folded into the symbol name)."""
+    pattern = re.compile(r"_\{")
+    for _ in range(200):
+        match = pattern.search(s)
+        if not match:
+            return s
+        brace = match.end() - 1
+        end = _match_brace(s, brace)
+        if end == -1:
+            return None
+        inner = re.sub(r"[^A-Za-z0-9]", "", s[brace + 1 : end])
+        s = s[: match.start()] + (f"_{inner}" if inner else "") + s[end + 1 :]
+    return None
+
+
+def _delatexify(s: str) -> str | None:
+    """Convert a LaTeX math string to a plain infix expression, or ``None``.
+
+    Conservative: refuses differential operators and returns None on any
+    unhandled construct (leftover braces/backslashes), so the caller stays
+    inconclusive rather than guessing.
+    """
+    if _DELATEX_DERIVATIVE.search(s):
+        return None
+    for src, dst in _DELATEX_REPLACERS:
+        s = s.replace(src, dst)
+    for step in (
+        _latex_frac,
+        _latex_sqrt,
+        lambda t: _latex_braced(t, "^", "**(", ")"),
+        _latex_subscript,
+    ):
+        s = step(s)
+        if s is None:
+            return None
+    s = s.replace("{", "(").replace("}", ")").replace("^", "**")
+    s = re.sub(r"\\([A-Za-z]+)", r"\1", s)  # strip remaining macro backslashes
+    if "\\" in s or "{" in s or "}" in s:
+        return None
+    return s
 
 
 def run_with_timeout(fn: Callable[[], object], timeout_s: float = _DEFAULT_TIMEOUT_S) -> tuple[bool, object]:
@@ -178,17 +338,34 @@ def safe_parse(text: str):
         return None
     if _looks_like_latex(raw):
         return _parse_latex(raw)
-    if _UNSAFE.search(raw):
+    return _parse_plain(raw)
+
+
+def _parse_plain(text: str, implicit: bool = False):
+    """Parse a plain (non-LaTeX) expression string into a SymPy object, or None.
+
+    ``implicit`` enables implicit multiplication/application (``2m`` → ``2*m``,
+    ``sin x`` → ``sin(x)``); used by the delatexify fallback.
+    """
+    if _UNSAFE.search(text):
         return None
-    if "=" in raw:
-        raw = raw.split("=")[-1].strip()
-        if not raw:
+    expr_text = text
+    if "=" in expr_text:
+        expr_text = expr_text.split("=")[-1].strip()
+        if not expr_text:
             return None
-    normalized = _INF.sub("oo", raw).replace("^", "**")
+    normalized = _INF.sub("oo", expr_text).replace("^", "**")
     try:
         sympy = _sympy()
-        from sympy.parsing.sympy_parser import parse_expr, standard_transformations
+        from sympy.parsing.sympy_parser import (
+            implicit_multiplication_application,
+            parse_expr,
+            standard_transformations,
+        )
 
+        transformations = standard_transformations
+        if implicit:
+            transformations = transformations + (implicit_multiplication_application,)
         local = {
             name: sympy.Symbol(name)
             for name in set(_IDENT.findall(normalized))
@@ -198,7 +375,7 @@ def safe_parse(text: str):
             lambda: parse_expr(
                 normalized,
                 local_dict=local,
-                transformations=standard_transformations,
+                transformations=transformations,
                 evaluate=True,
             )
         )

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -812,3 +812,114 @@ def check_conservation(
             f"{rel_drift if basis == 'relative' else abs_drift:.3g} > {tolerance:.3g})"
         ),
     }
+
+
+# ─── Symbolic identity (equation) checking ─────────────────────────────────────
+
+# Single-symbol assumptions that meaningfully change algebraic equality
+# (e.g. sqrt(x**2) == x only when x is positive).
+_ASSUMPTION_KEYS = frozenset(
+    {"positive", "negative", "nonnegative", "nonzero", "real", "integer", "rational", "complex"}
+)
+
+
+def check_equation(lhs: str, rhs: str, assumptions: dict | None = None, timeout_s: float = _DEFAULT_TIMEOUT_S) -> dict:
+    """Verify whether ``lhs == rhs`` symbolically (plain or LaTeX).
+
+    Optional ``assumptions`` maps a symbol to one of positive/negative/real/
+    integer/... so identities valid only under an assumption (e.g.
+    ``sqrt(x**2) == x`` for ``x`` positive) can be confirmed. Returns
+    pass/fail/inconclusive; undecidable comparisons are inconclusive, never pass.
+    """
+    left = safe_parse(lhs)
+    right = safe_parse(rhs)
+    if left is None or right is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "one or both sides are not machine-parseable"}
+    if assumptions:
+        sympy = _sympy()
+        replacements = {}
+        for name, kind in assumptions.items():
+            key = str(kind).strip().lower()
+            if key in _ASSUMPTION_KEYS:
+                replacements[sympy.Symbol(name)] = sympy.Symbol(name, **{key: True})
+        if replacements:
+            ok_l, left = run_with_timeout(lambda value=left: value.subs(replacements), timeout_s)
+            ok_r, right = run_with_timeout(lambda value=right: value.subs(replacements), timeout_s)
+            if not (ok_l and ok_r):
+                return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not apply assumptions"}
+
+    equal = symbolic_equal(left, right, timeout_s)
+    if equal is True:
+        return {"verdict": VERDICT_PASS, "detail": "left and right sides are equal"}
+    result = {
+        "verdict": VERDICT_FAIL if equal is False else VERDICT_INCONCLUSIVE,
+        "detail": (
+            "left and right sides are NOT equal"
+            if equal is False
+            else "equality is undecidable — review the simplified difference"
+        ),
+    }
+    ok, difference = run_with_timeout(lambda: _sympy().simplify(left - right), timeout_s)
+    if ok:
+        result["difference"] = str(difference)
+    return result
+
+
+# ─── Series / asymptotic expansion checking ────────────────────────────────────
+
+
+def check_series(
+    expression: str,
+    variable: str,
+    point: str = "0",
+    order: int = 6,
+    expected: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Compute the series of ``expression`` in ``variable`` about ``point``.
+
+    Returns the truncated expansion (through ``order``). When ``expected`` is
+    given, compares the computed series to it → pass/fail; otherwise the verdict
+    is ``computed``. Unparseable input or a series SymPy cannot evaluate →
+    inconclusive, never a false pass.
+    """
+    expr = safe_parse(expression)
+    if expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "expression is not machine-parseable"}
+    point_expr = safe_parse(point)
+    if point_expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"expansion point '{point}' is not machine-parseable"}
+    sympy = _sympy()
+    var = sympy.Symbol(variable)
+    ok, series = run_with_timeout(lambda: expr.series(var, point_expr, order).removeO(), timeout_s)
+    if not ok or series is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"SymPy could not compute the series ({series})"}
+
+    result: dict = {
+        "variable": variable,
+        "point": str(point_expr),
+        "order": order,
+        "computed_series": str(series),
+    }
+    if expected is None:
+        result["verdict"] = VERDICT_COMPUTED
+        result["detail"] = "computed the series expansion"
+        return result
+    expected_expr = safe_parse(expected)
+    if expected_expr is None:
+        result["verdict"] = VERDICT_COMPUTED
+        result["expected_parsed"] = False
+        result["detail"] = "computed series; expected expansion is prose — compare computed_series manually"
+        return result
+    result["expected_parsed"] = True
+    equal = symbolic_equal(series, expected_expr, timeout_s)
+    if equal is True:
+        result["verdict"] = VERDICT_PASS
+        result["detail"] = "computed series matches the expected expansion"
+    elif equal is False:
+        result["verdict"] = VERDICT_FAIL
+        result["detail"] = "computed series does NOT match the expected expansion"
+    else:
+        result["verdict"] = VERDICT_COMPUTED
+        result["detail"] = "equality undecidable — review computed_series vs expected"
+    return result

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -1149,3 +1149,156 @@ def check_tensor_indices(equation: str) -> dict:
         "issues": [],
         "detail": "index structure is consistent across all terms and both sides",
     }
+
+
+# ─── Integral checking ─────────────────────────────────────────────────────────
+
+
+def check_integral(
+    integrand: str,
+    variable: str,
+    claimed: str | None = None,
+    lower: str | None = None,
+    upper: str | None = None,
+    timeout_s: float = _DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Verify a claimed integral of ``integrand`` w.r.t. ``variable``.
+
+    Indefinite (no bounds): the claimed antiderivative is verified by
+    differentiation — ``d(claimed)/dx == integrand`` — which is always decidable
+    and so the robust direction. Definite (``lower`` & ``upper`` given): computes
+    ``integrate(integrand, (x, lower, upper))`` and compares to ``claimed``.
+    Unparseable input or an integral SymPy cannot evaluate → inconclusive.
+    """
+    integrand_expr = safe_parse(integrand)
+    if integrand_expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "integrand is not machine-parseable"}
+    sympy = _sympy()
+    var = sympy.Symbol(variable)
+    definite = lower is not None and upper is not None
+
+    if definite:
+        a = safe_parse(lower)
+        b = safe_parse(upper)
+        if a is None or b is None:
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "integration bounds are not machine-parseable"}
+        ok, value = run_with_timeout(lambda: sympy.integrate(integrand_expr, (var, a, b)), timeout_s)
+        if not ok or value is None or value.has(sympy.Integral):
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "SymPy could not evaluate the definite integral"}
+        result: dict = {"computed_value": str(value)}
+        if claimed is None:
+            result["verdict"] = VERDICT_COMPUTED
+            result["detail"] = "computed the definite integral"
+            return result
+        claimed_expr = safe_parse(claimed)
+        if claimed_expr is None:
+            result["verdict"] = VERDICT_COMPUTED
+            result["expected_parsed"] = False
+            result["detail"] = "computed the definite integral; claimed value is prose — compare manually"
+            return result
+        equal = symbolic_equal(value, claimed_expr, timeout_s)
+        result["verdict"] = VERDICT_PASS if equal is True else VERDICT_FAIL if equal is False else VERDICT_COMPUTED
+        result["detail"] = (
+            "computed definite integral matches the claimed value"
+            if equal is True
+            else "computed definite integral does NOT match the claimed value"
+            if equal is False
+            else "equality undecidable — review computed_value vs claimed"
+        )
+        return result
+
+    # Indefinite.
+    if claimed is not None:
+        antiderivative = safe_parse(claimed)
+        if antiderivative is None:
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "claimed antiderivative is not machine-parseable"}
+        ok, derivative = run_with_timeout(lambda: sympy.diff(antiderivative, var), timeout_s)
+        if not ok:
+            return {"verdict": VERDICT_INCONCLUSIVE, "detail": "could not differentiate the claimed antiderivative"}
+        equal = symbolic_equal(derivative, integrand_expr, timeout_s)
+        return {
+            "verdict": VERDICT_PASS if equal is True else VERDICT_FAIL if equal is False else VERDICT_INCONCLUSIVE,
+            "derivative_of_claimed": str(derivative),
+            "detail": (
+                f"d(claimed)/d{variable} equals the integrand — antiderivative is correct"
+                if equal is True
+                else f"d(claimed)/d{variable} does NOT equal the integrand"
+                if equal is False
+                else f"could not decide whether d(claimed)/d{variable} equals the integrand"
+            ),
+        }
+    ok, antiderivative = run_with_timeout(lambda: sympy.integrate(integrand_expr, var), timeout_s)
+    if not ok or antiderivative is None or antiderivative.has(sympy.Integral):
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "SymPy could not evaluate the indefinite integral"}
+    return {"verdict": VERDICT_COMPUTED, "antiderivative": str(antiderivative), "detail": "computed the antiderivative"}
+
+
+# ─── Commutator / operator-algebra checking ────────────────────────────────────
+
+_DERIV_SYMBOL = re.compile(r"^f_(x+)$")
+
+
+def _operator_action(text: str, func, var):
+    """Parse an operator's action on a test function f into a SymPy expression.
+
+    Uses ``f`` for the function and ``f_x``, ``f_xx`` … for its derivatives.
+    Returns an expression in ``f(var)`` and its derivatives, or None.
+    """
+    parsed = _parse_plain(text)
+    if parsed is None:
+        return None
+    sympy = _sympy()
+    applied = func(var)
+    replacements = {}
+    for symbol in parsed.free_symbols:
+        name = str(symbol)
+        if name == "f":
+            replacements[symbol] = applied
+        else:
+            match = _DERIV_SYMBOL.match(name)
+            if match:
+                replacements[symbol] = sympy.Derivative(applied, var, len(match.group(1)))
+    return parsed.subs(replacements)
+
+
+def check_commutator(
+    operators: dict, a: str, b: str, expected: str, variable: str = "x", timeout_s: float = _DEFAULT_TIMEOUT_S
+) -> dict:
+    """Verify a commutator ``[A, B] = expected`` by acting on a test function.
+
+    ``operators`` maps a name to its action on ``f`` (e.g. {"X": "x*f",
+    "P": "-I*hbar*f_x"}); ``expected`` is the claimed result's action (e.g.
+    "I*hbar*f" for ``[X, P] = i hbar``). Computes ``A(B f) - B(A f)`` symbolically
+    and compares. Unparseable operators or an undecidable result → inconclusive.
+    """
+    if a not in operators or b not in operators:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"operators must include both '{a}' and '{b}'"}
+    sympy = _sympy()
+    var = sympy.Symbol(variable)
+    func = sympy.Function("f")
+    action_a = _operator_action(operators[a], func, var)
+    action_b = _operator_action(operators[b], func, var)
+    expected_expr = _operator_action(expected, func, var)
+    if action_a is None or action_b is None or expected_expr is None:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": "operator action or expected result is not machine-parseable"}
+
+    def _commutator():
+        apply_a_to_b = action_a.subs(func, sympy.Lambda(var, action_b)).doit()
+        apply_b_to_a = action_b.subs(func, sympy.Lambda(var, action_a)).doit()
+        return sympy.simplify(apply_a_to_b - apply_b_to_a)
+
+    ok, commutator = run_with_timeout(_commutator, timeout_s)
+    if not ok:
+        return {"verdict": VERDICT_INCONCLUSIVE, "detail": f"could not evaluate the commutator ({commutator})"}
+    equal = symbolic_equal(commutator, expected_expr, timeout_s)
+    return {
+        "verdict": VERDICT_PASS if equal is True else VERDICT_FAIL if equal is False else VERDICT_INCONCLUSIVE,
+        "commutator_action": str(commutator),
+        "detail": (
+            f"[{a}, {b}] matches the expected result"
+            if equal is True
+            else f"[{a}, {b}] does NOT match the expected result"
+            if equal is False
+            else f"could not decide whether [{a}, {b}] matches the expected result"
+        ),
+    }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -731,3 +731,84 @@ def check_dimensions(expression: str, symbol_dims: dict) -> dict:
             "both sides share the same dimensions" if consistent else "left and right sides have different dimensions"
         ),
     }
+
+
+# ─── Conservation-law drift along a trajectory ─────────────────────────────────
+
+
+def check_conservation(
+    quantity: str, trajectory: list[dict], tolerance: float = 1e-6, timeout_s: float = _DEFAULT_TIMEOUT_S
+) -> dict:
+    """Evaluate a conserved quantity at each state and measure its drift.
+
+    ``quantity`` is an expression (plain or LaTeX) in the state variables;
+    ``trajectory`` is a list of states, each a mapping name → number. Returns a
+    pass/fail verdict on the relative drift versus ``tolerance`` (absolute drift
+    when the quantity is ~0 throughout). Unparseable quantities, missing
+    variables, or non-real values → inconclusive, never a false pass.
+    """
+    if len(trajectory) < 2:
+        return {
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "need at least 2 states to measure drift",
+        }
+    expr = safe_parse(quantity)
+    if expr is None:
+        return {
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "quantity expression is not machine-parseable",
+        }
+    sympy = _sympy()
+    free = {str(s) for s in expr.free_symbols}
+    for index, state in enumerate(trajectory):
+        missing = free - set(state.keys())
+        if missing:
+            return {
+                "verdict": VERDICT_INCONCLUSIVE,
+                "detail": f"state {index} is missing variables: {sorted(missing)}",
+            }
+
+    def _evaluate() -> list[float]:
+        values: list[float] = []
+        for state in trajectory:
+            substitutions = {sympy.Symbol(name): state[name] for name in free}
+            values.append(float(expr.subs(substitutions).evalf()))
+        return values
+
+    ok, values = run_with_timeout(_evaluate, timeout_s)
+    if not ok:
+        return {
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": f"could not evaluate the quantity numerically ({values})",
+        }
+
+    q_min, q_max = min(values), max(values)
+    abs_drift = q_max - q_min
+    scale = max(abs(v) for v in values)
+    if scale > 1e-300:
+        rel_drift = abs_drift / scale
+        conserved = rel_drift <= tolerance
+        basis = "relative"
+    else:
+        rel_drift = 0.0
+        conserved = abs_drift <= tolerance
+        basis = "absolute"
+    return {
+        "verdict": VERDICT_PASS if conserved else VERDICT_FAIL,
+        "conserved": conserved,
+        "n_steps": len(values),
+        "q_initial": values[0],
+        "q_final": values[-1],
+        "q_min": q_min,
+        "q_max": q_max,
+        "max_abs_drift": abs_drift,
+        "max_relative_drift": rel_drift,
+        "tolerance": tolerance,
+        "drift_basis": basis,
+        "detail": (
+            f"quantity is conserved within tolerance ({basis} drift {rel_drift if basis == 'relative' else abs_drift:.3g})"
+            if conserved
+            else f"quantity drifts beyond tolerance ({basis} drift "
+            f"{rel_drift if basis == 'relative' else abs_drift:.3g} > {tolerance:.3g})"
+        ),
+    }

--- a/src/gpd/mcp/servers/_cas.py
+++ b/src/gpd/mcp/servers/_cas.py
@@ -1,0 +1,337 @@
+"""Computer-algebra helpers backing executable verification checks.
+
+These helpers turn the verification server's limiting-case and symmetry tools
+from structural ``"documented"`` markers into actually-computed verdicts using
+SymPy. They are deliberately conservative: any parse failure, timeout, or
+genuine ambiguity downgrades to an ``INCONCLUSIVE`` verdict and never to a
+``PASS``, so the oracle can never manufacture a false confirmation.
+
+SymPy is imported lazily so importing the verification server stays cheap and
+degrades gracefully (``inconclusive``) in environments where the CAS backend is
+not yet installed, rather than hard-failing the whole server import.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+from collections.abc import Callable
+
+# ─── Verdict vocabulary (shared with the verification server result schema) ────
+
+VERDICT_PASS = "pass"  # computed result matches the expected result
+VERDICT_FAIL = "fail"  # computed result provably differs from expected
+VERDICT_COMPUTED = "computed"  # computed a real result; no machine-checkable expectation
+VERDICT_INCONCLUSIVE = "inconclusive"  # could not parse / evaluate / decide — never a pass
+
+_MAX_EXPR_LEN = 2000
+_DEFAULT_TIMEOUT_S = 4.0
+
+# Identifiers kept as SymPy callables/constants instead of being rebound to
+# plain Symbols, so exp()/sin()/sqrt()/oo still work. Every other identifier
+# (gamma, E, I, c, m, T, g, ...) is forced to a plain Symbol so physics notation
+# is not silently reinterpreted as a SymPy special function or constant.
+_FUNCTION_WHITELIST = frozenset(
+    {
+        "sin", "cos", "tan", "cot", "sec", "csc",
+        "asin", "acos", "atan", "atan2",
+        "sinh", "cosh", "tanh", "asinh", "acosh", "atanh",
+        "exp", "log", "ln", "sqrt", "Abs", "re", "im",
+        "oo", "pi",
+    }
+)
+
+# Reject obviously unsafe tokens before handing a string to the parser.
+_UNSAFE = re.compile(
+    r"(__|\bimport\b|\blambda\b|\bexec\b|\beval\b|\bopen\b|"
+    r"\bos\b|\bsys\b|\bsubprocess\b|\bgetattr\b|\bglobals\b|;|`|:=)"
+)
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_INF = re.compile(r"\b(?:infinity|infty|inf)\b", re.IGNORECASE)
+
+
+def _sympy():  # pragma: no cover - thin lazy import
+    import sympy
+
+    return sympy
+
+
+def run_with_timeout(fn: Callable[[], object], timeout_s: float = _DEFAULT_TIMEOUT_S) -> tuple[bool, object]:
+    """Run ``fn()`` in a daemon worker thread.
+
+    Returns ``(ok, value)`` on success or ``(False, reason)`` on timeout/error.
+    A timed-out thread cannot be killed, but as a daemon it never blocks the
+    response and is bounded by the caller's input-size cap.
+    """
+    box: dict[str, object] = {}
+
+    def worker() -> None:
+        try:
+            box["value"] = fn()
+            box["ok"] = True
+        except BaseException as exc:  # noqa: BLE001 - report, never propagate
+            box["ok"] = False
+            box["reason"] = type(exc).__name__
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+    thread.join(timeout_s)
+    if thread.is_alive():
+        return False, "timeout"
+    if box.get("ok"):
+        return True, box.get("value")
+    return False, box.get("reason", "error")
+
+
+def safe_parse(text: str):
+    """Parse a physics expression string into a SymPy object, or ``None``.
+
+    Conservative by design: rejects unsafe tokens, caps length, forces unknown
+    identifiers to plain Symbols, normalizes ``^``/``infinity`` notation, takes
+    the right-hand side of an equation (we reason about the formula), and
+    returns ``None`` on any failure.
+    """
+    if not isinstance(text, str):
+        return None
+    raw = text.strip()
+    if not raw or len(raw) > _MAX_EXPR_LEN:
+        return None
+    if _UNSAFE.search(raw):
+        return None
+    if "=" in raw:
+        raw = raw.split("=")[-1].strip()
+        if not raw:
+            return None
+    normalized = _INF.sub("oo", raw).replace("^", "**")
+    try:
+        sympy = _sympy()
+        from sympy.parsing.sympy_parser import parse_expr, standard_transformations
+
+        local = {
+            name: sympy.Symbol(name)
+            for name in set(_IDENT.findall(normalized))
+            if name not in _FUNCTION_WHITELIST
+        }
+        ok, value = run_with_timeout(
+            lambda: parse_expr(
+                normalized,
+                local_dict=local,
+                transformations=standard_transformations,
+                evaluate=True,
+            )
+        )
+        if not ok:
+            return None
+        return value
+    except Exception:  # noqa: BLE001 - any parse/import failure → unparseable
+        return None
+
+
+def symbolic_equal(a, b, timeout_s: float = _DEFAULT_TIMEOUT_S):
+    """Return ``True``/``False``/``None`` for whether two expressions are equal.
+
+    ``None`` means "could not decide" — callers must treat it as inconclusive,
+    never as equal.
+    """
+    try:
+        sympy = _sympy()
+    except Exception:  # noqa: BLE001
+        return None
+
+    def _check():
+        diff = sympy.simplify(a - b)
+        if diff == 0:
+            return True
+        verdict = a.equals(b)  # robust numeric+symbolic probe; may return None
+        if verdict is True:
+            return True
+        if verdict is False:
+            return False
+        if diff.is_number and diff != 0:
+            return False
+        return None
+
+    ok, value = run_with_timeout(_check, timeout_s)
+    return value if ok else None
+
+
+def parse_limit_target(description: str) -> tuple[str, str] | None:
+    """Parse a limit description into ``(variable, point_text)`` or ``None``.
+
+    Accepts ``"hbar -> 0"``, ``"c -> infinity"``, and descriptive prefixes such
+    as ``"classical limit: hbar -> 0"`` (uses the last ``X -> Y`` occurrence).
+    A composite ratio such as ``"v/c -> 0"`` is intentionally rejected because
+    it is not a single limit variable.
+    """
+    if not isinstance(description, str) or "->" not in description:
+        return None
+    matches = re.findall(r"([A-Za-z_][A-Za-z0-9_/]*)\s*->\s*([^,;]+)", description)
+    if not matches:
+        return None
+    var_raw, point_raw = matches[-1]
+    var = var_raw.strip()
+    if "/" in var or not var:
+        return None
+    return var, point_raw.strip()
+
+
+def check_limit(expression: str, limit_description: str, expected: str, timeout_s: float = _DEFAULT_TIMEOUT_S) -> dict:
+    """Compute ``lim_{var->point} expression`` and compare to ``expected``.
+
+    Returns an additive ``cas`` payload describing what was actually executed.
+    The verdict is one of pass/fail/computed/inconclusive.
+    """
+    target = parse_limit_target(limit_description)
+    if target is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "no machine-readable 'var -> point' in limit description",
+        }
+    var_name, point_text = target
+
+    expr = safe_parse(expression)
+    if expr is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "variable": var_name,
+            "point": point_text,
+            "detail": "expression is not machine-parseable",
+        }
+    point = safe_parse(point_text)
+    if point is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "variable": var_name,
+            "point": point_text,
+            "detail": f"limit point '{point_text}' is not machine-parseable",
+        }
+
+    sympy = _sympy()
+    var = sympy.Symbol(var_name)
+    ok, value = run_with_timeout(lambda: sympy.limit(expr, var, point), timeout_s)
+    if not ok:
+        return {
+            "attempted": True,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "variable": var_name,
+            "point": point_text,
+            "detail": f"SymPy could not evaluate the limit ({value})",
+        }
+
+    payload: dict[str, object] = {
+        "attempted": True,
+        "variable": var_name,
+        "point": point_text,
+        "computed_limit": str(value),
+    }
+    expected_expr = safe_parse(expected)
+    if expected_expr is None:
+        payload["verdict"] = VERDICT_COMPUTED
+        payload["expected_parsed"] = False
+        payload["detail"] = "computed the limit; expected result is prose — compare the computed_limit manually"
+        return payload
+
+    payload["expected_parsed"] = True
+    equal = symbolic_equal(value, expected_expr, timeout_s)
+    if equal is True:
+        payload["verdict"] = VERDICT_PASS
+        payload["detail"] = "computed limit matches the expected result"
+    elif equal is False:
+        payload["verdict"] = VERDICT_FAIL
+        payload["detail"] = "computed limit provably differs from the expected result"
+    else:
+        payload["verdict"] = VERDICT_COMPUTED
+        payload["detail"] = "equality is undecidable — review computed_limit vs expected"
+    return payload
+
+
+# Substitution-based symmetries we can execute: name fragment → (transform var, label).
+_PARITY_VARS = ("x", "r")
+_TIME_VARS = ("t",)
+
+
+def _pick_variable(free_names: list[str], preferred: tuple[str, ...]) -> str | None:
+    for name in preferred:
+        if name in free_names:
+            return name
+    if len(free_names) == 1:
+        return free_names[0]
+    return None
+
+
+def check_symmetry(expression: str, symmetry: str, timeout_s: float = _DEFAULT_TIMEOUT_S) -> dict:
+    """Execute a coordinate-reflection symmetry check where one is well-defined.
+
+    Handles parity (``x -> -x``) and time-reversal (``t -> -t``) by substitution
+    and classifies the expression as invariant (even) / odd / neither. Other
+    symmetries (gauge, Lorentz, ...) have no single-substitution test and return
+    inconclusive so the structural ``status`` field still drives those.
+    """
+    name = symmetry.lower().replace("_", " ").replace("-", " ")
+    expr = safe_parse(expression)
+    if expr is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "expression is not machine-parseable",
+        }
+
+    free_names = sorted(str(s) for s in expr.free_symbols)
+    if "parity" in name:
+        var_name = _pick_variable(free_names, _PARITY_VARS)
+    elif "time" in name and "revers" in name:
+        var_name = _pick_variable(free_names, _TIME_VARS)
+    else:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "no single-substitution transformation defined for this symmetry",
+        }
+
+    if var_name is None:
+        return {
+            "attempted": False,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "detail": "could not unambiguously identify the variable to transform",
+        }
+
+    sympy = _sympy()
+    var = sympy.Symbol(var_name)
+    ok, transformed = run_with_timeout(lambda: expr.subs(var, -var), timeout_s)
+    if not ok:
+        return {
+            "attempted": True,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "transformation": f"{var_name} -> -{var_name}",
+            "detail": f"substitution failed ({transformed})",
+        }
+
+    even = symbolic_equal(transformed, expr, timeout_s)
+    odd = symbolic_equal(transformed, -expr, timeout_s)
+    if even is True:
+        classification, invariant = "invariant (even)", True
+    elif odd is True:
+        classification, invariant = "odd", False
+    elif even is False and odd is False:
+        classification, invariant = "neither even nor odd", False
+    else:
+        return {
+            "attempted": True,
+            "verdict": VERDICT_INCONCLUSIVE,
+            "transformation": f"{var_name} -> -{var_name}",
+            "transformed_expression": str(transformed),
+            "detail": "could not classify behavior under the transformation",
+        }
+
+    return {
+        "attempted": True,
+        "verdict": VERDICT_COMPUTED,
+        "transformation": f"{var_name} -> -{var_name}",
+        "transformed_expression": str(transformed),
+        "classification": classification,
+        "invariant": invariant,
+        "detail": f"expression is {classification} under {var_name} -> -{var_name}",
+    }

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -5610,6 +5610,71 @@ def commutator_check(operators: dict[str, str], a: str, b: str, expected: str, v
         return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
 
 
+@mcp.tool(annotations=read_only_tool_annotations())
+def pde_check(equation: str, solution: str, variables: list[str], function: str = "u") -> dict:
+    """Verify a candidate solution satisfies a partial differential equation.
+
+    Partial derivatives of ``function`` use subscript notation — each letter
+    after ``_`` is one differentiation w.r.t. that variable: ``u_t``, ``u_xx``,
+    ``u_xt`` (mixed). The equation may be a residual or "LHS = RHS". Substitutes
+    the solution and its partials and simplifies the residual: zero → pass,
+    nonzero → fail.
+
+    Args:
+        equation: e.g. the heat equation "u_t = alpha * u_xx".
+        solution: e.g. "exp(-alpha*k**2*t) * sin(k*x)" (plain or LaTeX).
+        variables: the independent variables, e.g. ["t", "x"].
+        function: the dependent function name (default "u").
+    """
+    with gpd_span("mcp.verification.pde_check"):
+        validated_equation, error = _validate_string(equation, field_name="equation")
+        if error is not None:
+            return error
+        validated_solution, error = _validate_string(solution, field_name="solution")
+        if error is not None:
+            return error
+        validated_variables, error = _validate_string_list(variables, field_name="variables")
+        if error is not None:
+            return error
+        validated_function, error = _validate_string(function, field_name="function")
+        if error is not None:
+            return error
+        result = _cas.check_pde(
+            validated_equation, validated_solution, validated_variables, validated_function
+        )
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
+@mcp.tool(annotations=read_only_tool_annotations())
+def matrix_check(matrix: list[list[str]], property: str) -> dict:
+    """Verify a structural property of a matrix.
+
+    ``property`` is one of: symmetric, antisymmetric, hermitian, anti-hermitian,
+    unitary, orthogonal, idempotent (projection), involutory, normal. Entries are
+    expression strings; ``I`` denotes the imaginary unit (e.g. the Pauli matrix
+    ``Y = [["0", "-I"], ["I", "0"]]``). Returns pass/fail; unparseable entries or
+    an undecidable comparison → inconclusive.
+
+    Args:
+        matrix: rows of entry strings, e.g. [["0", "1"], ["1", "0"]] (Pauli X).
+        property: the property to verify.
+    """
+    with gpd_span("mcp.verification.matrix_check"):
+        if not isinstance(matrix, list) or not matrix:
+            return _error_result("matrix must be a non-empty list of rows")
+        for index, row in enumerate(matrix):
+            if not isinstance(row, list) or not row:
+                return _error_result(f"matrix[{index}] must be a non-empty list of entry strings")
+            for col, cell in enumerate(row):
+                if not isinstance(cell, str):
+                    return _error_result(f"matrix[{index}][{col}] must be a string")
+        validated_property, error = _validate_string(property, field_name="property")
+        if error is not None:
+            return error
+        result = _cas.check_matrix(matrix, validated_property)
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -2137,6 +2137,42 @@ def _dims_equal(a: dict[str, int], b: dict[str, int]) -> bool:
     return all(a.get(k, 0) == b.get(k, 0) for k in all_keys)
 
 
+# Named physical quantities → base-dimension exponents over {M, L, T, Q, Theta}.
+# Used to give real symbols dimensions for symbolic dimensional analysis.
+_NAMED_DIMENSIONS: dict[str, dict[str, int]] = {
+    "dimensionless": {}, "scalar": {}, "1": {},
+    "mass": {"M": 1}, "length": {"L": 1}, "distance": {"L": 1}, "position": {"L": 1},
+    "time": {"T": 1}, "charge": {"Q": 1}, "temperature": {"Theta": 1},
+    "current": {"Q": 1, "T": -1},
+    "velocity": {"L": 1, "T": -1}, "speed": {"L": 1, "T": -1},
+    "acceleration": {"L": 1, "T": -2},
+    "momentum": {"M": 1, "L": 1, "T": -1},
+    "force": {"M": 1, "L": 1, "T": -2},
+    "energy": {"M": 1, "L": 2, "T": -2}, "work": {"M": 1, "L": 2, "T": -2},
+    "power": {"M": 1, "L": 2, "T": -3},
+    "pressure": {"M": 1, "L": -1, "T": -2},
+    "frequency": {"T": -1}, "angular_frequency": {"T": -1},
+    "area": {"L": 2}, "volume": {"L": 3}, "density": {"M": 1, "L": -3},
+    "action": {"M": 1, "L": 2, "T": -1},  # e.g. hbar
+    "voltage": {"M": 1, "L": 2, "T": -2, "Q": -1},
+}
+
+
+def _spec_to_dimvec(spec: str) -> dict[str, int] | None:
+    """Resolve a dimension spec to base-exponents, or None if unrecognized.
+
+    Accepts a named quantity ("energy", "velocity", ...) or a bracket form
+    ("[M][L]^2[T]^-2"). Returns {} for an explicitly dimensionless spec.
+    """
+    text = spec.strip()
+    named = _NAMED_DIMENSIONS.get(text.lower())
+    if named is not None:
+        return dict(named)
+    if "[" in text:
+        return {k: v for k, v in _parse_dimensions(text).items() if v != 0}
+    return None
+
+
 # ─── MCP Tools ────────────────────────────────────────────────────────────────
 
 
@@ -4906,22 +4942,43 @@ def get_bundle_checklist(bundle_ids: BundleIdListInput) -> dict:
 
 
 @mcp.tool(annotations=read_only_tool_annotations())
-def dimensional_check(expressions: list[str]) -> dict:
+def dimensional_check(expressions: list[str], dimensions: dict[str, str] | None = None) -> dict:
     """Verify dimensional consistency of physics expressions.
 
-    Each expression should be in the format "LHS = RHS" where dimensions
-    are annotated with [M], [L], [T], [Q], [Theta] notation.
+    Two modes:
 
-    Example: "[M][L]^2[T]^-2 = [M][L]^2[T]^-2" (energy = energy)
+    1. **Annotated** — each expression is "LHS = RHS" with dimensions written in
+       [M], [L], [T], [Q], [Theta] notation, e.g. "[M][L]^2[T]^-2 = [M][L]^2[T]^-2".
+    2. **Symbolic** — pass real expressions (e.g. "E = m c^2", LaTeX allowed) plus
+       a ``dimensions`` map of symbol → dimension. Each dimension is a named
+       quantity ("energy", "velocity", "mass", "force", ...) or a bracket form
+       ("[M][L]^2[T]^-2"). The tool then computes the dimensions of each side
+       with SymPy and returns a real pass/fail in the result's ``cas`` block,
+       also flagging sums whose terms have incompatible dimensions.
+
+    Symbols absent from ``dimensions`` or otherwise unresolvable yield an
+    ``inconclusive`` verdict — never a false pass.
     """
     with gpd_span("mcp.verification.dimensional_check"):
         validated_expressions, error = _validate_string_list(expressions, field_name="expressions")
         if error is not None:
             return error
-        return stable_mcp_response(_dimensional_check_inner(validated_expressions))
+        symbol_dims: dict[str, dict[str, int]] | None = None
+        if dimensions is not None:
+            validated_dims, error = _validate_string_mapping(dimensions, field_name="dimensions")
+            if error is not None:
+                return error
+            symbol_dims = {}
+            for symbol, spec in validated_dims.items():
+                dimvec = _spec_to_dimvec(spec)
+                if dimvec is not None:
+                    symbol_dims[symbol] = dimvec
+        return stable_mcp_response(_dimensional_check_inner(validated_expressions, symbol_dims))
 
 
-def _dimensional_check_inner(expressions: list[str]) -> dict:
+def _dimensional_check_inner(
+    expressions: list[str], symbol_dims: dict[str, dict[str, int]] | None = None
+) -> dict:
     results: list[dict[str, object]] = []
 
     for expr in expressions:
@@ -4951,7 +5008,17 @@ def _dimensional_check_inner(expressions: list[str]) -> dict:
             "lhs_dimensions": {k: v for k, v in lhs_dims.items() if v != 0},
             "rhs_dimensions": {k: v for k, v in rhs_dims.items() if v != 0},
         }
-        if no_annotations:
+        if no_annotations and symbol_dims is not None:
+            # Symbolic path: compute dimensions of real symbols via the CAS.
+            cas = _cas.check_dimensions(expr, symbol_dims)
+            result["cas"] = cas
+            if cas["verdict"] == _cas.VERDICT_PASS:
+                result["valid"] = True
+            if "lhs_dimensions" in cas:
+                result["lhs_dimensions"] = cas["lhs_dimensions"]
+                result["rhs_dimensions"] = cas["rhs_dimensions"]
+            result["note"] = cas["detail"]
+        elif no_annotations:
             result["note"] = "No dimension annotations found — cannot verify"
         elif not match:
             mismatches = {}
@@ -4964,10 +5031,13 @@ def _dimensional_check_inner(expressions: list[str]) -> dict:
         results.append(result)
 
     all_valid = bool(results) and all(r.get("valid", False) for r in results)
+    cas_verdicts = [r["cas"]["verdict"] for r in results if isinstance(r.get("cas"), dict)]
     return {
         "schema_version": VERIFICATION_SCHEMA_VERSION,
         "all_consistent": all_valid,
         "checked_count": len(results),
+        "cas_executed": sum(1 for r in results if r.get("cas", {}).get("attempted")),
+        "overall_cas_verdict": _aggregate_cas_verdict(cas_verdicts),
         "results": results,
     }
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -5387,6 +5387,81 @@ def conservation_check(
         return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
 
 
+@mcp.tool(annotations=read_only_tool_annotations())
+def equation_check(lhs: str, rhs: str, assumptions: dict[str, str] | None = None) -> dict:
+    """Verify whether two expressions are algebraically equal (the core of any
+    derivation step).
+
+    Computes ``simplify(lhs - rhs)`` / ``.equals()`` with SymPy and returns a
+    real pass/fail, so equality is checked by the CAS rather than by the agent's
+    mental algebra. Accepts plain or LaTeX expressions. Optional ``assumptions``
+    maps a symbol to positive/negative/real/integer/nonzero/... for identities
+    that hold only under an assumption (e.g. ``sqrt(x**2) = x`` for x > 0).
+    Undecidable comparisons return inconclusive — never a false pass.
+
+    Args:
+        lhs: left-hand side, e.g. "sin(x)**2 + cos(x)**2" or LaTeX.
+        rhs: right-hand side, e.g. "1".
+        assumptions: optional symbol -> assumption (e.g. {"x": "positive"}).
+    """
+    with gpd_span("mcp.verification.equation_check"):
+        validated_lhs, error = _validate_string(lhs, field_name="lhs")
+        if error is not None:
+            return error
+        validated_rhs, error = _validate_string(rhs, field_name="rhs")
+        if error is not None:
+            return error
+        validated_assumptions = None
+        if assumptions is not None:
+            validated_assumptions, error = _validate_string_mapping(assumptions, field_name="assumptions")
+            if error is not None:
+                return error
+        result = _cas.check_equation(validated_lhs, validated_rhs, validated_assumptions)
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
+@mcp.tool(annotations=read_only_tool_annotations())
+def series_check(
+    expression: str, variable: str, point: str = "0", order: int = 6, expected: str | None = None
+) -> dict:
+    """Compute (and optionally verify) a Taylor / asymptotic series expansion.
+
+    Perturbation theory and asymptotic analysis are pervasive in physics and
+    error-prone by hand. This computes ``series(expression, variable, point,
+    order)`` with SymPy; if ``expected`` is supplied it returns a real pass/fail,
+    otherwise it returns the computed expansion. Accepts plain or LaTeX input.
+    Unparseable input or a series SymPy cannot evaluate → inconclusive.
+
+    Args:
+        expression: e.g. "sin(x)" or LaTeX r"\\frac{1}{1-x}".
+        variable: the expansion variable, e.g. "x".
+        point: expansion point ("0", "oo", or a symbol). Defaults to "0".
+        order: truncation order (1..15). Defaults to 6.
+        expected: optional claimed expansion to compare against.
+    """
+    with gpd_span("mcp.verification.series_check"):
+        validated_expression, error = _validate_string(expression, field_name="expression")
+        if error is not None:
+            return error
+        validated_variable, error = _validate_string(variable, field_name="variable")
+        if error is not None:
+            return error
+        validated_point, error = _validate_string(point, field_name="point")
+        if error is not None:
+            return error
+        if isinstance(order, bool) or not isinstance(order, int) or not (1 <= order <= 15):
+            return _error_result("order must be an integer between 1 and 15")
+        validated_expected = None
+        if expected is not None:
+            validated_expected, error = _validate_string(expected, field_name="expected")
+            if error is not None:
+                return error
+        result = _cas.check_series(
+            validated_expression, validated_variable, validated_point, order, validated_expected
+        )
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -5462,6 +5462,63 @@ def series_check(
         return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
 
 
+@mcp.tool(annotations=read_only_tool_annotations())
+def ode_check(equation: str, solution: str, variable: str = "x", function: str = "y") -> dict:
+    """Verify a candidate solution satisfies a differential equation.
+
+    Substitutes the solution and its derivatives into the ODE and simplifies the
+    residual with SymPy: zero → pass, provably nonzero → fail. Use prime notation
+    for derivatives of ``function`` (``y``, ``y'``, ``y''`` …); the equation may
+    be a residual or "LHS = RHS".
+
+    Args:
+        equation: e.g. "y'' + omega**2 * y = 0".
+        solution: e.g. "A*cos(omega*x) + B*sin(omega*x)" (plain or LaTeX).
+        variable: the independent variable (default "x").
+        function: the dependent function name used in the equation (default "y").
+    """
+    with gpd_span("mcp.verification.ode_check"):
+        validated_equation, error = _validate_string(equation, field_name="equation")
+        if error is not None:
+            return error
+        validated_solution, error = _validate_string(solution, field_name="solution")
+        if error is not None:
+            return error
+        validated_variable, error = _validate_string(variable, field_name="variable")
+        if error is not None:
+            return error
+        validated_function, error = _validate_string(function, field_name="function")
+        if error is not None:
+            return error
+        result = _cas.check_ode(
+            validated_equation, validated_solution, validated_variable, validated_function
+        )
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
+@mcp.tool(annotations=read_only_tool_annotations())
+def tensor_check(equation: str) -> dict:
+    """Check free/dummy index consistency of a tensor equation.
+
+    Indices are written ``^{...}`` (upper) / ``_{...}`` (lower), space- or
+    backslash-separated, e.g. "F^{mu nu} = \\partial^{mu} A^{nu} - \\partial^{nu} A^{mu}".
+    Verifies every term on a side carries the same free indices in the same
+    up/down position, that the two sides match, and that repeated indices are
+    valid one-up/one-down contractions. Returns pass/fail with the free-index
+    signature and a list of issues; this checks index bookkeeping, not the
+    tensor algebra itself.
+
+    Args:
+        equation: a tensor equation "LHS = RHS" with indexed terms.
+    """
+    with gpd_span("mcp.verification.tensor_check"):
+        validated_equation, error = _validate_string(equation, field_name="equation")
+        if error is not None:
+            return error
+        result = _cas.check_tensor_indices(validated_equation)
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -5347,6 +5347,46 @@ def _coverage_inner(error_class_ids: list[int], active_checks: list[str]) -> dic
     }
 
 
+@mcp.tool(annotations=read_only_tool_annotations())
+def conservation_check(
+    quantity: str, trajectory: list[dict[str, float]], tolerance: float = 1e-6
+) -> dict:
+    """Verify a conserved quantity stays constant along a trajectory.
+
+    Evaluates ``quantity`` (an expression in the state variables; plain or LaTeX)
+    at every state in ``trajectory`` and measures its drift. Returns a real
+    pass/fail verdict on the relative drift versus ``tolerance`` (absolute drift
+    when the quantity is ~0 throughout), with the min/max/initial/final values.
+
+    This catches the most common dynamics error class — energy/momentum/charge
+    that silently drifts — by actually computing it, rather than trusting that
+    the integrator conserved it.
+
+    Args:
+        quantity: e.g. "0.5*m*v**2 + 0.5*k*x**2" (SHO energy) or LaTeX.
+        trajectory: list of states, each a mapping of variable name -> number.
+        tolerance: maximum allowed relative drift (default 1e-6).
+    """
+    with gpd_span("mcp.verification.conservation_check"):
+        validated_quantity, error = _validate_string(quantity, field_name="quantity")
+        if error is not None:
+            return error
+        if not isinstance(trajectory, list) or not trajectory:
+            return _error_result("trajectory must be a non-empty list of state mappings")
+        for index, state in enumerate(trajectory):
+            if not isinstance(state, dict):
+                return _error_result(f"trajectory[{index}] must be a mapping of variable -> number")
+            for key, value in state.items():
+                if not isinstance(key, str):
+                    return _error_result(f"trajectory[{index}] keys must be strings")
+                if isinstance(value, bool) or not isinstance(value, (int, float)):
+                    return _error_result(f"trajectory[{index}][{key}] must be a number")
+        if isinstance(tolerance, bool) or not isinstance(tolerance, (int, float)) or tolerance < 0:
+            return _error_result("tolerance must be a non-negative number")
+        result = _cas.check_conservation(validated_quantity, trajectory, float(tolerance))
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -2140,19 +2140,31 @@ def _dims_equal(a: dict[str, int], b: dict[str, int]) -> bool:
 # Named physical quantities → base-dimension exponents over {M, L, T, Q, Theta}.
 # Used to give real symbols dimensions for symbolic dimensional analysis.
 _NAMED_DIMENSIONS: dict[str, dict[str, int]] = {
-    "dimensionless": {}, "scalar": {}, "1": {},
-    "mass": {"M": 1}, "length": {"L": 1}, "distance": {"L": 1}, "position": {"L": 1},
-    "time": {"T": 1}, "charge": {"Q": 1}, "temperature": {"Theta": 1},
+    "dimensionless": {},
+    "scalar": {},
+    "1": {},
+    "mass": {"M": 1},
+    "length": {"L": 1},
+    "distance": {"L": 1},
+    "position": {"L": 1},
+    "time": {"T": 1},
+    "charge": {"Q": 1},
+    "temperature": {"Theta": 1},
     "current": {"Q": 1, "T": -1},
-    "velocity": {"L": 1, "T": -1}, "speed": {"L": 1, "T": -1},
+    "velocity": {"L": 1, "T": -1},
+    "speed": {"L": 1, "T": -1},
     "acceleration": {"L": 1, "T": -2},
     "momentum": {"M": 1, "L": 1, "T": -1},
     "force": {"M": 1, "L": 1, "T": -2},
-    "energy": {"M": 1, "L": 2, "T": -2}, "work": {"M": 1, "L": 2, "T": -2},
+    "energy": {"M": 1, "L": 2, "T": -2},
+    "work": {"M": 1, "L": 2, "T": -2},
     "power": {"M": 1, "L": 2, "T": -3},
     "pressure": {"M": 1, "L": -1, "T": -2},
-    "frequency": {"T": -1}, "angular_frequency": {"T": -1},
-    "area": {"L": 2}, "volume": {"L": 3}, "density": {"M": 1, "L": -3},
+    "frequency": {"T": -1},
+    "angular_frequency": {"T": -1},
+    "area": {"L": 2},
+    "volume": {"L": 3},
+    "density": {"M": 1, "L": -3},
     "action": {"M": 1, "L": 2, "T": -1},  # e.g. hbar
     "voltage": {"M": 1, "L": 2, "T": -2, "Q": -1},
 }
@@ -4976,9 +4988,7 @@ def dimensional_check(expressions: list[str], dimensions: dict[str, str] | None 
         return stable_mcp_response(_dimensional_check_inner(validated_expressions, symbol_dims))
 
 
-def _dimensional_check_inner(
-    expressions: list[str], symbol_dims: dict[str, dict[str, int]] | None = None
-) -> dict:
+def _dimensional_check_inner(expressions: list[str], symbol_dims: dict[str, dict[str, int]] | None = None) -> dict:
     results: list[dict[str, object]] = []
 
     for expr in expressions:

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -67,6 +67,7 @@ from gpd.core.verification_checks import (
 )
 from gpd.mcp.servers import (
     ABSOLUTE_PROJECT_DIR_SCHEMA,
+    _cas,
     configure_mcp_logging,
     read_only_tool_annotations,
     resolve_absolute_project_dir,
@@ -4975,12 +4976,18 @@ def _dimensional_check_inner(expressions: list[str]) -> dict:
 def limiting_case_check(expression: str, limits: dict[str, str]) -> dict:
     """Verify that an expression reduces to known results in specified limits.
 
-    This is a structural check -- it validates that the limit analysis
-    has been documented. The actual mathematical verification should be
-    performed by a CAS (SymPy) via the code execution MCP server.
+    When a limit is written as ``var -> point`` (e.g. ``"hbar -> 0"``) and both
+    the expression and the expected result are machine-parseable, this tool
+    actually computes ``sympy.limit(expression, var, point)`` and returns a
+    real ``pass``/``fail``/``computed`` verdict in each result's ``cas`` block
+    (with the aggregate in ``overall_cas_verdict``). Parse failures, timeouts,
+    or prose limits (e.g. ``"non-relativistic limit"``) downgrade to
+    ``inconclusive`` and fall back to the structural ``status`` marker — the
+    oracle never reports ``pass`` for something it could not compute.
 
     Args:
-        expression: The general expression being checked
+        expression: The general expression being checked (``LHS = RHS`` allowed;
+                    the RHS formula is used).
         limits: Dict mapping limit descriptions to expected results.
                 E.g., {"hbar -> 0": "classical Hamilton-Jacobi",
                        "c -> infinity": "non-relativistic Schrodinger"}
@@ -5016,12 +5023,17 @@ def _limiting_case_inner(expression: str, limits: dict[str, str]) -> dict:
                 limit_type = stype
                 break
 
+        cas = _cas.check_limit(expression, limit_desc, expected_result)
         results.append(
             {
                 "limit": limit_desc,
                 "expected": expected_result,
                 "limit_type": limit_type,
+                # Structural marker (kept for backward compatibility): records that
+                # the limit analysis was supplied. The authoritative result is in
+                # the `cas` block below when the limit is machine-evaluable.
                 "status": "documented",
+                "cas": cas,
                 "guidance": (
                     f"Verify: apply limit '{limit_desc}' to the expression. "
                     f"Result should reduce to: {expected_result}. "
@@ -5043,21 +5055,40 @@ def _limiting_case_inner(expression: str, limits: dict[str, str]) -> dict:
         if not any("weak" in key.lower() or "g ->" in key.lower() for key in limits):
             suggestions.append("Consider checking weak-coupling limit (g -> 0)")
 
+    cas_verdicts = [r["cas"]["verdict"] for r in results if isinstance(r.get("cas"), dict)]
     return {
         "schema_version": VERIFICATION_SCHEMA_VERSION,
         "expression_length": len(expression),
         "limits_checked": len(results),
+        "cas_executed": sum(1 for r in results if r.get("cas", {}).get("attempted")),
+        "overall_cas_verdict": _aggregate_cas_verdict(cas_verdicts),
         "results": results,
         "suggestions": suggestions,
     }
+
+
+def _aggregate_cas_verdict(verdicts: list[str]) -> str:
+    """Collapse per-item CAS verdicts into one. A single FAIL dominates."""
+    if _cas.VERDICT_FAIL in verdicts:
+        return _cas.VERDICT_FAIL
+    if _cas.VERDICT_PASS in verdicts:
+        return _cas.VERDICT_PASS
+    if _cas.VERDICT_COMPUTED in verdicts:
+        return _cas.VERDICT_COMPUTED
+    return _cas.VERDICT_INCONCLUSIVE
 
 
 @mcp.tool(annotations=read_only_tool_annotations())
 def symmetry_check(expression: str, symmetries: list[str]) -> dict:
     """Verify that an expression respects specified symmetries.
 
-    Structural check that symmetry analysis has been documented.
-    Actual verification should use CAS or explicit transformation.
+    For coordinate-reflection symmetries (``parity`` → ``x -> -x``,
+    ``time-reversal`` → ``t -> -t``) over a machine-parseable expression, this
+    tool actually performs the substitution with SymPy and classifies the
+    result as invariant (even) / odd / neither in each result's ``cas`` block.
+    Symmetries with no single-substitution test (gauge, Lorentz, ...) return
+    ``inconclusive`` and rely on the structural ``status`` + ``strategy``
+    guidance, so the executed verdict is never fabricated.
 
     Args:
         expression: The expression to check
@@ -5111,19 +5142,28 @@ def _symmetry_check_inner(expression: str, symmetries: list[str]) -> dict:
                 matched_type = key
                 break
 
+        cas = _cas.check_symmetry(expression, sym)
         results.append(
             {
                 "symmetry": sym,
                 "matched_type": matched_type,
                 "strategy": strategy or f"Apply {sym} transformation to expression and verify expected behavior",
+                # Structural marker (kept for backward compatibility). When the
+                # symmetry reduces to a coordinate reflection (parity / time
+                # reversal) over a parseable expression, the executed result is
+                # in the `cas` block.
                 "status": "requires_verification",
+                "cas": cas,
             }
         )
 
+    cas_verdicts = [r["cas"]["verdict"] for r in results if isinstance(r.get("cas"), dict)]
     return {
         "schema_version": VERIFICATION_SCHEMA_VERSION,
         "expression_length": len(expression),
         "symmetries_checked": len(results),
+        "cas_executed": sum(1 for r in results if r.get("cas", {}).get("attempted")),
+        "overall_cas_verdict": _aggregate_cas_verdict(cas_verdicts),
         "results": results,
     }
 

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -5519,6 +5519,97 @@ def tensor_check(equation: str) -> dict:
         return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
 
 
+@mcp.tool(annotations=read_only_tool_annotations())
+def integral_check(
+    integrand: str,
+    variable: str,
+    claimed: str | None = None,
+    lower: str | None = None,
+    upper: str | None = None,
+) -> dict:
+    """Verify a claimed integral.
+
+    Indefinite (no bounds): the claimed antiderivative is verified by
+    differentiation — ``d(claimed)/dx == integrand`` — the robust direction.
+    Definite (``lower`` and ``upper`` given): computes the definite integral with
+    SymPy and compares to ``claimed``. With no ``claimed``, returns the computed
+    result. Plain or LaTeX input; an integral SymPy cannot evaluate →
+    inconclusive.
+
+    Args:
+        integrand: e.g. "2*x" or LaTeX.
+        variable: integration variable, e.g. "x".
+        claimed: claimed antiderivative (indefinite) or value (definite).
+        lower, upper: bounds for a definite integral (e.g. "0", "oo", "pi").
+    """
+    with gpd_span("mcp.verification.integral_check"):
+        validated_integrand, error = _validate_string(integrand, field_name="integrand")
+        if error is not None:
+            return error
+        validated_variable, error = _validate_string(variable, field_name="variable")
+        if error is not None:
+            return error
+        validated_claimed = None
+        if claimed is not None:
+            validated_claimed, error = _validate_string(claimed, field_name="claimed")
+            if error is not None:
+                return error
+        validated_lower = None
+        if lower is not None:
+            validated_lower, error = _validate_string(lower, field_name="lower")
+            if error is not None:
+                return error
+        validated_upper = None
+        if upper is not None:
+            validated_upper, error = _validate_string(upper, field_name="upper")
+            if error is not None:
+                return error
+        if (validated_lower is None) != (validated_upper is None):
+            return _error_result("a definite integral needs both lower and upper bounds")
+        result = _cas.check_integral(
+            validated_integrand, validated_variable, validated_claimed, validated_lower, validated_upper
+        )
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
+@mcp.tool(annotations=read_only_tool_annotations())
+def commutator_check(operators: dict[str, str], a: str, b: str, expected: str, variable: str = "x") -> dict:
+    """Verify an operator commutator ``[a, b] = expected`` on a test function.
+
+    ``operators`` maps a name to its action on the test function ``f``, using
+    ``f`` and ``f_x``, ``f_xx`` … for derivatives. Computes ``a(b f) - b(a f)``
+    with SymPy and compares to ``expected``. Example: the canonical commutator
+    ``operators={"X": "x*f", "P": "-I*hbar*f_x"}, a="X", b="P",
+    expected="I*hbar*f"`` (i.e. [x, p] = i hbar) → pass.
+
+    Args:
+        operators: name -> action on f (e.g. {"X": "x*f", "P": "-I*hbar*f_x"}).
+        a, b: operator names to commute.
+        expected: the claimed result's action on f (e.g. "I*hbar*f").
+        variable: the spatial variable used in the actions (default "x").
+    """
+    with gpd_span("mcp.verification.commutator_check"):
+        validated_operators, error = _validate_string_mapping(operators, field_name="operators")
+        if error is not None:
+            return error
+        validated_a, error = _validate_string(a, field_name="a")
+        if error is not None:
+            return error
+        validated_b, error = _validate_string(b, field_name="b")
+        if error is not None:
+            return error
+        validated_expected, error = _validate_string(expected, field_name="expected")
+        if error is not None:
+            return error
+        validated_variable, error = _validate_string(variable, field_name="variable")
+        if error is not None:
+            return error
+        result = _cas.check_commutator(
+            validated_operators, validated_a, validated_b, validated_expected, validated_variable
+        )
+        return stable_mcp_response({"schema_version": VERIFICATION_SCHEMA_VERSION, **result})
+
+
 # ─── Entry Point ──────────────────────────────────────────────────────────────
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -271,7 +271,7 @@ flowchart TD
   `authority`
   Fallback version source when installed metadata is unavailable.
 
-- `pyproject.toml -> external Python packages {typer, rich, pydantic, PyYAML, mcp, pybtex, Pillow, jinja2, pytest, pytest-asyncio, pytest-xdist, ruff, hatchling, arxiv-mcp-server, arxiv, httpx, cairosvg, pypdf}`
+- `pyproject.toml -> external Python packages {typer, rich, pydantic, PyYAML, mcp, pybtex, Pillow, jinja2, sympy, lark, pytest, pytest-asyncio, pytest-xdist, ruff, hatchling, arxiv-mcp-server, arxiv, httpx, cairosvg, pypdf}`
   `external-package`
 
 - `src/gpd/mcp/builtin_servers.py -> infra/gpd-*.json`

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ It covers:
 - `src/gpd/hooks/*.py`: `11`
 - `src/gpd/mcp/*.py`: `5`
 - `src/gpd/mcp/integrations/*.py`: `2`
-- `src/gpd/mcp/servers/*.py`: `15`
+- `src/gpd/mcp/servers/*.py`: `16`
 - `infra/gpd-*.json`: `8`
 
 Excluded as noise from node counting, but still modeled where contractually relevant:

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -2980,6 +2980,53 @@ class TestVerificationServer:
         assert result["schema_version"] == 1
         assert result["error"] == "expressions[1] must be a string"
 
+    # --- dimensional_check symbolic mode (real expressions + dimension map) ---
+
+    def test_dimensional_check_symbolic_energy_mass_velocity(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        result = dimensional_check(["E = m*c^2"], {"E": "energy", "m": "mass", "c": "velocity"})
+        assert result["all_consistent"] is True
+        assert result["results"][0]["cas"]["verdict"] == "pass"
+
+    def test_dimensional_check_symbolic_catches_inconsistency(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        result = dimensional_check(["E = m*c"], {"E": "energy", "m": "mass", "c": "velocity"})
+        assert result["all_consistent"] is False
+        assert result["results"][0]["cas"]["verdict"] == "fail"
+
+    def test_dimensional_check_symbolic_latex(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        result = dimensional_check(
+            [r"E = \frac{1}{2} m v^2"], {"E": "energy", "m": "mass", "v": "velocity"}
+        )
+        assert result["results"][0]["cas"]["verdict"] == "pass"
+
+    def test_dimensional_check_symbolic_mixed_sum_fails(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        # Adding a length and a time is dimensionally inconsistent.
+        result = dimensional_check(["x = a + t"], {"x": "length", "a": "length", "t": "time"})
+        assert result["results"][0]["cas"]["verdict"] == "fail"
+
+    def test_dimensional_check_symbolic_missing_symbol_inconclusive(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        result = dimensional_check(["E = m*c^2"], {"E": "energy", "m": "mass"})
+        assert result["results"][0]["cas"]["verdict"] == "inconclusive"
+        assert result["all_consistent"] is False
+
+    def test_dimensional_check_symbolic_bracket_spec(self):
+        from gpd.mcp.servers.verification_server import dimensional_check
+
+        # A dimension may be given as a bracket spec instead of a name.
+        result = dimensional_check(
+            ["p = m*v"], {"p": "[M][L][T]^-1", "m": "mass", "v": "velocity"}
+        )
+        assert result["results"][0]["cas"]["verdict"] == "pass"
+
     # --- limiting_case_check (pure function) ---
 
     def test_limiting_case_check_basic(self):

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3256,6 +3256,69 @@ class TestVerificationServer:
         assert cas["classification"] == "invariant (even)"
         assert cas["invariant"] is True
 
+    # --- conservation_check (executable trajectory drift) ---
+
+    def test_conservation_check_conserved_energy(self):
+        import math
+
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        # SHO on the unit circle: E = 1/2 v^2 + 1/2 x^2 is exactly conserved.
+        traj = [
+            {"x": math.cos(i * math.pi / 6), "v": -math.sin(i * math.pi / 6), "m": 1.0, "k": 1.0}
+            for i in range(13)
+        ]
+        result = conservation_check("0.5*m*v**2 + 0.5*k*x**2", traj)
+        assert result["verdict"] == "pass"
+        assert result["conserved"] is True
+        assert result["max_relative_drift"] < 1e-6
+
+    def test_conservation_check_catches_drift(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        bad = [{"x": 0.0, "v": 1.0 + 0.05 * i, "m": 1.0, "k": 1.0} for i in range(10)]
+        result = conservation_check("0.5*m*v**2 + 0.5*k*x**2", bad)
+        assert result["verdict"] == "fail"
+        assert result["conserved"] is False
+
+    def test_conservation_check_zero_quantity_absolute_basis(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check("p1 + p2", [{"p1": 1.0, "p2": -1.0}, {"p1": 2.0, "p2": -2.0}])
+        assert result["verdict"] == "pass"
+        assert result["drift_basis"] == "absolute"
+
+    def test_conservation_check_latex_quantity(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check(r"\frac{1}{2} m v^2", [{"m": 1, "v": 2}, {"m": 1, "v": 2}])
+        assert result["verdict"] == "pass"
+
+    def test_conservation_check_missing_variable_inconclusive(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check("a + b", [{"a": 1.0}, {"a": 2.0}])
+        assert result["verdict"] == "inconclusive"
+
+    def test_conservation_check_too_short_inconclusive(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check("x", [{"x": 1.0}])
+        assert result["verdict"] == "inconclusive"
+
+    def test_conservation_check_invalid_trajectory_returns_error_envelope(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check("x", "notalist")
+        assert result["schema_version"] == 1
+        assert "error" in result
+
+    def test_conservation_check_unparseable_quantity_inconclusive(self):
+        from gpd.mcp.servers.verification_server import conservation_check
+
+        result = conservation_check("not a real expr $$$", [{"x": 1.0}, {"x": 2.0}])
+        assert result["verdict"] == "inconclusive"
+
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3083,6 +3083,39 @@ class TestVerificationServer:
         assert result["results"][0]["cas"]["verdict"] == "inconclusive"
         assert result["overall_cas_verdict"] != "pass"
 
+    # --- limiting_case_check LaTeX expressions ---
+
+    def test_limiting_case_cas_latex_classical_limit_pass(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        # (1 - cos(hbar*x)) / hbar -> 0 as hbar -> 0, given in LaTeX.
+        result = limiting_case_check(
+            r"\frac{1 - \cos(\hbar x)}{\hbar}", {r"\hbar \to 0": "0"}
+        )
+        assert result["overall_cas_verdict"] == "pass"
+        assert result["results"][0]["cas"]["variable"] == "hbar"
+
+    def test_limiting_case_cas_latex_infinity_limit(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        result = limiting_case_check(r"\frac{1}{1 + x}", {r"x \to \infty": "0"})
+        assert result["overall_cas_verdict"] == "pass"
+
+    def test_limiting_case_cas_latex_juxtaposed_superscripts_degrade_safely(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        # lark cannot parse juxtaposed superscript products (a^2 b^2); the
+        # oracle must degrade to inconclusive, never a false pass.
+        result = limiting_case_check(r"\frac{\hbar^2 k^2}{2m}", {r"\hbar \to 0": "0"})
+        assert result["results"][0]["cas"]["verdict"] == "inconclusive"
+        assert result["overall_cas_verdict"] != "pass"
+
+    def test_cas_latex_rejects_dangerous_tex(self):
+        from gpd.mcp.servers import _cas
+
+        assert _cas.safe_parse(r"\input{/etc/passwd}") is None
+        assert _cas.safe_parse(r"\frac{\hbar^2}{2m}") is not None
+
     def test_limiting_case_check_invalid_limit_key_returns_error_envelope(self):
         from gpd.mcp.servers.verification_server import limiting_case_check
 
@@ -3156,6 +3189,14 @@ class TestVerificationServer:
         assert row["status"] == "requires_verification"
         assert row["strategy"] is not None
         assert row["cas"]["verdict"] == "inconclusive"
+
+    def test_symmetry_cas_latex_parity_even(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        result = symmetry_check(r"V = \frac{1}{2} k x^2", ["parity"])
+        cas = result["results"][0]["cas"]
+        assert cas["classification"] == "invariant (even)"
+        assert cas["invariant"] is True
 
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -2999,9 +2999,7 @@ class TestVerificationServer:
     def test_dimensional_check_symbolic_latex(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 
-        result = dimensional_check(
-            [r"E = \frac{1}{2} m v^2"], {"E": "energy", "m": "mass", "v": "velocity"}
-        )
+        result = dimensional_check([r"E = \frac{1}{2} m v^2"], {"E": "energy", "m": "mass", "v": "velocity"})
         assert result["results"][0]["cas"]["verdict"] == "pass"
 
     def test_dimensional_check_symbolic_mixed_sum_fails(self):
@@ -3022,9 +3020,7 @@ class TestVerificationServer:
         from gpd.mcp.servers.verification_server import dimensional_check
 
         # A dimension may be given as a bracket spec instead of a name.
-        result = dimensional_check(
-            ["p = m*v"], {"p": "[M][L][T]^-1", "m": "mass", "v": "velocity"}
-        )
+        result = dimensional_check(["p = m*v"], {"p": "[M][L][T]^-1", "m": "mass", "v": "velocity"})
         assert result["results"][0]["cas"]["verdict"] == "pass"
 
     # --- limiting_case_check (pure function) ---
@@ -3136,9 +3132,7 @@ class TestVerificationServer:
         from gpd.mcp.servers.verification_server import limiting_case_check
 
         # (1 - cos(hbar*x)) / hbar -> 0 as hbar -> 0, given in LaTeX.
-        result = limiting_case_check(
-            r"\frac{1 - \cos(\hbar x)}{\hbar}", {r"\hbar \to 0": "0"}
-        )
+        result = limiting_case_check(r"\frac{1 - \cos(\hbar x)}{\hbar}", {r"\hbar \to 0": "0"})
         assert result["overall_cas_verdict"] == "pass"
         assert result["results"][0]["cas"]["variable"] == "hbar"
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3555,6 +3555,82 @@ class TestVerificationServer:
 
         assert commutator_check({"X": "x*f"}, "X", "P", "f")["verdict"] == "inconclusive"
 
+    # --- pde_check (solution satisfies a partial differential equation) ---
+
+    def test_pde_check_heat_equation(self):
+        from gpd.mcp.servers.verification_server import pde_check
+
+        result = pde_check("u_t = alpha*u_xx", "exp(-alpha*k**2*t)*sin(k*x)", ["t", "x"])
+        assert result["verdict"] == "pass"
+
+    def test_pde_check_wave_equation(self):
+        from gpd.mcp.servers.verification_server import pde_check
+
+        result = pde_check("u_tt = c**2*u_xx", "sin(k*x - c*k*t)", ["t", "x"])
+        assert result["verdict"] == "pass"
+
+    def test_pde_check_laplace(self):
+        from gpd.mcp.servers.verification_server import pde_check
+
+        result = pde_check("u_xx + u_yy = 0", "exp(k*x)*sin(k*y)", ["x", "y"])
+        assert result["verdict"] == "pass"
+
+    def test_pde_check_wrong_solution(self):
+        from gpd.mcp.servers.verification_server import pde_check
+
+        result = pde_check("u_t = alpha*u_xx", "sin(k*x)*t", ["t", "x"])
+        assert result["verdict"] == "fail"
+
+    def test_pde_check_function_absent_inconclusive(self):
+        from gpd.mcp.servers.verification_server import pde_check
+
+        result = pde_check("w + 1 = 0", "x", ["t", "x"])
+        assert result["verdict"] == "inconclusive"
+
+    # --- matrix_check (structural matrix properties) ---
+
+    def test_matrix_check_pauli_x_hermitian(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["0", "1"], ["1", "0"]], "hermitian")["verdict"] == "pass"
+
+    def test_matrix_check_pauli_y_unitary(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["0", "-I"], ["I", "0"]], "unitary")["verdict"] == "pass"
+
+    def test_matrix_check_rotation_orthogonal(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["cos(t)", "-sin(t)"], ["sin(t)", "cos(t)"]], "orthogonal")["verdict"] == "pass"
+
+    def test_matrix_check_not_symmetric(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["1", "2"], ["3", "4"]], "symmetric")["verdict"] == "fail"
+
+    def test_matrix_check_projection_idempotent(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["1", "0"], ["0", "0"]], "idempotent")["verdict"] == "pass"
+
+    def test_matrix_check_non_square_unitary_fails(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["1", "0", "0"], ["0", "1", "0"]], "unitary")["verdict"] == "fail"
+
+    def test_matrix_check_unknown_property_inconclusive(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        assert matrix_check([["1", "0"], ["0", "1"]], "magical")["verdict"] == "inconclusive"
+
+    def test_matrix_check_invalid_entry_error_envelope(self):
+        from gpd.mcp.servers.verification_server import matrix_check
+
+        result = matrix_check([["1", 2], ["3", "4"]], "symmetric")
+        assert result["schema_version"] == 1
+        assert "error" in result
+
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3489,6 +3489,72 @@ class TestVerificationServer:
         result = tensor_check(r"A^{mu} B_{mu}")
         assert result["verdict"] == "inconclusive"
 
+    # --- integral_check (antiderivative / definite integral) ---
+
+    def test_integral_check_antiderivative_correct(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        assert integral_check("x**2", "x", "x**3/3")["verdict"] == "pass"
+
+    def test_integral_check_antiderivative_wrong(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        assert integral_check("x**2", "x", "x**3")["verdict"] == "fail"
+
+    def test_integral_check_definite(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        assert integral_check("x**2", "x", "1/3", "0", "1")["verdict"] == "pass"
+
+    def test_integral_check_gaussian(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        assert integral_check("exp(-x**2)", "x", "sqrt(pi)", "-oo", "oo")["verdict"] == "pass"
+
+    def test_integral_check_latex_antiderivative(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        assert integral_check(r"\frac{1}{x}", "x", "log(x)")["verdict"] == "pass"
+
+    def test_integral_check_computes_antiderivative(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        result = integral_check("cos(x)", "x")
+        assert result["verdict"] == "computed"
+        assert result["antiderivative"] == "sin(x)"
+
+    def test_integral_check_one_bound_error_envelope(self):
+        from gpd.mcp.servers.verification_server import integral_check
+
+        result = integral_check("x", "x", None, "0", None)
+        assert result["schema_version"] == 1
+        assert "error" in result
+
+    # --- commutator_check (operator algebra) ---
+
+    def test_commutator_check_canonical(self):
+        from gpd.mcp.servers.verification_server import commutator_check
+
+        ops = {"X": "x*f", "P": "-I*hbar*f_x"}
+        assert commutator_check(ops, "X", "P", "I*hbar*f")["verdict"] == "pass"
+
+    def test_commutator_check_wrong(self):
+        from gpd.mcp.servers.verification_server import commutator_check
+
+        ops = {"X": "x*f", "P": "-I*hbar*f_x"}
+        assert commutator_check(ops, "X", "P", "f")["verdict"] == "fail"
+
+    def test_commutator_check_self_commutes(self):
+        from gpd.mcp.servers.verification_server import commutator_check
+
+        ops = {"X": "x*f", "P": "-I*hbar*f_x"}
+        assert commutator_check(ops, "X", "X", "0")["verdict"] == "pass"
+
+    def test_commutator_check_missing_operator_inconclusive(self):
+        from gpd.mcp.servers.verification_server import commutator_check
+
+        assert commutator_check({"X": "x*f"}, "X", "P", "f")["verdict"] == "inconclusive"
+
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3028,6 +3028,61 @@ class TestVerificationServer:
         )
         assert result["results"][0]["limit_type"] == "classical"
 
+    # --- limiting_case_check CAS-backed executable verdicts ---
+
+    def test_limiting_case_cas_pass_on_correct_limit(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        result = limiting_case_check("f = sin(x)/x", {"x -> 0": "1"})
+        assert result["overall_cas_verdict"] == "pass"
+        assert result["cas_executed"] == 1
+        cas = result["results"][0]["cas"]
+        assert cas["attempted"] is True
+        assert cas["verdict"] == "pass"
+        assert cas["computed_limit"] == "1"
+
+    def test_limiting_case_cas_fail_catches_wrong_limit(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        # sin(x)/x -> 1, not 0: the oracle must catch the false claim.
+        result = limiting_case_check("f = sin(x)/x", {"x -> 0": "0"})
+        assert result["overall_cas_verdict"] == "fail"
+        assert result["results"][0]["cas"]["verdict"] == "fail"
+
+    def test_limiting_case_cas_infinity_limit(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        result = limiting_case_check("E = 1/(1 + x)", {"x -> infinity": "0"})
+        assert result["overall_cas_verdict"] == "pass"
+
+    def test_limiting_case_cas_inconclusive_on_prose_limit(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        # A prose limit (no "var -> point") cannot be computed; the verdict must
+        # be inconclusive and the structural status preserved (backward compat).
+        result = limiting_case_check(
+            "E = gamma * m * c^2",
+            {"non-relativistic limit": "E = m*c^2 + 1/2*m*v^2"},
+        )
+        row = result["results"][0]
+        assert row["status"] == "documented"
+        assert row["cas"]["verdict"] == "inconclusive"
+        assert row["cas"]["attempted"] is False
+
+    def test_limiting_case_cas_never_passes_unparseable_expression(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        result = limiting_case_check("totally unparseable prose here", {"x -> 0": "0"})
+        assert result["results"][0]["cas"]["verdict"] == "inconclusive"
+        assert result["overall_cas_verdict"] != "pass"
+
+    def test_limiting_case_cas_rejects_unsafe_input(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        result = limiting_case_check('__import__("os").system("echo hi")', {"x -> 0": "0"})
+        assert result["results"][0]["cas"]["verdict"] == "inconclusive"
+        assert result["overall_cas_verdict"] != "pass"
+
     def test_limiting_case_check_invalid_limit_key_returns_error_envelope(self):
         from gpd.mcp.servers.verification_server import limiting_case_check
 
@@ -3072,6 +3127,35 @@ class TestVerificationServer:
 
         assert result["schema_version"] == 1
         assert result["error"] == "symmetries[1] must be a string"
+
+    # --- symmetry_check CAS-backed executable verdicts ---
+
+    def test_symmetry_cas_parity_even(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        result = symmetry_check("V = x**2", ["parity"])
+        cas = result["results"][0]["cas"]
+        assert cas["attempted"] is True
+        assert cas["invariant"] is True
+        assert "even" in cas["classification"]
+        assert cas["transformation"] == "x -> -x"
+
+    def test_symmetry_cas_parity_odd(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        result = symmetry_check("V = x**3", ["parity"])
+        assert result["results"][0]["cas"]["classification"] == "odd"
+
+    def test_symmetry_cas_inconclusive_for_gauge(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        # No single-substitution test for gauge: stays inconclusive and keeps
+        # the structural status + strategy guidance.
+        result = symmetry_check("A_mu field", ["gauge invariance"])
+        row = result["results"][0]
+        assert row["status"] == "requires_verification"
+        assert row["strategy"] is not None
+        assert row["cas"]["verdict"] == "inconclusive"
 
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3319,6 +3319,85 @@ class TestVerificationServer:
         result = conservation_check("not a real expr $$$", [{"x": 1.0}, {"x": 2.0}])
         assert result["verdict"] == "inconclusive"
 
+    # --- equation_check (symbolic identity) ---
+
+    def test_equation_check_true_identity(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        assert equation_check("sin(x)**2 + cos(x)**2", "1")["verdict"] == "pass"
+
+    def test_equation_check_false_identity(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        result = equation_check("sin(x)**2", "1 - cos(x)")
+        assert result["verdict"] == "fail"
+        assert "difference" in result
+
+    def test_equation_check_with_assumption(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        # sqrt(x**2) == x only when x is positive.
+        assert equation_check("sqrt(x**2)", "x", {"x": "positive"})["verdict"] == "pass"
+        assert equation_check("sqrt(x**2)", "x")["verdict"] != "pass"
+
+    def test_equation_check_latex(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        result = equation_check(r"\frac{a}{b} + \frac{c}{b}", r"\frac{a+c}{b}")
+        assert result["verdict"] == "pass"
+
+    def test_equation_check_unparseable_inconclusive(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        assert equation_check("not real $$$", "1")["verdict"] == "inconclusive"
+
+    def test_equation_check_invalid_input_error_envelope(self):
+        from gpd.mcp.servers.verification_server import equation_check
+
+        result = equation_check("x", 5)
+        assert result["schema_version"] == 1
+        assert "error" in result
+
+    # --- series_check (Taylor / asymptotic expansion) ---
+
+    def test_series_check_computes_expansion(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        result = series_check("sin(x)", "x")
+        assert result["verdict"] == "computed"
+        assert "x**5/120" in result["computed_series"]
+
+    def test_series_check_matches_expected(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        result = series_check("sin(x)", "x", "0", 6, "x - x**3/6 + x**5/120")
+        assert result["verdict"] == "pass"
+
+    def test_series_check_catches_wrong_expansion(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        result = series_check("sin(x)", "x", "0", 6, "x - x**3/3")
+        assert result["verdict"] == "fail"
+
+    def test_series_check_latex_geometric(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        result = series_check(r"\frac{1}{1-x}", "x", "0", 5)
+        assert result["verdict"] == "computed"
+        assert "x**4" in result["computed_series"]
+
+    def test_series_check_invalid_order_error_envelope(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        result = series_check("sin(x)", "x", "0", 99)
+        assert result["schema_version"] == 1
+        assert "error" in result
+
+    def test_series_check_unparseable_inconclusive(self):
+        from gpd.mcp.servers.verification_server import series_check
+
+        assert series_check("not real $$$", "x")["verdict"] == "inconclusive"
+
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3398,6 +3398,97 @@ class TestVerificationServer:
 
         assert series_check("not real $$$", "x")["verdict"] == "inconclusive"
 
+    # --- ode_check (solution satisfies a differential equation) ---
+
+    def test_ode_check_sho_solution(self):
+        from gpd.mcp.servers.verification_server import ode_check
+
+        result = ode_check("y'' + omega**2 * y = 0", "A*cos(omega*x) + B*sin(omega*x)")
+        assert result["verdict"] == "pass"
+
+    def test_ode_check_wrong_solution(self):
+        from gpd.mcp.servers.verification_server import ode_check
+
+        result = ode_check("y'' + omega**2 * y = 0", "A*cos(2*omega*x)")
+        assert result["verdict"] == "fail"
+
+    def test_ode_check_first_order_decay(self):
+        from gpd.mcp.servers.verification_server import ode_check
+
+        result = ode_check("y' + k*y = 0", "C*exp(-k*x)")
+        assert result["verdict"] == "pass"
+
+    def test_ode_check_latex_solution(self):
+        from gpd.mcp.servers.verification_server import ode_check
+
+        result = ode_check("y'' + y = 0", r"\sin(x)")
+        assert result["verdict"] == "pass"
+
+    def test_ode_check_function_absent_inconclusive(self):
+        from gpd.mcp.servers.verification_server import ode_check
+
+        result = ode_check("z + 1 = 0", "x")
+        assert result["verdict"] == "inconclusive"
+
+    # --- symmetry_check scale invariance (Euler homogeneity) ---
+
+    def test_symmetry_check_scale_homogeneous(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        result = symmetry_check("V = k*x**2", ["scale invariance"])
+        cas = result["results"][0]["cas"]
+        assert cas["scale_degree"] == "2"
+        assert "degree 2" in cas["classification"]
+
+    def test_symmetry_check_scale_not_homogeneous(self):
+        from gpd.mcp.servers.verification_server import symmetry_check
+
+        result = symmetry_check("f = x**2 + x", ["scale"])
+        cas = result["results"][0]["cas"]
+        assert cas["invariant"] is False
+        assert "not scale-homogeneous" in cas["classification"]
+
+    # --- tensor_check (index / contraction consistency) ---
+
+    def test_tensor_check_consistent_maxwell(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"F^{mu nu} = \partial^{mu} A^{nu} - \partial^{nu} A^{mu}")
+        assert result["verdict"] == "pass"
+        assert result["free_indices"] == ["mu(upper)", "nu(upper)"]
+
+    def test_tensor_check_valid_contraction(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"S = T^{mu nu} g_{mu nu}")
+        assert result["verdict"] == "pass"
+        assert result["free_indices"] == []
+
+    def test_tensor_check_up_down_mismatch(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"A^{mu} = B_{mu}")
+        assert result["verdict"] == "fail"
+
+    def test_tensor_check_same_position_repeat(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"X = A^{mu} B^{mu}")
+        assert result["verdict"] == "fail"
+        assert result["issues"]
+
+    def test_tensor_check_free_index_mismatch(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"A^{mu} = B^{mu} C^{nu}")
+        assert result["verdict"] == "fail"
+
+    def test_tensor_check_no_equals_inconclusive(self):
+        from gpd.mcp.servers.verification_server import tensor_check
+
+        result = tensor_check(r"A^{mu} B_{mu}")
+        assert result["verdict"] == "inconclusive"
+
     def test_dimensional_check_rejects_whitespace_only_expression(self):
         from gpd.mcp.servers.verification_server import dimensional_check
 

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -3101,12 +3101,20 @@ class TestVerificationServer:
         result = limiting_case_check(r"\frac{1}{1 + x}", {r"x \to \infty": "0"})
         assert result["overall_cas_verdict"] == "pass"
 
-    def test_limiting_case_cas_latex_juxtaposed_superscripts_degrade_safely(self):
+    def test_limiting_case_cas_latex_juxtaposed_superscripts_rescued(self):
         from gpd.mcp.servers.verification_server import limiting_case_check
 
-        # lark cannot parse juxtaposed superscript products (a^2 b^2); the
-        # oracle must degrade to inconclusive, never a false pass.
+        # lark rejects juxtaposed superscript products (a^2 b^2); the delatexify
+        # fallback rescues them. Kinetic energy hbar^2 k^2 / 2m -> 0 as hbar -> 0.
         result = limiting_case_check(r"\frac{\hbar^2 k^2}{2m}", {r"\hbar \to 0": "0"})
+        assert result["overall_cas_verdict"] == "pass"
+        assert result["results"][0]["cas"]["computed_limit"] == "0"
+
+    def test_limiting_case_cas_latex_derivative_degrades_safely(self):
+        from gpd.mcp.servers.verification_server import limiting_case_check
+
+        # Differential operators must never be faked into algebra: inconclusive.
+        result = limiting_case_check(r"\frac{d^2 \psi}{dx^2}", {r"x \to 0": "0"})
         assert result["results"][0]["cas"]["verdict"] == "inconclusive"
         assert result["overall_cas_verdict"] != "pass"
 
@@ -3115,6 +3123,15 @@ class TestVerificationServer:
 
         assert _cas.safe_parse(r"\input{/etc/passwd}") is None
         assert _cas.safe_parse(r"\frac{\hbar^2}{2m}") is not None
+
+    def test_cas_delatexify_hamiltonian_and_refuses_derivatives(self):
+        from gpd.mcp.servers import _cas
+
+        # Full harmonic-oscillator Hamiltonian parses via the delatexify fallback.
+        assert _cas.safe_parse(r"\frac{p^2}{2m} + \frac{1}{2} m \omega^2 x^2") is not None
+        # Derivative / Laplacian operators are refused (stay None → inconclusive).
+        assert _cas.safe_parse(r"\frac{d^2 \psi}{dx^2}") is None
+        assert _cas.safe_parse(r"\nabla^2 \phi") is None
 
     def test_limiting_case_check_invalid_limit_key_returns_error_envelope(self):
         from gpd.mcp.servers.verification_server import limiting_case_check

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -1395,6 +1395,8 @@ def test_read_only_builtin_mcp_tools_publish_annotations() -> None:
             "tensor_check",
             "integral_check",
             "commutator_check",
+            "pde_check",
+            "matrix_check",
         },
     }
 

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -1389,6 +1389,8 @@ def test_read_only_builtin_mcp_tools_publish_annotations() -> None:
             "symmetry_check",
             "get_verification_coverage",
             "conservation_check",
+            "equation_check",
+            "series_check",
         },
     }
 

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -1388,6 +1388,7 @@ def test_read_only_builtin_mcp_tools_publish_annotations() -> None:
             "limiting_case_check",
             "symmetry_check",
             "get_verification_coverage",
+            "conservation_check",
         },
     }
 

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -1393,6 +1393,8 @@ def test_read_only_builtin_mcp_tools_publish_annotations() -> None:
             "series_check",
             "ode_check",
             "tensor_check",
+            "integral_check",
+            "commutator_check",
         },
     }
 

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -1391,6 +1391,8 @@ def test_read_only_builtin_mcp_tools_publish_annotations() -> None:
             "conservation_check",
             "equation_check",
             "series_check",
+            "ode_check",
+            "tensor_check",
         },
     }
 

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -28,7 +28,7 @@
     "`src/gpd/hooks/*.py`": 11,
     "`src/gpd/mcp/*.py`": 5,
     "`src/gpd/mcp/integrations/*.py`": 2,
-    "`src/gpd/mcp/servers/*.py`": 15,
+    "`src/gpd/mcp/servers/*.py`": 16,
     "`infra/gpd-*.json`": 8
   },
   "prompt_stem_inventory": {

--- a/tests/test_release_consistency.py
+++ b/tests/test_release_consistency.py
@@ -423,12 +423,14 @@ def _string_constant_assignments(repo_root: Path, relative_path: str) -> dict[st
 def _expected_runtime_dependency_names() -> set[str]:
     return {
         "jinja2",
+        "lark",
         "mcp",
         "pillow",
         "pybtex",
         "pydantic",
         "pyyaml",
         "rich",
+        "sympy",
         "typer",
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -679,6 +679,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "sympy" },
     { name = "typer" },
 ]
 
@@ -719,6 +720,7 @@ requires-dist = [
     { name = "pypdf", marker = "extra == 'paper'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=15.0.0" },
+    { name = "sympy", specifier = ">=1.13" },
     { name = "typer", specifier = ">=0.24.2" },
 ]
 provides-extras = ["paper", "arxiv"]
@@ -1063,6 +1065,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -2184,6 +2195,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -673,6 +673,7 @@ version = "1.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
+    { name = "lark" },
     { name = "mcp" },
     { name = "pillow" },
     { name = "pybtex" },
@@ -712,6 +713,7 @@ requires-dist = [
     { name = "cairosvg", marker = "extra == 'paper'", specifier = ">=2.7.0" },
     { name = "httpx", marker = "extra == 'arxiv'", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "lark", specifier = ">=1.1" },
     { name = "mcp", specifier = ">=1.27.0" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pybtex", specifier = ">=0.25.1" },
@@ -834,6 +836,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Make GPD's physics-verification checks **actually compute** instead of returning
prose. Previously `dimensional_check` / `limiting_case_check` / `symmetry_check`
returned a structural marker (`"documented"` / `"requires_verification"`) and
told the agent to "use SymPy" — delegating the verdict to the LLM's weakest
skill (symbolic algebra). This adds a SymPy computer-algebra backend so the
verdict no longer depends on trusting the agent under review, accepts **LaTeX**
input (how physics is written), and grows the verification surface from 3 checks
to a full executable suite.

There are no behavioral surprises: existing tools are upgraded additively (all
prior fields preserved), and every check returns **`inconclusive` rather than a
false `pass`** when it can't decide.

## Executable checks

**Upgraded (now compute):**
- `limiting_case_check` — `sympy.limit(expr, var, point)` vs expected → pass/fail
- `symmetry_check` — parity (`x→-x`), time-reversal (`t→-t`), and **scale/dilation** (Euler homogeneity degree)
- `dimensional_check` — keeps `[M][L][T]` annotations **and** adds symbolic dimensional analysis of real equations via a `dimensions` map (`E = m c^2` with {E:energy,m:mass,c:velocity})

**New tools:**
| Tool | Verifies |
|---|---|
| `conservation_check` | energy/momentum/charge drift along a trajectory |
| `equation_check` | any claimed algebraic identity (every derivation step) |
| `series_check` | Taylor / asymptotic expansions |
| `ode_check` | a solution satisfies an ODE (prime notation) |
| `pde_check` | a solution satisfies a PDE (subscript notation; heat/wave/Laplace/Schrödinger) |
| `tensor_check` | free/dummy index consistency of a tensor equation |
| `integral_check` | antiderivative (by differentiation) or definite integral |
| `commutator_check` | operator commutator `[a,b]=expected` (e.g. `[x,p]=iℏ`) |
| `matrix_check` | symmetric/hermitian/unitary/orthogonal/idempotent/involutory/normal |

```python
limiting_case_check("f = sin(x)/x", {"x -> 0": "0"})                     # "fail" (it's 1)
pde_check("u_t = alpha*u_xx", "exp(-alpha*k**2*t)*sin(k*x)", ["t","x"])  # "pass" (heat eq)
matrix_check([["0","-I"],["I","0"]], "unitary")                          # "pass" (Pauli Y)
commutator_check({"X":"x*f","P":"-I*hbar*f_x"}, "X","P","I*hbar*f")      # "pass" ([x,p]=iħ)
integral_check("exp(-x**2)", "x", "sqrt(pi)", "-oo", "oo")               # "pass"
```

## LaTeX input

Expressions are parsed with SymPy's grammar-based **lark** backend (no code
execution), with placeholder rewriting for lark-unsupported macros (`\hbar`,
`\Omega`, …). When lark rejects valid physics (e.g. juxtaposed superscript
products `\frac{\hbar^2 k^2}{2m}`), a conservative **delatexify** fallback
converts to plain infix with implicit multiplication. Differential operators are
refused so the fallback can never fabricate algebra from a derivative.

## Principled scope: no fake Lorentz check

`symmetry_check` does **not** auto-verify Lorentz invariance — that needs the
4-vector/metric structure the tool can't infer from a bare expression, so faking
a verdict would violate "never a false pass." Lorentz stays guidance-only;
`tensor_check` covers the index-bookkeeping half instead.

## Safety / honesty

Untrusted input is screened (unsafe Python tokens and dangerous TeX rejected),
parsing forces identifiers to plain Symbols, and SymPy runs in a timeout-bounded
worker thread. Any parse failure, timeout, undecidable comparison, missing
symbol/operator/function, non-real value, too-short trajectory, or unevaluable
integral/series → `inconclusive`, never a false `pass`.

## Dependencies

- `sympy>=1.13` — CAS backend
- `lark>=1.1` — pure-Python LaTeX-math grammar for `parse_latex`

## Integration & tests

All tools are registered read-only and listed in the `gpd-verification`
descriptor (`builtin_servers.py`, `infra/gpd-verification.json`) and the
contract-visibility expectations. Curated release surfaces and repo-graph
artifacts are kept in sync with the new deps/file. ~120 new tests; full
`tests/mcp` + release + repo-graph suites green locally (1028 passed).

> Consolidated from the former stacked PR #248 into this single PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CAS-backed symbolic verification with detailed per-check CAS results and aggregated verdicts
  * New verification tools: conservation, equation, series, ODE, tensor, integral, commutator, PDE, and matrix checks
  * Dimensional-consistency checks accepting named quantity mappings and bracket-form specs; richer limit and symmetry reporting

* **Tests**
  * Expanded test coverage for all CAS-backed checks, LaTeX/math parsing, timeouts, and verdict behaviors

* **Chores**
  * Added sympy and lark to project dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->