### PR TITLE
feat: add gpd:zen command

### DIFF
--- a/src/gpd/commands/zen.md
+++ b/src/gpd/commands/zen.md
@@ -1,0 +1,29 @@
+---
+name: gpd:zen
+description: Print a short physics-research zen koan to reset your focus, without taking any action
+argument-hint: "[optional mood word]"
+context_mode: projectless
+allowed-tools:
+  - file_read
+help:
+  group: Starter commands
+  order: 50
+  compact_description: Print a short research koan and take no action
+  display_signature: gpd:zen
+---
+
+
+<objective>
+Print one short physics-research zen koan to help the user reset focus between
+tasks. This is a purely decorative, read-only command. Do not create project
+artifacts, write files, run analysis, infer setup, or route into another
+workflow.
+</objective>
+
+<execution_context>
+@{GPD_INSTALL_DIR}/workflows/zen.md
+</execution_context>
+
+<process>
+Follow the included zen workflow exactly.
+</process>

--- a/src/gpd/registry.py
+++ b/src/gpd/registry.py
@@ -1645,6 +1645,7 @@ _SKILL_CATEGORY_MAP: dict[str, str] = {
     "gpd-quick": "execution",
     "gpd-help": "help",
     "gpd-suggest": "help",
+    "gpd-zen": "help",
     # Full-name entries for skills not captured by prefix matching.
     "gpd-bibliographer": "research",
     "gpd-check-todos": "management",

--- a/src/gpd/specs/references/help/detailed-command-reference.md
+++ b/src/gpd/specs/references/help/detailed-command-reference.md
@@ -41,6 +41,9 @@ Notes:
 
 - Staged workflow: `new-project`.
 
+**`gpd:zen [optional mood word]`**
+Print a short physics-research zen koan to reset your focus, without taking any action
+
 **`gpd:map-research`**
 Map existing research project — theoretical framework, computations, conventions, and open questions
 

--- a/src/gpd/specs/workflows/help.md
+++ b/src/gpd/specs/workflows/help.md
@@ -81,6 +81,7 @@ This is the compact grouped list of runtime commands. For normal-terminal instal
 - `gpd:tour` - Show a read-only overview of the main commands
 - `gpd:new-project` - Create a full GPD project
 - `gpd:new-project --minimal` - Create a GPD project through the shortest setup path
+- `gpd:zen` - Print a short research koan and take no action
 - `gpd:map-research` - Map an existing research folder before planning
 - `gpd:resume-work` - Resume the selected project's canonical state inside the runtime
 - `gpd:progress` - Review project status and likely next steps

--- a/src/gpd/specs/workflows/zen.md
+++ b/src/gpd/specs/workflows/zen.md
@@ -1,0 +1,36 @@
+<purpose>
+Print one short physics-research zen koan to help the user reset focus. This is
+a purely decorative, read-only surface. It does not create files, change project
+state, run analysis, or route into another workflow.
+</purpose>
+
+<process>
+
+<step name="parse_mood">
+Inspect `$ARGUMENTS`. Any text is treated only as an optional mood word used to
+pick a fitting koan. Empty arguments are fine. Do not infer setup, narrow scope,
+or route based on the argument.
+</step>
+
+<step name="print_koan">
+Open with this exact sentence:
+
+`This is a read-only koan. It changes nothing in your project.`
+
+Then print exactly one koan, chosen freely from the list below (or a close
+variant in the same spirit). If a mood word was given, prefer a koan that fits
+it; otherwise choose any.
+
+- "The fastest calculation is the one you did not need to do."
+- "A wrong sign is a teacher; check the limits and it confesses."
+- "Before adding a term, ask which symmetry forbids it."
+- "Two derivations that agree have earned one unit of trust."
+- "Dimensional analysis is humility wearing a lab coat."
+- "When the integral diverges, the physics is telling you where you stopped looking."
+
+Close with a single short encouragement to return to the next task. Do not
+append status, next steps, project analysis, or commentary beyond the koan and
+the one-line encouragement.
+</step>
+
+</process>

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,9 +32,9 @@ It covers:
 
 <!-- repo-graph-scope:start -->
 
-- `src/gpd/commands/*.md`: `71`
+- `src/gpd/commands/*.md`: `72`
 - `src/gpd/agents/*.md`: `24`
-- `src/gpd/specs/workflows/*.md`: `72`
+- `src/gpd/specs/workflows/*.md`: `73`
 - `src/gpd/specs/templates/**/*.md`: `81`
 - `src/gpd/specs/references/**/*.md`: `241`
 - `src/gpd/adapters/*.py`: `15`
@@ -67,7 +67,7 @@ Excluded as noise from node counting, but still modeled where contractually rele
 Prompt stem inventory:
 
 <!-- repo-graph-prompt-stem-inventory:start -->
-- Same-stem command/workflow prompt stems: `69`
+- Same-stem command/workflow prompt stems: `70`
 - Command-only prompt stems: `health`, `suggest-next`
 - Workflow-only prompt stems: `execute-plan`, `transition`, `verify-phase`
 <!-- repo-graph-prompt-stem-inventory:end -->
@@ -565,7 +565,7 @@ flowchart TD
   Canonical parser for agent prompt definitions.
 
 <!-- repo-graph-same-stem-command-workflow:start -->
-- `src/gpd/commands/{add-phase,add-todo,arxiv-submission,audit-milestone,autonomous,branch-hypothesis,check-todos,compact-state,compare-branches,compare-experiment,compare-results,complete-milestone,debug,decisions,derive-equation,digest-knowledge,dimensional-analysis,discover,discuss-phase,error-patterns,error-propagation,execute-phase,explain,export,export-logs,graph,help,insert-phase,limiting-cases,list-phase-assumptions,literature-review,map-research,merge-phases,new-milestone,new-project,numerical-convergence,parameter-sweep,pause-work,peer-review,plan-milestone-gaps,plan-phase,progress,quick,reapply-patches,record-backtrack,record-insight,regression-check,remove-phase,research-phase,respond-to-referees,resume-work,review-knowledge,revise-phase,route,sensitivity-analysis,set-profile,set-tier-models,settings,show-phase,slides,start,sync-state,tangent,tour,undo,update,validate-conventions,verify-work,write-paper}.md -> src/gpd/specs/workflows/{same stems}.md`
+- `src/gpd/commands/{add-phase,add-todo,arxiv-submission,audit-milestone,autonomous,branch-hypothesis,check-todos,compact-state,compare-branches,compare-experiment,compare-results,complete-milestone,debug,decisions,derive-equation,digest-knowledge,dimensional-analysis,discover,discuss-phase,error-patterns,error-propagation,execute-phase,explain,export,export-logs,graph,help,insert-phase,limiting-cases,list-phase-assumptions,literature-review,map-research,merge-phases,new-milestone,new-project,numerical-convergence,parameter-sweep,pause-work,peer-review,plan-milestone-gaps,plan-phase,progress,quick,reapply-patches,record-backtrack,record-insight,regression-check,remove-phase,research-phase,respond-to-referees,resume-work,review-knowledge,revise-phase,route,sensitivity-analysis,set-profile,set-tier-models,settings,show-phase,slides,start,sync-state,tangent,tour,undo,update,validate-conventions,verify-work,write-paper,zen}.md -> src/gpd/specs/workflows/{same stems}.md`
 <!-- repo-graph-same-stem-command-workflow:end -->
   `include`
   Explicit same-stem command-to-workflow includes are node-level edges, not just an aggregate count.

--- a/tests/adapters/test_runtime_projection_diagnostics_budget.py
+++ b/tests/adapters/test_runtime_projection_diagnostics_budget.py
@@ -36,7 +36,7 @@ COMMAND_ONLY_RUNTIME_PRESSURE_BUDGETS = {
     "codex": {
         "shell_fence_count": 31,
         "shell_rewrite_count": 31,
-        "bridge_command_occurrences": 245,
+        "bridge_command_occurrences": 246,
         "runtime_note_count": 2,
     },
     "copilot-cli": {

--- a/tests/core/test_command_prompt_budget.py
+++ b/tests/core/test_command_prompt_budget.py
@@ -97,6 +97,7 @@ COMMAND_BASELINES = {
     "validate-conventions": (271, 10_556, 1),
     "verify-work": (228, 8_001, 1),
     "write-paper": (332, 14_789, 1),
+    "zen": (64, 2_013, 1),
 }
 WORST_COMMAND_HARD_CAPS = {
     "compare-experiment": (540, 22_500),
@@ -197,6 +198,7 @@ WORKFLOW_BASELINES = {
     "verify-phase": (377, 20_313, 0),
     "verify-work": (16, 755, 0),
     "write-paper": (31, 1_661, 0),
+    "zen": (36, 1_371, 0),
 }
 WORST_WORKFLOW_HARD_CAPS = {
     "verify-phase": (720, 44_000),

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -19,9 +19,9 @@
     "dist"
   ],
   "scope_counts": {
-    "`src/gpd/commands/*.md`": 71,
+    "`src/gpd/commands/*.md`": 72,
     "`src/gpd/agents/*.md`": 24,
-    "`src/gpd/specs/workflows/*.md`": 72,
+    "`src/gpd/specs/workflows/*.md`": 73,
     "`src/gpd/specs/templates/**/*.md`": 81,
     "`src/gpd/specs/references/**/*.md`": 241,
     "`src/gpd/adapters/*.py`": 15,
@@ -101,7 +101,8 @@
       "update",
       "validate-conventions",
       "verify-work",
-      "write-paper"
+      "write-paper",
+      "zen"
     ],
     "command_only_stems": [
       "health",


### PR DESCRIPTION
## What

Adds a small, intentionally-light `gpd:zen` slash command (plus its same-stem workflow spec) that prints one short, read-only physics-research koan and takes no action — a projectless palate-cleanser between tasks.

## Changes

- `src/gpd/commands/zen.md`, `src/gpd/specs/workflows/zen.md` — new command + same-stem workflow (read-only, `context_mode: projectless`, `file_read` only).
- `src/gpd/registry.py` — map `gpd-zen` to the `help` skill category.
- Regenerated surfaces: help workflow + detailed-command-reference markers, repo-graph contract, and `tests/README.md` same-stem block.
- Prompt-budget baselines for the new command/workflow, and a +1 bump to the codex command-projection advisory budget (structural, from adding one command surface).

## Tests

Full suite green: `12952 passed, 14 skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `gpd:zen` command—a read-only starter command that prints a short physics-research zen koan to reset focus. Supports an optional mood word argument to tailor the output.

* **Documentation**
  * Updated command reference and help workflows to document the new zen command and its usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->