### PR TITLE
Executed numeric-oracle verification (blind, numbers-vs-numbers)

### DIFF
--- a/infra/gpd-compute.json
+++ b/infra/gpd-compute.json
@@ -1,0 +1,38 @@
+{
+  "name": "gpd-compute",
+  "description": "Optional no-network numeric oracle for executed verification. Evaluates agent-authored expressions or evaluators at caller-supplied sample points in a sandboxed mpmath/numpy runtime with a timeout, and returns a stable content hash of the executed source. No network access and no API keys; deterministic by design.",
+  "transport": "stdio",
+  "command": "gpd-mcp-compute",
+  "args": [],
+  "env": {},
+  "capabilities": [
+    "evaluate_expression",
+    "evaluator_hash",
+    "probe_capability",
+    "describe_runtime"
+  ],
+  "registry_prefix": "gpd_compute",
+  "prerequisites": [
+    "Install GPD before enabling built-in MCP servers.",
+    "Install the gpd-compute package in the same environment before enabling gpd-compute."
+  ],
+  "health_check": {
+    "probe_kind": "schema_valid",
+    "tool": "describe_runtime",
+    "input": {},
+    "expect": "no_network is true"
+  },
+  "alternatives": {
+    "python_module": {
+      "command": "${GPD_PYTHON}",
+      "args": [
+        "-m",
+        "gpd.mcp.servers.compute_bridge"
+      ],
+      "notes": "Replace `${GPD_PYTHON}` with a Python >=3.11 interpreter that has GPD installed."
+    }
+  },
+  "optional": true,
+  "availability": "conditional",
+  "availability_condition": "Available only when the optional Python module 'gpd_compute' is installed."
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ arxiv = [
     "cairosvg>=2.7.0",
     "pypdf>=5.0",
 ]
+# NOTE: a `compute` extra pinning the standalone `gpd-compute` package is added
+# once that package is published to PyPI. Until then the gpd-compute MCP server
+# is gated purely by `module_check` (it is advertised only when the user has
+# installed gpd-compute into the environment), which keeps uv.lock solvable.
 
 [project.scripts]
 gpd = "gpd.cli:entrypoint"
@@ -71,6 +75,7 @@ gpd = "gpd.cli:entrypoint"
 "gpd-mcp-errors" = "gpd.mcp.servers.errors_mcp:main"
 "gpd-mcp-patterns" = "gpd.mcp.servers.patterns_server:main"
 "gpd-mcp-arxiv" = "gpd.mcp.servers.arxiv_bridge:main"
+"gpd-mcp-compute" = "gpd.mcp.servers.compute_bridge:main"
 "gpd-mcp-wolfram" = "gpd.mcp.integrations.wolfram_bridge:main"
 "gpd-mcp-state" = "gpd.mcp.servers.state_server:main"
 "gpd-mcp-skills" = "gpd.mcp.servers.skills_server:main"

--- a/src/gpd/agents/gpd-blind-deriver.md
+++ b/src/gpd/agents/gpd-blind-deriver.md
@@ -1,0 +1,72 @@
+---
+name: gpd-blind-deriver
+description: Independently computes a single physics quantity from the problem statement and ConventionLock only, evaluates it via the gpd-compute oracle, and returns values, an evaluator content hash, and a typed restatement. Never sees the claimed answer or derivation.
+tools: mcp__gpd_compute__probe_capability, mcp__gpd_compute__evaluate_expression, mcp__gpd_compute__evaluator_hash, mcp__gpd_compute__describe_runtime
+commit_authority: orchestrator
+surface: internal
+role_family: verification
+artifact_write_authority: read_only
+shared_state_authority: return_only
+color: cyan
+---
+
+<role>
+You independently compute ONE physics quantity so a verifier can compare your numbers against a claim's numbers. You are deliberately BLIND: you are given only the problem statement and the project ConventionLock. You are NOT given, and must never ask for, the claimed answer, the derivation, STATE.md, the verification report, or any prior result. Your job is not to agree — it is to derive the quantity from scratch and report what you actually computed.
+
+Your only tools are the gpd-compute oracle tools. You have no file, shell, search, or web access by design. If you find yourself needing the claimed answer to proceed, that is a signal the quantity is not independently checkable — return `no_oracle_yet` rather than guessing.
+</role>
+
+<blinding_contract>
+In context, you have ONLY:
+- the problem statement (the physical setup and the target quantity), and
+- the ConventionLock (metric signature, Fourier convention, gauge, normalization, etc.).
+
+You must NOT use or request: the claimed final answer, the candidate derivation, STATE.md, VERIFICATION.md, prior verifier output, or pre-computed expected values at the sample points. Compute the quantity yourself under the locked conventions.
+</blinding_contract>
+
+<process>
+1. Restate the target as a `TypedRestatement`: the observable id (echo the contracted observable id you were given), its kind (scalar / curve / integral / special_function / asymptotic / dimensionless / ...), and a one-line statement of exactly what quantity you will compute, expressed under the ConventionLock.
+2. Call `probe_capability` with that restatement. If it returns `no_oracle_yet`, stop and return that status with the reason — do not fabricate an evaluator.
+3. Independently construct a numeric evaluator for the quantity:
+   - Prefer `kind: "expression"` with `declared_inputs` naming the symbols, e.g. a closed form, a definite integral (`quad(...)`), a special-function expression, or a dimensionless ratio.
+   - Compute under the user's ConventionLock (signs, factors of 2pi, normalizations). Do not silently switch conventions.
+4. Choose at least 20 sample points spanning the relevant regime (include a limiting-case ladder when the quantity has an asymptotic or boundary regime). Use the same input symbols the verifier will use.
+5. Call `evaluate_expression(submission, sample_points, precision)`. If it rejects or returns `no_oracle_yet`, return that verbatim.
+6. Return the envelope verbatim. Do not adjust your numbers to match anything — there is nothing to match against in your context.
+</process>
+
+<return_contract>
+First emit the oracle payload as a body block (the verifier reads it from your message), then close with a minimal `gpd_return` envelope.
+
+Body block:
+
+```yaml
+blind_oracle:
+  restatement:
+    observable_id: "<contracted observable id you were given>"
+    observable_kind: "<scalar|curve|integral|special_function|asymptotic|dimensionless|...>"
+    statement: "<one line: exactly what you computed, under the ConventionLock>"
+  sample_points:
+    - { label: "p0", bindings: { "<sym>": "<value>" } }
+    # ... >= 20 points
+  values:
+    - { label: "p0", value: "<decimal string>", real: <float>, imag: <float> }
+    # ... one per sample point
+  evaluator_hash: "sha256:<...>"       # from gpd-compute; the verifier re-confirms it
+  capability_class: "<from probe_capability / evaluate_expression>"
+  oracle_status: "evaluated"            # or no_oracle_yet / rejected
+  runtime: { version: "<...>", no_network: true }
+```
+
+Return envelope (machine-read by the orchestrator):
+
+```yaml
+gpd_return:
+  status: completed        # or blocked / checkpoint
+  files_written: []        # you never write files
+  issues: []
+  next_actions: []
+```
+
+If `oracle_status` is `no_oracle_yet` or `rejected`, still emit the body block with empty `values` and the reason in `statement`; the verifier will record INCONCLUSIVE. Never emit a value without a backing `evaluator_hash`.
+</return_contract>

--- a/src/gpd/agents/gpd-verifier.md
+++ b/src/gpd/agents/gpd-verifier.md
@@ -1,7 +1,7 @@
 ---
 name: gpd-verifier
 description: Verifies phase goals with direct physics checks, decisive comparisons, and a canonical VERIFICATION.md report.
-tools: file_read, file_write, shell, search_files, find_files, web_search, web_fetch, mcp__gpd_verification__get_bundle_checklist, mcp__gpd_verification__suggest_contract_checks, mcp__gpd_verification__run_contract_check
+tools: file_read, file_write, shell, search_files, find_files, web_search, web_fetch, task, mcp__gpd_verification__get_bundle_checklist, mcp__gpd_verification__suggest_contract_checks, mcp__gpd_verification__run_contract_check, mcp__gpd_compute__evaluate_expression, mcp__gpd_compute__evaluator_hash, mcp__gpd_compute__probe_capability
 commit_authority: orchestrator
 surface: internal
 role_family: verification
@@ -186,6 +186,8 @@ Execute or re-derive at least one decisive physics check for the artifact: subst
 
 Record the code, actual output, and PASS/FAIL/INCONCLUSIVE verdict in VERIFICATION.md.
 
+For a decisive quantitative claim with a contracted observable, prefer a blind numbers-vs-numbers check (`gpd-blind-deriver` + `contract.numeric_oracle_agreement`) over re-deriving from the stated result, which anchors you. See `{GPD_INSTALL_DIR}/references/verification/core/blind-oracle-subprotocol.md`.
+
 ### Level 4: Integration
 
 Confirm the artifact is integrated with the phase goal, contract target, convention lock, dependencies, and downstream references. A correct-looking artifact still fails this level if it proves the wrong claim, uses the wrong convention, or cannot be tied to the declared contract target.
@@ -224,7 +226,7 @@ Use the verification-report helper to serialize the gap ledger for `gpd:plan-pha
 
 ## Computational Oracle Gate (HARD REQUIREMENT)
 
-VERIFICATION.md is incomplete without at least one actually executed computational oracle block: executed `python`/`bash`/CAS code, actual output, and a PASS/FAIL/INCONCLUSIVE verdict based on that output. If the report lacks this evidence, do not return `status: completed`; run a numerical spot-check, limiting-case evaluation, dimensional trace, or convergence test first.
+VERIFICATION.md is incomplete without at least one actually executed computational oracle block: executed `python`/`bash`/CAS code, actual output, and a PASS/FAIL/INCONCLUSIVE verdict based on that output. A GREEN `contract.numeric_oracle_agreement` check (the blind oracle sub-protocol) satisfies this gate; INCONCLUSIVE shows the gate ran but never counts as a pass. If the report lacks this evidence, do not return `status: completed`; run the blind oracle check, a numerical spot-check, limiting-case evaluation, dimensional trace, or convergence test first.
 
 If code execution is unavailable, document static-analysis mode, cap confidence at MEDIUM, and leave decisive execution checks deferred rather than independently confirmed. Still attempt execution before declaring it unavailable.
 
@@ -285,6 +287,8 @@ gpd_return:
   score: "3/3"
   confidence: HIGH
 ```
+
+When the blind oracle sub-protocol runs, record its GREEN/INCONCLUSIVE verdict (hashes, points compared, fidelity) as executed evidence in the VERIFICATION.md body, not in this return envelope.
 
 Local file gate: the return file list is fail-closed; include only files that genuinely landed on disk in this run. A completed verifier return may include `${phase_dir}/${phase_number}-VERIFICATION.md` only after the canonical report passes frontmatter and contract validation. If a draft report still fails validation, leave it as invalid evidence, return blocked outside the report artifact, and do not list it as completed. Non-completed returns may use `[]` unless a partial verification artifact was truly written and verified on disk.
 

--- a/src/gpd/contracts.py
+++ b/src/gpd/contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -1875,13 +1876,21 @@ class ContractObservable(BaseModel):
     definition: str
     regime: str | None = None
     units: str | None = None
+    # Optional numeric-oracle binding: how this observable should be sampled and
+    # compared when an executed numeric-oracle check (contract.numeric_oracle_agreement)
+    # diffs a blind re-derivation against the claim's evaluator. All optional so
+    # existing contracts validate unchanged.
+    numeric_tolerance: float | None = None
+    min_shared_points: int | None = None
+    sample_point_schema: dict[str, str] | None = None
+    evaluator_role_hint: str | None = None
 
     @field_validator("id", "name", "definition", mode="before")
     @classmethod
     def _normalize_required_fields(cls, value: object) -> object:
         return _normalize_required_str(value)
 
-    @field_validator("regime", "units", mode="before")
+    @field_validator("regime", "units", "evaluator_role_hint", mode="before")
     @classmethod
     def _normalize_optional_fields(cls, value: object) -> object:
         return _normalize_non_empty_optional_str(value)
@@ -1890,6 +1899,24 @@ class ContractObservable(BaseModel):
     @classmethod
     def _normalize_kind(cls, value: object) -> object:
         return _normalize_literal_choice(_normalize_required_str(value), CONTRACT_OBSERVABLE_KIND_VALUES)
+
+    @field_validator("numeric_tolerance")
+    @classmethod
+    def _validate_numeric_tolerance(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError("numeric_tolerance must be a positive finite number")
+        return value
+
+    @field_validator("min_shared_points")
+    @classmethod
+    def _validate_min_shared_points(cls, value: int | None) -> int | None:
+        if value is None:
+            return None
+        if value < 1:
+            raise ValueError("min_shared_points must be at least 1")
+        return value
 
 
 class ContractClaim(BaseModel):

--- a/src/gpd/core/config.py
+++ b/src/gpd/core/config.py
@@ -176,6 +176,13 @@ MODEL_PROFILES: dict[str, dict[str, ModelTier]] = {
         "review": ModelTier.TIER_1,
         "paper-writing": ModelTier.TIER_2,
     },
+    "gpd-blind-deriver": {
+        "deep-theory": ModelTier.TIER_1,
+        "numerical": ModelTier.TIER_1,
+        "exploratory": ModelTier.TIER_2,
+        "review": ModelTier.TIER_1,
+        "paper-writing": ModelTier.TIER_2,
+    },
     "gpd-plan-checker": {
         "deep-theory": ModelTier.TIER_2,
         "numerical": ModelTier.TIER_2,

--- a/src/gpd/core/numeric_oracle.py
+++ b/src/gpd/core/numeric_oracle.py
@@ -1,0 +1,392 @@
+"""Deterministic numeric-oracle verification primitives.
+
+This module is the engine-side half of GPD's executed numeric-oracle
+verification. It performs ONLY deterministic bookkeeping: it compares numbers
+that an agent obtained by calling the separate ``gpd-compute`` MCP tool and
+content-addresses the resulting verdict. It makes no LLM calls and no network
+or oracle calls of its own.
+
+The verification model is "numbers vs numbers":
+
+- A *blind* re-deriver (which never sees the claimed answer) authors an
+  independent evaluator and evaluates it at shared sample points.
+- The claim's own evaluator is evaluated at the same points.
+- This module diffs the two numeric vectors and emits a tri-state verdict:
+
+  * ``GREEN`` — every shared usable point agrees within tolerance, the blind
+    agent's typed restatement matches the contracted observable, and both
+    sides carry a backing executed-cell hash.
+  * ``RED`` — the two evaluators disagree beyond tolerance (a real conflict).
+  * ``INCONCLUSIVE`` — the oracle could not decide: a missing backing
+    evaluator-cell hash (anti-fabrication), fewer than the required number of
+    shared usable points, or a proposition-fidelity mismatch (the blind agent
+    computed a different quantity than the contracted observable).
+
+The kernel ``Result`` type stays binary (Pass/Fail); the tri-state lives here
+and is surfaced one layer up (the contract-check ``status``). This mirrors
+``reproducibility.py`` and reuses the shared content-addressing kernel.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+)
+
+from gpd.core.kernel import Fail, Pass, RegistryBase
+from gpd.core.kernel import run as run_kernel
+
+__all__ = [
+    "EvaluatorCell",
+    "TypedRestatement",
+    "SamplePointEvaluation",
+    "NumericOracleComparison",
+    "NumericOracleVerdict",
+    "NumericOracleRegistry",
+    "compare_numeric_oracle",
+    "build_numeric_oracle_kernel_verdict",
+    "DEFAULT_MIN_SHARED_POINTS",
+]
+
+_HASH_HEX_RE = re.compile(r"[0-9a-f]{64}")
+_STRICT_FROZEN_MODEL_CONFIG = ConfigDict(frozen=True, extra="forbid")
+
+#: The default minimum number of shared, usable sample points required before a
+#: numeric agreement can be scored GREEN. Fewer than this is INCONCLUSIVE.
+DEFAULT_MIN_SHARED_POINTS = 20
+
+
+def _coerce_optional_number(value: object) -> float | None:
+    """Coerce a per-point evaluation value to ``float`` or ``None``.
+
+    Rejects booleans and strings so a fabricated/ill-typed value cannot slip
+    through the comparison as a number.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("evaluation value must be a number, not a bool")
+    if isinstance(value, int | float):
+        return float(value)
+    raise ValueError("evaluation value must be a number or null")
+
+
+class EvaluatorCell(BaseModel):
+    """Provenance for one executed evaluator (claim-side or blind-side).
+
+    The ``content_hash`` is the stable hash of the evaluator source that
+    ``gpd-compute`` actually executed. Its presence is the anti-fabrication
+    leg: numbers without a backing executed-cell hash are not accepted.
+    """
+
+    model_config = _STRICT_FROZEN_MODEL_CONFIG
+
+    evaluator_id: str
+    content_hash: str
+    role: Literal["claim", "blind"]
+
+    @field_validator("content_hash", mode="before")
+    @classmethod
+    def _normalize_hash(cls, value: object) -> object:
+        if not isinstance(value, str):
+            raise ValueError("content_hash must be a string")
+        raw = value.strip().lower()
+        hexpart = raw[len("sha256:") :] if raw.startswith("sha256:") else raw
+        if not _HASH_HEX_RE.fullmatch(hexpart):
+            raise ValueError("content_hash must be a sha256 hex digest")
+        return f"sha256:{hexpart}"
+
+    @field_validator("evaluator_id")
+    @classmethod
+    def _non_empty_id(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("evaluator_id cannot be empty")
+        return value
+
+
+class TypedRestatement(BaseModel):
+    """The blind agent's typed restatement of WHAT quantity it computed.
+
+    The proposition-fidelity guard compares this against the contracted
+    observable so numeric agreement on the *wrong* quantity cannot pass GREEN.
+    """
+
+    model_config = _STRICT_FROZEN_MODEL_CONFIG
+
+    observable_id: str
+    observable_kind: str
+    statement: str
+
+    @field_validator("observable_id", "observable_kind", "statement")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("field cannot be empty")
+        return value
+
+
+class SamplePointEvaluation(BaseModel):
+    """One shared sample point with the value from each evaluator."""
+
+    model_config = _STRICT_FROZEN_MODEL_CONFIG
+
+    point_index: int
+    sample_point: dict[str, str] = Field(default_factory=dict)
+    claim_value: float | None = None
+    blind_value: float | None = None
+
+    @field_validator("claim_value", "blind_value", mode="before")
+    @classmethod
+    def _coerce_values(cls, value: object) -> float | None:
+        return _coerce_optional_number(value)
+
+
+class NumericOracleComparison(BaseModel):
+    """The full input to a numeric-oracle comparison.
+
+    Carries the two evaluators' provenance, the per-point numbers obtained from
+    ``gpd-compute``, the tolerance, and the blind agent's typed restatement
+    plus the contracted observable to check fidelity against.
+    """
+
+    model_config = _STRICT_FROZEN_MODEL_CONFIG
+
+    contracted_observable_id: str
+    contracted_observable_kind: str | None = None
+    typed_restatement: TypedRestatement
+    tolerance: float
+    min_shared_points: int = DEFAULT_MIN_SHARED_POINTS
+    sample_points: list[SamplePointEvaluation] = Field(default_factory=list)
+    claim_cell: EvaluatorCell | None = None
+    blind_cell: EvaluatorCell | None = None
+
+    @field_validator("contracted_observable_id")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        if not value.strip():
+            raise ValueError("contracted_observable_id cannot be empty")
+        return value
+
+    @field_validator("tolerance")
+    @classmethod
+    def _positive_tolerance(cls, value: float) -> float:
+        if not math.isfinite(value) or value <= 0:
+            raise ValueError("tolerance must be a positive finite number")
+        return value
+
+    @field_validator("min_shared_points")
+    @classmethod
+    def _positive_min_points(cls, value: int) -> int:
+        if value < 1:
+            raise ValueError("min_shared_points must be at least 1")
+        return value
+
+
+class NumericOracleVerdict(BaseModel):
+    """The deterministic tri-state outcome of a numeric-oracle comparison."""
+
+    model_config = _STRICT_FROZEN_MODEL_CONFIG
+
+    verdict: Literal["GREEN", "INCONCLUSIVE", "RED"]
+    reason: str
+    both_cells_present: bool
+    fidelity_ok: bool
+    agreeing_points: int
+    total_shared_points: int
+    min_shared_points: int
+    tolerance: float
+    max_abs_diff: float | None = None
+    worst_point_index: int | None = None
+
+
+def compare_numeric_oracle(comparison: NumericOracleComparison) -> NumericOracleVerdict:
+    """Deterministically compare claim-side vs blind-side numbers.
+
+    Pure and fail-closed: returns INCONCLUSIVE on any undecidable condition
+    (missing backing hash, fidelity mismatch, insufficient shared points),
+    GREEN only on full agreement, RED on genuine numeric disagreement.
+    """
+    both_cells_present = comparison.claim_cell is not None and comparison.blind_cell is not None
+
+    fidelity_ok = (
+        comparison.typed_restatement.observable_id == comparison.contracted_observable_id
+        and (
+            comparison.contracted_observable_kind is None
+            or comparison.typed_restatement.observable_kind == comparison.contracted_observable_kind
+        )
+    )
+
+    usable: list[tuple[int, float]] = []
+    for point in comparison.sample_points:
+        claim_value = point.claim_value
+        blind_value = point.blind_value
+        if claim_value is None or blind_value is None:
+            continue
+        if not (math.isfinite(claim_value) and math.isfinite(blind_value)):
+            continue
+        usable.append((point.point_index, abs(claim_value - blind_value)))
+
+    total_shared = len(usable)
+    agreeing = sum(1 for _, diff in usable if diff <= comparison.tolerance)
+    max_abs_diff = max((diff for _, diff in usable), default=None)
+    worst_point_index = max(usable, key=lambda item: item[1])[0] if usable else None
+
+    def _verdict(verdict: str, reason: str) -> NumericOracleVerdict:
+        return NumericOracleVerdict(
+            verdict=verdict,
+            reason=reason,
+            both_cells_present=both_cells_present,
+            fidelity_ok=fidelity_ok,
+            agreeing_points=agreeing,
+            total_shared_points=total_shared,
+            min_shared_points=comparison.min_shared_points,
+            tolerance=comparison.tolerance,
+            max_abs_diff=max_abs_diff,
+            worst_point_index=worst_point_index,
+        )
+
+    # Anti-fabrication: every accepted number must carry a backing executed-cell hash.
+    if not both_cells_present:
+        missing = "claim" if comparison.claim_cell is None else "blind"
+        if comparison.claim_cell is None and comparison.blind_cell is None:
+            missing = "claim and blind"
+        return _verdict(
+            "INCONCLUSIVE",
+            f"missing backing executed-cell hash for the {missing} evaluator",
+        )
+
+    # Proposition fidelity: the blind agent must have computed the contracted quantity.
+    if not fidelity_ok:
+        return _verdict(
+            "INCONCLUSIVE",
+            "blind restatement does not match the contracted observable "
+            f"(restated {comparison.typed_restatement.observable_id!r}/"
+            f"{comparison.typed_restatement.observable_kind!r} vs contracted "
+            f"{comparison.contracted_observable_id!r}/{comparison.contracted_observable_kind!r})",
+        )
+
+    # Sufficiency: enough shared usable points to be decisive.
+    if total_shared < comparison.min_shared_points:
+        return _verdict(
+            "INCONCLUSIVE",
+            f"only {total_shared} shared usable sample points "
+            f"(need >= {comparison.min_shared_points})",
+        )
+
+    # Agreement.
+    if agreeing == total_shared:
+        return _verdict(
+            "GREEN",
+            f"all {total_shared} shared points agree within tolerance {comparison.tolerance:g}",
+        )
+    return _verdict(
+        "RED",
+        f"{total_shared - agreeing}/{total_shared} shared points disagree beyond "
+        f"tolerance {comparison.tolerance:g} (max abs diff {max_abs_diff:g} at point "
+        f"{worst_point_index})",
+    )
+
+
+class NumericOracleRegistry(RegistryBase):
+    """Kernel-compatible registry wrapper for a numeric-oracle comparison."""
+
+    def __init__(
+        self,
+        comparison: NumericOracleComparison,
+        verdict: NumericOracleVerdict,
+        raw_bytes: bytes,
+    ) -> None:
+        super().__init__(raw_bytes)
+        self.comparison = comparison
+        self.verdict = verdict
+
+    @classmethod
+    def from_comparison(cls, comparison: NumericOracleComparison) -> NumericOracleRegistry:
+        verdict = compare_numeric_oracle(comparison)
+        payload = comparison.model_dump(mode="json")
+        raw_bytes = json.dumps(
+            payload,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+        return cls(comparison=comparison, verdict=verdict, raw_bytes=raw_bytes)
+
+    def stats(self) -> dict[str, int]:
+        return {
+            "sample_points": len(self.comparison.sample_points),
+            "shared_usable_points": self.verdict.total_shared_points,
+            "agreeing_points": self.verdict.agreeing_points,
+        }
+
+
+def build_numeric_oracle_kernel_verdict(
+    comparison: NumericOracleComparison,
+    *,
+    generated_at: datetime | None = None,
+) -> dict[str, object]:
+    """Build a content-addressed kernel verdict for a numeric-oracle comparison.
+
+    The kernel ``overall`` is ``PASS`` exactly when the comparison is GREEN
+    (both cells present, fidelity matched, enough points, full agreement). The
+    richer tri-state is attached under ``numeric_oracle_verdict`` for the
+    contract-check layer to map onto its ``status`` (GREEN -> pass,
+    RED -> fail, INCONCLUSIVE -> insufficient_evidence).
+    """
+    registry = NumericOracleRegistry.from_comparison(comparison)
+
+    def both_cells_present(reg: RegistryBase) -> object:
+        if not isinstance(reg, NumericOracleRegistry):
+            return Fail("numeric oracle registry type mismatch")
+        if reg.verdict.both_cells_present:
+            return Pass("both evaluators carry a backing executed-cell hash")
+        return Fail("missing a backing executed-cell hash (anti-fabrication)")
+
+    def sufficient_sample_points(reg: RegistryBase) -> object:
+        if not isinstance(reg, NumericOracleRegistry):
+            return Fail("numeric oracle registry type mismatch")
+        shared = reg.verdict.total_shared_points
+        required = reg.comparison.min_shared_points
+        if shared >= required:
+            return Pass(f"{shared} shared usable points (>= {required})")
+        return Fail(f"only {shared} shared usable points (need >= {required})")
+
+    def proposition_fidelity(reg: RegistryBase) -> object:
+        if not isinstance(reg, NumericOracleRegistry):
+            return Fail("numeric oracle registry type mismatch")
+        if reg.verdict.fidelity_ok:
+            return Pass("blind restatement matches the contracted observable")
+        return Fail("blind restatement does not match the contracted observable")
+
+    def numbers_agree(reg: RegistryBase) -> object:
+        if not isinstance(reg, NumericOracleRegistry):
+            return Fail("numeric oracle registry type mismatch")
+        shared = reg.verdict.total_shared_points
+        agreeing = reg.verdict.agreeing_points
+        if shared > 0 and agreeing == shared:
+            return Pass(f"all {shared} shared points agree within tolerance")
+        return Fail(reg.verdict.reason)
+
+    verdict_dict = run_kernel(
+        registry,
+        {
+            "both_cells_present": both_cells_present,
+            "sufficient_sample_points": sufficient_sample_points,
+            "proposition_fidelity": proposition_fidelity,
+            "numbers_agree": numbers_agree,
+        },
+        predicates_source=Path(__file__),
+        generated_at=generated_at,
+    )
+    verdict_dict["numeric_oracle_verdict"] = registry.verdict.model_dump(mode="json")
+    return verdict_dict

--- a/src/gpd/core/verification_checks.py
+++ b/src/gpd/core/verification_checks.py
@@ -60,6 +60,7 @@ class VerificationCheckDef(BaseModel):
         "contract_proof_quantifier_domain",
         "contract_claim_to_proof_alignment",
         "contract_counterexample_search",
+        "contract_numeric_oracle_agreement",
     ] = "universal"
     contract_aware: bool = False
     binding_targets: list[
@@ -348,6 +349,19 @@ VERIFICATION_CHECK_DEFS: tuple[VerificationCheckDef, ...] = (
         check_class="contract_counterexample_search",
         contract_aware=True,
         binding_targets=["observable", "claim", "deliverable", "acceptance_test"],
+    ),
+    VerificationCheckDef(
+        check_id="5.25",
+        check_key="contract.numeric_oracle_agreement",
+        name="Numeric-oracle agreement",
+        description="Confirm an independent blind re-derivation agrees numerically with the claim's evaluator at the required number of shared sample points, with a matching typed restatement and backing executed-cell hashes",
+        tier=1,
+        catches="Fabricated numbers, evaluator drift, proposition substitution, claim-vs-derivation divergence that survives because no independent executed check was run",
+        evidence_kind="computational",
+        oracle_hint="Evaluate both the blind and claim evaluators at the shared sample points via the gpd-compute oracle, then compare returned numbers and evaluator cell hashes deterministically; missing backing hash, fidelity mismatch, or too few shared points are inconclusive, not pass.",
+        check_class="contract_numeric_oracle_agreement",
+        contract_aware=True,
+        binding_targets=["observable", "claim", "acceptance_test"],
     ),
 )
 

--- a/src/gpd/mcp/builtin_servers.py
+++ b/src/gpd/mcp/builtin_servers.py
@@ -17,6 +17,7 @@ from copy import deepcopy
 
 from gpd.mcp.descriptor_text import SKILLS_SERVER_DESCRIPTION
 from gpd.mcp.servers.arxiv_bridge import ADVERTISED_TOOL_NAMES, DOWNLOAD_SOURCE_TOOL_NAME, UPSTREAM_CORE_TOOL_NAMES
+from gpd.mcp.servers.compute_bridge import ADVERTISED_TOOL_NAMES as COMPUTE_ADVERTISED_TOOL_NAMES
 from gpd.mcp.verification_contract_policy import verification_server_description
 
 logger = logging.getLogger(__name__)
@@ -75,11 +76,21 @@ _BUILTIN_SERVERS: dict[str, _ServerDef] = {
         "optional": True,
         "module_check": "arxiv_mcp_server",
     },
+    "gpd-compute": {
+        "command": _PYTHON_COMMAND_SENTINEL,
+        "args": ["-m", "gpd.mcp.servers.compute_bridge"],
+        "env": {},
+        "optional": True,
+        "module_check": "gpd_compute",
+    },
 }
 
 _PUBLIC_BOOTSTRAP_PREREQUISITE = "Install GPD before enabling built-in MCP servers."
 _ARXIV_EXTRA_PREREQUISITE = (
     "Install GPD with the `arxiv` Python extra in the same environment before enabling gpd-arxiv."
+)
+_COMPUTE_EXTRA_PREREQUISITE = (
+    "Install the gpd-compute package in the same environment before enabling gpd-compute."
 )
 _ENTRY_POINT_NOTES = _PYTHON_LAUNCH_NOTES
 _ARXIV_UPSTREAM_CAPABILITIES = list(UPSTREAM_CORE_TOOL_NAMES)
@@ -255,6 +266,26 @@ _PUBLIC_DESCRIPTOR_METADATA: dict[str, dict[str, object]] = {
             "tool": "search_papers",
             "input": {"query": "quantum field theory", "max_results": 1},
             "expect": "contains paper",
+        },
+    },
+    "gpd-compute": {
+        "description": (
+            "Optional no-network numeric oracle for executed verification. Evaluates "
+            "agent-authored expressions or evaluators at caller-supplied sample points in a "
+            "sandboxed mpmath/numpy runtime with a timeout, and returns a stable content hash "
+            "of the executed source. No network access and no API keys; deterministic by design."
+        ),
+        "capabilities": list(COMPUTE_ADVERTISED_TOOL_NAMES),
+        "registry_prefix": "gpd_compute",
+        "prerequisites": [
+            _PUBLIC_BOOTSTRAP_PREREQUISITE,
+            _COMPUTE_EXTRA_PREREQUISITE,
+        ],
+        "health_check": {
+            "probe_kind": "schema_valid",
+            "tool": "describe_runtime",
+            "input": {},
+            "expect": "no_network is true",
         },
     },
 }

--- a/src/gpd/mcp/servers/compute_bridge.py
+++ b/src/gpd/mcp/servers/compute_bridge.py
@@ -1,0 +1,52 @@
+"""GPD-owned bridge for the optional no-network ``gpd-compute`` MCP server.
+
+``gpd-compute`` is a separate public package that provides a sandboxed,
+no-network numeric evaluator (mpmath/numpy) used by GPD's executed
+numeric-oracle verification. This thin bridge launches that package's MCP
+server so GPD can register it as an optional built-in server, exactly as
+``gpd-arxiv`` bridges the optional ``arxiv-mcp-server`` package.
+
+The external package is imported lazily inside :func:`main` so this module stays
+importable for descriptor and metadata introspection even when the optional
+``compute`` extra is not installed. It performs no network access and requires
+no API keys.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("gpd.compute_bridge")
+
+#: Name of the external package this bridge launches. Used as the optional
+#: ``module_check`` so the server is only advertised when the extra is present.
+UPSTREAM_COMPUTE_MODULE = "gpd_compute"
+
+#: Tools advertised by the ``gpd-compute`` MCP server. The public descriptor's
+#: capabilities are derived from this tuple, so it must track the external
+#: package's published tool surface.
+ADVERTISED_TOOL_NAMES: tuple[str, ...] = (
+    "evaluate_expression",
+    "evaluator_hash",
+    "probe_capability",
+    "describe_runtime",
+)
+
+_MISSING_DEPENDENCY_MESSAGE = (
+    "gpd-compute is not installed. Install GPD with the 'compute' extra "
+    "(for example: pip install 'get-physics-done[compute]') to enable the "
+    "gpd-compute MCP server."
+)
+
+
+def main() -> None:
+    """Console entry point: launch the external ``gpd-compute`` MCP server."""
+    try:
+        from gpd_compute.server import main as _compute_main
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise SystemExit(_MISSING_DEPENDENCY_MESSAGE) from exc
+    _compute_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/gpd/mcp/servers/verification_server.py
+++ b/src/gpd/mcp/servers/verification_server.py
@@ -57,6 +57,14 @@ from gpd.core.contract_validation import (
     is_repair_relevant_project_contract_schema_finding,
     split_project_contract_schema_findings,
 )
+from gpd.core.numeric_oracle import (
+    DEFAULT_MIN_SHARED_POINTS,
+    EvaluatorCell,
+    NumericOracleComparison,
+    SamplePointEvaluation,
+    TypedRestatement,
+    build_numeric_oracle_kernel_verdict,
+)
 from gpd.core.observability import gpd_span
 from gpd.core.protocol_bundles import ResolvedProtocolBundle, get_protocol_bundle, render_protocol_bundle_context
 from gpd.core.verification_checks import (
@@ -427,6 +435,18 @@ class ContractMetadataRequest(_ContractRequestBase):
     quantifiers: list[str] | None = None
     conclusion_clause_ids: list[str] | None = None
     claim_statement: str | None = None
+    # Numeric-oracle agreement (contract.numeric_oracle_agreement)
+    contracted_observable_id: str | None = None
+    contracted_observable_kind: str | None = None
+    typed_restatement_observable_id: str | None = None
+    typed_restatement_observable_kind: str | None = None
+    typed_restatement_statement: str | None = None
+    numeric_tolerance: int | float | None = None
+    min_shared_points: int | None = None
+    claim_evaluator_id: str | None = None
+    blind_evaluator_id: str | None = None
+    claim_cell_hash: str | None = None
+    blind_cell_hash: str | None = None
 
 
 class ContractObservedRequest(_ContractRequestBase):
@@ -451,6 +471,11 @@ class ContractObservedRequest(_ContractRequestBase):
     quantifier_status: str | None = None
     scope_status: str | None = None
     counterexample_status: str | None = None
+    # Numeric-oracle agreement (contract.numeric_oracle_agreement): per-point
+    # inputs and the numbers each evaluator returned from the gpd-compute oracle.
+    sample_points: list[dict[str, str]] | None = None
+    claim_values: list[float | None] | None = None
+    blind_values: list[float | None] | None = None
 
 
 class RunContractCheckRequest(_ContractRequestBase):
@@ -736,6 +761,17 @@ _CONTRACT_METADATA_INPUT_SCHEMA: dict[str, object] = _object_schema(
         "quantifiers": _string_list_or_null_schema(),
         "conclusion_clause_ids": _string_list_or_null_schema(),
         "claim_statement": _non_empty_string_or_null_schema(),
+        "contracted_observable_id": _non_empty_string_or_null_schema(),
+        "contracted_observable_kind": _non_empty_string_or_null_schema(),
+        "typed_restatement_observable_id": _non_empty_string_or_null_schema(),
+        "typed_restatement_observable_kind": _non_empty_string_or_null_schema(),
+        "typed_restatement_statement": _non_empty_string_or_null_schema(),
+        "numeric_tolerance": _number_or_null_schema(),
+        "min_shared_points": _number_or_null_schema(),
+        "claim_evaluator_id": _non_empty_string_or_null_schema(),
+        "blind_evaluator_id": _non_empty_string_or_null_schema(),
+        "claim_cell_hash": _non_empty_string_or_null_schema(),
+        "blind_cell_hash": _non_empty_string_or_null_schema(),
     },
     additional_properties=False,
 )
@@ -762,6 +798,21 @@ _CONTRACT_OBSERVED_INPUT_SCHEMA: dict[str, object] = _object_schema(
         "quantifier_status": _enum_string_or_null_schema(_QUANTIFIER_STATUS_VALUES),
         "scope_status": _enum_string_or_null_schema(_SCOPE_STATUS_VALUES),
         "counterexample_status": _enum_string_or_null_schema(_COUNTEREXAMPLE_STATUS_VALUES),
+        "sample_points": {
+            "anyOf": [{"type": "array", "items": {"type": "object"}}, {"type": "null"}]
+        },
+        "claim_values": {
+            "anyOf": [
+                {"type": "array", "items": {"anyOf": [{"type": "number"}, {"type": "null"}]}},
+                {"type": "null"},
+            ]
+        },
+        "blind_values": {
+            "anyOf": [
+                {"type": "array", "items": {"anyOf": [{"type": "number"}, {"type": "null"}]}},
+                {"type": "null"},
+            ]
+        },
     },
     additional_properties=False,
 )
@@ -805,6 +856,10 @@ _CONTRACT_OBSERVABLE_INPUT_SCHEMA: dict[str, object] = _object_schema(
         "definition": _non_empty_string_schema(),
         "regime": _non_empty_string_or_null_schema(),
         "units": _non_empty_string_or_null_schema(),
+        "numeric_tolerance": _number_or_null_schema(),
+        "min_shared_points": _number_or_null_schema(),
+        "sample_point_schema": {"anyOf": [{"type": "object"}, {"type": "null"}]},
+        "evaluator_role_hint": _non_empty_string_or_null_schema(),
     },
     required=("id", "name", "definition"),
     additional_properties=False,
@@ -4148,6 +4203,150 @@ def run_contract_check(request: RunContractCheckPayload, project_dir: OptionalAb
                 ):
                     status = "warning"
                     evidence_directness = "mixed"
+
+            elif check_meta.check_key == "contract.numeric_oracle_agreement":
+                string_fields = {
+                    "contracted_observable_id": metadata.get("contracted_observable_id"),
+                    "contracted_observable_kind": metadata.get("contracted_observable_kind"),
+                    "typed_restatement_observable_id": metadata.get("typed_restatement_observable_id"),
+                    "typed_restatement_observable_kind": metadata.get("typed_restatement_observable_kind"),
+                    "typed_restatement_statement": metadata.get("typed_restatement_statement"),
+                    "claim_evaluator_id": metadata.get("claim_evaluator_id"),
+                    "blind_evaluator_id": metadata.get("blind_evaluator_id"),
+                    "claim_cell_hash": metadata.get("claim_cell_hash"),
+                    "blind_cell_hash": metadata.get("blind_cell_hash"),
+                }
+                parsed_strings: dict[str, str | None] = {}
+                for field_key, field_value in string_fields.items():
+                    parsed_value, field_error = _validate_optional_string(
+                        field_value, field_name=f"metadata.{field_key}"
+                    )
+                    if field_error is not None:
+                        return _error_result(field_error)
+                    parsed_strings[field_key] = parsed_value
+
+                tolerance, error = _validate_number(
+                    metadata.get("numeric_tolerance"), field_name="metadata.numeric_tolerance"
+                )
+                if error is not None:
+                    return error
+
+                min_points_value = metadata.get("min_shared_points")
+                if min_points_value is None:
+                    min_shared_points = DEFAULT_MIN_SHARED_POINTS
+                elif isinstance(min_points_value, bool) or not isinstance(min_points_value, int):
+                    return _error_result("metadata.min_shared_points must be an integer")
+                elif min_points_value < 1:
+                    return _error_result("metadata.min_shared_points must be at least 1")
+                else:
+                    min_shared_points = min_points_value
+
+                sample_points_raw = observed.get("sample_points")
+                claim_values_raw = observed.get("claim_values")
+                blind_values_raw = observed.get("blind_values")
+                for observed_field, observed_value in (
+                    ("observed.sample_points", sample_points_raw),
+                    ("observed.claim_values", claim_values_raw),
+                    ("observed.blind_values", blind_values_raw),
+                ):
+                    if observed_value is not None and not isinstance(observed_value, list):
+                        return _error_result(f"{observed_field} must be a list")
+
+                contracted_observable_id = parsed_strings["contracted_observable_id"]
+                restated_id = parsed_strings["typed_restatement_observable_id"]
+                restated_kind = parsed_strings["typed_restatement_observable_kind"]
+                restated_statement = parsed_strings["typed_restatement_statement"]
+
+                if not contracted_observable_id:
+                    missing_inputs.append("metadata.contracted_observable_id")
+                if not (restated_id and restated_kind and restated_statement):
+                    missing_inputs.append("metadata.typed_restatement_observable_id/kind/statement")
+                if tolerance is None:
+                    missing_inputs.append("metadata.numeric_tolerance")
+                if not sample_points_raw:
+                    missing_inputs.append("observed.sample_points")
+                if claim_values_raw is None:
+                    missing_inputs.append("observed.claim_values")
+                if blind_values_raw is None:
+                    missing_inputs.append("observed.blind_values")
+
+                metrics["contracted_observable_id"] = contracted_observable_id
+                metrics["min_shared_points"] = min_shared_points
+                metrics["tolerance"] = tolerance
+
+                if not missing_inputs:
+                    claim_values = claim_values_raw or []
+                    blind_values = blind_values_raw or []
+                    try:
+                        point_models: list[SamplePointEvaluation] = []
+                        for index, raw_point in enumerate(sample_points_raw or []):
+                            point_map = (
+                                {str(key): str(value) for key, value in raw_point.items()}
+                                if isinstance(raw_point, dict)
+                                else {}
+                            )
+                            point_models.append(
+                                SamplePointEvaluation(
+                                    point_index=index,
+                                    sample_point=point_map,
+                                    claim_value=claim_values[index] if index < len(claim_values) else None,
+                                    blind_value=blind_values[index] if index < len(blind_values) else None,
+                                )
+                            )
+                        claim_cell = (
+                            EvaluatorCell(
+                                evaluator_id=parsed_strings["claim_evaluator_id"] or "claim",
+                                content_hash=parsed_strings["claim_cell_hash"],
+                                role="claim",
+                            )
+                            if parsed_strings["claim_cell_hash"]
+                            else None
+                        )
+                        blind_cell = (
+                            EvaluatorCell(
+                                evaluator_id=parsed_strings["blind_evaluator_id"] or "blind",
+                                content_hash=parsed_strings["blind_cell_hash"],
+                                role="blind",
+                            )
+                            if parsed_strings["blind_cell_hash"]
+                            else None
+                        )
+                        comparison = NumericOracleComparison(
+                            contracted_observable_id=contracted_observable_id,
+                            contracted_observable_kind=parsed_strings["contracted_observable_kind"],
+                            typed_restatement=TypedRestatement(
+                                observable_id=restated_id,
+                                observable_kind=restated_kind,
+                                statement=restated_statement,
+                            ),
+                            tolerance=tolerance,
+                            min_shared_points=min_shared_points,
+                            sample_points=point_models,
+                            claim_cell=claim_cell,
+                            blind_cell=blind_cell,
+                        )
+                    except (PydanticValidationError, ValueError) as exc:
+                        return _error_result(f"invalid numeric-oracle inputs: {exc}")
+
+                    oracle_verdict_dict = build_numeric_oracle_kernel_verdict(comparison)
+                    oracle_verdict = oracle_verdict_dict["numeric_oracle_verdict"]
+                    metrics["numeric_oracle_verdict"] = oracle_verdict
+                    metrics["verdict_hash"] = oracle_verdict_dict["verdict_hash"]
+                    metrics["shared_usable_points"] = oracle_verdict["total_shared_points"]
+                    verdict_label = oracle_verdict["verdict"]
+                    if verdict_label == "GREEN":
+                        status = "pass"
+                        evidence_directness = "direct"
+                    elif verdict_label == "RED":
+                        status = "fail"
+                        evidence_directness = "direct"
+                        automated_issues.append(oracle_verdict["reason"])
+                    else:
+                        status = "insufficient_evidence"
+                        evidence_directness = "metadata_only"
+                        automated_issues.append(oracle_verdict["reason"])
+                        if not oracle_verdict["both_cells_present"]:
+                            missing_inputs.append("metadata.claim_cell_hash/blind_cell_hash")
 
             elif check_meta.check_key == "contract.direct_proxy_consistency":
                 proxy_only, error = _validate_boolean(observed.get("proxy_only"), field_name="observed.proxy_only")

--- a/src/gpd/specs/references/verification/core/blind-oracle-subprotocol.md
+++ b/src/gpd/specs/references/verification/core/blind-oracle-subprotocol.md
@@ -1,0 +1,35 @@
+# Blind Oracle Sub-Protocol
+
+Executed, **numbers-vs-numbers** verification of a decisive quantitative claim. Re-deriving from the artifact's stated result anchors the verifier to the claim; this protocol removes the anchor by having an independent agent compute the quantity blind, then comparing the two number vectors deterministically in the engine. Used by `gpd-verifier` (Level 3) for any decisive quantitative claim that has a contracted observable and a constructible numeric evaluator.
+
+## Roles
+
+- **`gpd-blind-deriver`** — the only agent that authors an *independent* evaluator. It is blinded by tool starvation (its only tools are the `gpd-compute` MCP tools; it has no file/shell/search/web access) and by handoff scoping.
+- **`gpd-compute`** — the optional no-network sandboxed numeric oracle (mpmath/numpy). Pure: source + sample points → values + a content hash of the executed source. No claim awareness.
+- **`gpd-verifier`** — orchestrates: spawns the blind deriver, evaluates the claim side, and calls the engine's deterministic comparator. The engine compares numbers only; it calls no model and no oracle.
+
+## Steps
+
+1. **Spawn the blind deriver.** Spawn `gpd-blind-deriver` (via `task`) passing **only** the problem statement and the ConventionLock from `state.json`. Do **not** pass the artifact's claimed answer, the derivation, `STATE.md`, or the verification report. It returns a `blind_oracle` block: a typed restatement (observable id/kind + one-line statement), the sample points it chose (>= 20, spanning the regime), per-point `values`, and an `evaluator_hash` — or `oracle_status: no_oracle_yet` if no independent evaluator is constructible.
+
+2. **Evaluate the claim side.** Build the claim-side evaluator yourself from the artifact's stated result and evaluate it at the **same** sample points via `mcp__gpd_compute__evaluate_expression`, obtaining claim-side `values` and a claim-side `evaluator_hash`. Re-confirm each side's hash with `mcp__gpd_compute__evaluator_hash` — a value without a verifiable backing executed-cell hash is not accepted (anti-fabrication).
+
+3. **Compare in the engine.** Call `mcp__gpd_verification__run_contract_check` with `check_key: contract.numeric_oracle_agreement`:
+   - `metadata`: `contracted_observable_id`, `contracted_observable_kind`, the blind agent's `typed_restatement_observable_id`/`_kind`/`_statement`, `numeric_tolerance`, `claim_cell_hash`, `blind_cell_hash`.
+   - `observed`: `sample_points`, `claim_values`, `blind_values`.
+   The engine diffs the two vectors at the shared usable points and returns a `status`:
+   - `pass` — **GREEN**: every shared point agrees within tolerance, the blind restatement matches the contracted observable, and both backing hashes are present. Satisfies the Computational Oracle Gate.
+   - `fail` — **RED**: genuine claim-vs-blind numeric disagreement. This is a `gaps_found` issue and enters the planner/checker loop.
+   - `insufficient_evidence` — **INCONCLUSIVE**: a missing backing hash, a proposition-fidelity mismatch (the blind agent computed a different quantity), or fewer than the required shared usable points. Does **not** block and is **not** a pass.
+
+4. **Record the verdict** as the decisive check's executed evidence in `VERIFICATION.md` (verdict, both hashes, points compared, fidelity, capability class).
+
+## Why blinding matters
+
+- **Anti-anchoring:** the blind agent never sees the answer, so agreement is corroboration, not confirmation bias.
+- **Proposition fidelity:** the typed restatement must match the contracted observable, so numeric agreement on the *wrong* quantity cannot pass GREEN.
+- **Anti-fabrication:** every accepted number carries a backing executed-cell hash the verifier independently re-confirms.
+
+## Honest scope
+
+On flagship hep-th workloads (interacting-QFT path integrals, GR-tensor canonicalization, and other classes needing symbolic canonicalization), an independent numeric evaluator often cannot be constructed; `gpd-compute` returns `no_oracle_yet` and the verdict is INCONCLUSIVE. That is intended, honest behavior — record it and fall back to a conventional Level 3 check; never treat `no_oracle_yet` as a failure or paper over it as a pass.

--- a/src/gpd/specs/templates/plan-contract-schema.md
+++ b/src/gpd/specs/templates/plan-contract-schema.md
@@ -161,6 +161,10 @@ Rules:
   definition: "[What quantity or behavior is being established]"
   regime: "large-k"
   units: "dimensionless"
+  numeric_tolerance: 1.0e-6
+  min_shared_points: 20
+  sample_point_schema: { k: "dimensionless" }
+  evaluator_role_hint: "compute the residual F(k) at the sampled k values"
 ```
 
 Rules:
@@ -170,6 +174,7 @@ Rules:
 - `kind: scalar|curve|map|classification|proof_obligation|other`
 - When `kind: proof_obligation`, make `definition` name the theorem/result plus the hypotheses or parameter regime the proof must cover. Do not hide proof scope in body prose alone.
 - `regime` and `units` are optional strings; omit them instead of fabricating placeholders.
+- `numeric_tolerance`, `min_shared_points`, `sample_point_schema`, and `evaluator_role_hint` are optional and only used by the executed numeric-oracle check (`contract.numeric_oracle_agreement`): they declare how a blind re-derivation should be sampled and compared against the claim's evaluator. `numeric_tolerance` is a positive number, `min_shared_points` defaults to 20, `sample_point_schema` maps each input symbol to its units (or `dimensionless`), and `evaluator_role_hint` says what to compute without revealing the answer. Omit them for observables that have no constructible numeric evaluator.
 - Claims may only reference observables that appear in `observables[]`.
 
 ### `deliverables[]`

--- a/src/gpd/specs/workflows/set-profile.md
+++ b/src/gpd/specs/workflows/set-profile.md
@@ -116,7 +116,7 @@ Change cadence with `gpd:settings` or by editing `GPD/config.json` (`execution.r
 
 If you also want to pin concrete runtime model strings for `tier-1`, `tier-2`, or `tier-3`, use `gpd:set-tier-models` for the direct path or `gpd:settings` for the broader unattended/configuration flow. `set-profile` changes the abstract tier assignments, not the runtime-native model IDs.
 
-For full agent tier assignments across all 24 agents, see `references/orchestration/model-profiles.md`.
+For full agent tier assignments across all 25 agents, see `references/orchestration/model-profiles.md`.
 For detailed behavioral effect descriptions per agent per profile, see the "Behavioral Effects" section in `references/orchestration/model-profiles.md`.
 
 Next spawned agents will use the new profile.

--- a/src/gpd/specs/workflows/verify-work/gap-repair.md
+++ b/src/gpd/specs/workflows/verify-work/gap-repair.md
@@ -3,6 +3,8 @@ Plan, check, and close verifier-diagnosed gaps without changing verifier-owned c
 </purpose>
 <philosophy>
 Verifier owns scientific status. This stage turns diagnosed gaps into plans, checks, and records closeout after canonical validation.
+
+An INCONCLUSIVE numeric-oracle verdict (`contract.numeric_oracle_agreement` -> `insufficient_evidence`, including `no_oracle_yet`) is **not** a gap: the physics may be correct, the oracle just could not certify it. Route it to `expert_needed` or suggested checks, never to gap-closure. Only a RED verdict (genuine numeric disagreement) is a `gaps_found` issue for the loop below.
 </philosophy>
 <shared_contract_floor>
 **Project Contract Gate:** {project_contract_gate}

--- a/src/gpd/specs/workflows/verify-work/interactive-validation.md
+++ b/src/gpd/specs/workflows/verify-work/interactive-validation.md
@@ -25,8 +25,12 @@ Display compactly:
 
 **Independent computation:** {computation description and result}
 
+**Oracle verdict:** {oracle_status: PASS | INCONCLUSIVE | (none)} — {sample_points_compared} points, fidelity {matched|mismatch}
+
 Confirm this matches your result, or describe what differs.
 ```
+
+The **Oracle verdict** line is shown only when the verifier recorded a blind oracle check (`contract.numeric_oracle_agreement`) for this check; omit it otherwise. Surface the verifier's recorded verdict verbatim — do not recompute it here.
 
 Present verifier-produced evidence exactly once per check. Do not derive a new physics criterion here.
 

--- a/src/gpd/specs/workflows/verify-work/inventory-build.md
+++ b/src/gpd/specs/workflows/verify-work/inventory-build.md
@@ -55,6 +55,8 @@ For PLAN contracts with project-local anchors or prior-output paths, call `sugge
 
 Spawn `gpd-verifier` once with scoped write. It owns target extraction, evidence mapping, proof policy, checks, decisive comparisons, canonical status, suggested contract checks, and the gap ledger.
 
+For decisive quantitative claims with a contracted observable, instruct the verifier to run its Blind Oracle Sub-Protocol: spawn `gpd-blind-deriver` with only the problem statement and ConventionLock (never the artifact's final answer or derivation), then compare claim-side vs blind-side numbers via `contract.numeric_oracle_agreement`. The blind deriver is a nested, write-nothing spawn — it touches no allowed paths, so it needs no additional spawn-contract scope here. A GREEN oracle verdict satisfies the verifier's Computational Oracle Gate; INCONCLUSIVE (including `no_oracle_yet`) never blocks and is not a pass; RED becomes a `gaps_found` issue.
+
 Pass the project contract, proof freshness summary, reference handles, and protocol bundle handoff fields into the handoff so the verifier can build its own authoritative ledger.
 Point it at `{GPD_INSTALL_DIR}/references/verification/verification-status-authority.md`. Presentation headings are non-authority; route through the verifier tuple plus canonical report status.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,7 +33,7 @@ It covers:
 <!-- repo-graph-scope:start -->
 
 - `src/gpd/commands/*.md`: `71`
-- `src/gpd/agents/*.md`: `24`
+- `src/gpd/agents/*.md`: `25`
 - `src/gpd/specs/workflows/*.md`: `72`
 - `src/gpd/specs/templates/**/*.md`: `81`
 - `src/gpd/specs/references/**/*.md`: `241`
@@ -41,8 +41,8 @@ It covers:
 - `src/gpd/hooks/*.py`: `11`
 - `src/gpd/mcp/*.py`: `5`
 - `src/gpd/mcp/integrations/*.py`: `2`
-- `src/gpd/mcp/servers/*.py`: `15`
-- `infra/gpd-*.json`: `8`
+- `src/gpd/mcp/servers/*.py`: `16`
+- `infra/gpd-*.json`: `9`
 
 Excluded as noise from node counting, but still modeled where contractually relevant:
 

--- a/tests/adapters/projection_budget_support.py
+++ b/tests/adapters/projection_budget_support.py
@@ -46,7 +46,7 @@ STAGED_PROJECTED_COMMAND_CHAR_BUDGET = 20_000
 
 COMPACT_WORKFLOW_REFERENCE_COMMAND_PROJECTION_BUDGETS = {
     "compare-experiment": {
-        "codex": {"chars": 7_700, "lines": 150},
+        "codex": {"chars": 7_750, "lines": 150},
         "copilot-cli": {"chars": 8_000, "lines": 150},
         "gemini": {"chars": 8_400, "lines": 150},
         "opencode": {"chars": 7_950, "lines": 160},

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -81,8 +81,8 @@ class TestEnums:
 
 
 class TestModelProfiles:
-    def test_all_24_agents_present(self):
-        assert len(MODEL_PROFILES) == 24
+    def test_all_25_agents_present(self):
+        assert len(MODEL_PROFILES) == 25
 
     def test_all_agents_have_5_profiles(self):
         profiles = {profile.value for profile in ModelProfile}

--- a/tests/core/test_numeric_oracle.py
+++ b/tests/core/test_numeric_oracle.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from gpd.core.numeric_oracle import (
+    DEFAULT_MIN_SHARED_POINTS,
+    EvaluatorCell,
+    NumericOracleComparison,
+    SamplePointEvaluation,
+    TypedRestatement,
+    build_numeric_oracle_kernel_verdict,
+    compare_numeric_oracle,
+)
+
+_CLAIM_HASH = "sha256:" + "a" * 64
+_BLIND_HASH = "sha256:" + "b" * 64
+_FIXED_TIME = datetime(2026, 6, 4, 12, 0, 0, tzinfo=UTC)
+
+
+def _claim_cell() -> EvaluatorCell:
+    return EvaluatorCell(evaluator_id="claim-eval", content_hash=_CLAIM_HASH, role="claim")
+
+
+def _blind_cell() -> EvaluatorCell:
+    return EvaluatorCell(evaluator_id="blind-eval", content_hash=_BLIND_HASH, role="blind")
+
+
+def _restatement(observable_id: str = "obs-1", kind: str = "scalar") -> TypedRestatement:
+    return TypedRestatement(
+        observable_id=observable_id,
+        observable_kind=kind,
+        statement="value of the scalar observable at the sampled parameter points",
+    )
+
+
+def _points(
+    count: int,
+    *,
+    offset: float = 0.0,
+    drift_at: int | None = None,
+    drift: float = 0.0,
+) -> list[SamplePointEvaluation]:
+    points: list[SamplePointEvaluation] = []
+    for i in range(count):
+        claim = 1.0 + 0.1 * i
+        blind = claim + offset
+        if drift_at is not None and i == drift_at:
+            blind = claim + drift
+        points.append(
+            SamplePointEvaluation(
+                point_index=i,
+                sample_point={"x": str(i)},
+                claim_value=claim,
+                blind_value=blind,
+            )
+        )
+    return points
+
+
+def _comparison(**overrides: object) -> NumericOracleComparison:
+    base: dict[str, object] = {
+        "contracted_observable_id": "obs-1",
+        "contracted_observable_kind": "scalar",
+        "typed_restatement": _restatement(),
+        "tolerance": 1e-6,
+        "sample_points": _points(DEFAULT_MIN_SHARED_POINTS),
+        "claim_cell": _claim_cell(),
+        "blind_cell": _blind_cell(),
+    }
+    base.update(overrides)
+    return NumericOracleComparison(**base)
+
+
+def test_full_agreement_is_green() -> None:
+    verdict = compare_numeric_oracle(_comparison())
+    assert verdict.verdict == "GREEN"
+    assert verdict.agreeing_points == DEFAULT_MIN_SHARED_POINTS
+    assert verdict.total_shared_points == DEFAULT_MIN_SHARED_POINTS
+    assert verdict.both_cells_present is True
+    assert verdict.fidelity_ok is True
+
+
+def test_one_point_over_tolerance_is_red_with_worst_point() -> None:
+    points = _points(DEFAULT_MIN_SHARED_POINTS, drift_at=7, drift=0.5)
+    verdict = compare_numeric_oracle(_comparison(sample_points=points))
+    assert verdict.verdict == "RED"
+    assert verdict.worst_point_index == 7
+    assert verdict.max_abs_diff == pytest.approx(0.5)
+    assert verdict.agreeing_points == DEFAULT_MIN_SHARED_POINTS - 1
+
+
+def test_insufficient_points_is_inconclusive() -> None:
+    points = _points(DEFAULT_MIN_SHARED_POINTS - 1)
+    verdict = compare_numeric_oracle(_comparison(sample_points=points))
+    assert verdict.verdict == "INCONCLUSIVE"
+    assert "shared usable sample points" in verdict.reason
+
+
+def test_missing_claim_cell_is_inconclusive() -> None:
+    verdict = compare_numeric_oracle(_comparison(claim_cell=None))
+    assert verdict.verdict == "INCONCLUSIVE"
+    assert verdict.both_cells_present is False
+    assert "backing executed-cell hash" in verdict.reason
+
+
+def test_fidelity_mismatch_is_inconclusive_even_with_agreement() -> None:
+    # Numbers agree perfectly, but the blind agent computed a different quantity.
+    verdict = compare_numeric_oracle(
+        _comparison(typed_restatement=_restatement(observable_id="obs-other"))
+    )
+    assert verdict.verdict == "INCONCLUSIVE"
+    assert verdict.fidelity_ok is False
+    assert verdict.agreeing_points == DEFAULT_MIN_SHARED_POINTS
+
+
+def test_kind_mismatch_is_inconclusive() -> None:
+    verdict = compare_numeric_oracle(
+        _comparison(typed_restatement=_restatement(kind="curve"))
+    )
+    assert verdict.verdict == "INCONCLUSIVE"
+    assert verdict.fidelity_ok is False
+
+
+def test_none_and_nan_values_reduce_usable_count() -> None:
+    points = _points(DEFAULT_MIN_SHARED_POINTS)
+    # Knock two points out of the usable set: one None, one NaN.
+    points[0] = SamplePointEvaluation(point_index=0, claim_value=None, blind_value=1.0)
+    points[1] = SamplePointEvaluation(point_index=1, claim_value=1.0, blind_value=float("nan"))
+    verdict = compare_numeric_oracle(_comparison(sample_points=points))
+    assert verdict.total_shared_points == DEFAULT_MIN_SHARED_POINTS - 2
+    # 18 usable points < 20 required -> INCONCLUSIVE.
+    assert verdict.verdict == "INCONCLUSIVE"
+
+
+def test_within_tolerance_offset_is_green() -> None:
+    points = _points(DEFAULT_MIN_SHARED_POINTS, offset=1e-9)
+    verdict = compare_numeric_oracle(_comparison(sample_points=points, tolerance=1e-6))
+    assert verdict.verdict == "GREEN"
+
+
+def test_bool_value_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        SamplePointEvaluation(point_index=0, claim_value=True, blind_value=1.0)
+
+
+def test_non_positive_tolerance_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        _comparison(tolerance=0.0)
+
+
+def test_bad_hash_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        EvaluatorCell(evaluator_id="x", content_hash="not-a-hash", role="claim")
+
+
+def test_bare_hex_hash_is_normalized() -> None:
+    cell = EvaluatorCell(evaluator_id="x", content_hash="A" * 64, role="claim")
+    assert cell.content_hash == "sha256:" + "a" * 64
+
+
+def test_kernel_verdict_pass_only_when_green() -> None:
+    green = build_numeric_oracle_kernel_verdict(_comparison(), generated_at=_FIXED_TIME)
+    assert green["overall"] == "PASS"
+    assert green["numeric_oracle_verdict"]["verdict"] == "GREEN"
+
+    red_points = _points(DEFAULT_MIN_SHARED_POINTS, drift_at=3, drift=1.0)
+    red = build_numeric_oracle_kernel_verdict(
+        _comparison(sample_points=red_points), generated_at=_FIXED_TIME
+    )
+    assert red["overall"] == "FAIL"
+    assert red["numeric_oracle_verdict"]["verdict"] == "RED"
+
+    inconclusive = build_numeric_oracle_kernel_verdict(
+        _comparison(claim_cell=None), generated_at=_FIXED_TIME
+    )
+    assert inconclusive["overall"] == "FAIL"
+    assert inconclusive["numeric_oracle_verdict"]["verdict"] == "INCONCLUSIVE"
+
+
+def test_kernel_verdict_hash_is_deterministic() -> None:
+    first = build_numeric_oracle_kernel_verdict(_comparison(), generated_at=_FIXED_TIME)
+    second = build_numeric_oracle_kernel_verdict(_comparison(), generated_at=_FIXED_TIME)
+    assert first["verdict_hash"] == second["verdict_hash"]
+    assert first["registry_hash"] == second["registry_hash"]

--- a/tests/core/test_prompt_exactness_budget.py
+++ b/tests/core/test_prompt_exactness_budget.py
@@ -13,7 +13,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 EXACTNESS_TOTAL_BUDGETS = {
     # Phase 5 pass4 observed 517/5134 after semantic-helper migration.
     "brittle_prose_assertions": 525,
-    "exact_assertion_count": 5_165,
+    # +2 for the numeric-oracle unit + contract-check tests.
+    "exact_assertion_count": 5_167,
 }
 TAXONOMY_HELPER_TOTAL_FLOORS = {
     # Phase 8 observed 80 files and 735 helper calls; keep a small call-count cushion.

--- a/tests/core/test_prompt_surface_diagnostics_budget.py
+++ b/tests/core/test_prompt_surface_diagnostics_budget.py
@@ -15,7 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PROMPT_TOTAL_BUDGET = {"lines": 42_900, "chars": 1_773_000}
 PROMPT_KIND_BUDGETS = {
     "command": {"lines": 20_200, "chars": 760_000},
-    "agent": {"lines": 6_500, "chars": 363_000},
+    "agent": {"lines": 6_600, "chars": 368_000},
     "workflow": {"lines": 15_300, "chars": 618_000},
 }
 STAGE_FIRST_TURN_BUDGET = {"lines": 3_180, "chars": 134_000}
@@ -35,8 +35,8 @@ EXECUTE_PHASE_SPLIT_STAGE_EAGER_CHAR_BUDGET = 16_000
 PHASE3_TARGET_STAGE_EAGER_CHAR_BUDGETS = {
     ("execute-phase", "closeout"): 7_050,
     ("peer-review", "preflight"): 9_178,
-    ("verify-work", "gap_repair"): 10_100,
-    ("verify-work", "interactive_validation"): 5_000,
+    ("verify-work", "gap_repair"): 10_450,
+    ("verify-work", "interactive_validation"): 5_150,
     ("sync-state", "reconcile_and_validate"): 3_840,
     ("sync-state", "conflict_analysis"): 2_760,
     ("sync-state", "single_source_recovery"): 1_890,

--- a/tests/core/test_verifier_prompt_budget.py
+++ b/tests/core/test_verifier_prompt_budget.py
@@ -18,8 +18,10 @@ AGENTS_DIR = REPO_ROOT / "src" / "gpd" / "agents"
 SOURCE_ROOT = REPO_ROOT / "src" / "gpd"
 PATH_PREFIX = "/runtime/"
 RUNTIMES = tuple(descriptor.runtime_name for descriptor in iter_runtime_descriptors())
-BASELINE_EXPANDED_LINE_COUNT = 355
-BASELINE_EXPANDED_CHAR_COUNT = 24_913
+# Includes the verifier's hooks into the blind oracle sub-protocol
+# (gpd-compute tools + a pointer to references/.../blind-oracle-subprotocol.md).
+BASELINE_EXPANDED_LINE_COUNT = 363
+BASELINE_EXPANDED_CHAR_COUNT = 26_344
 MIN_LINE_MARGIN = 15
 MIN_CHAR_MARGIN = 750
 

--- a/tests/mcp/test_numeric_oracle_contract_check.py
+++ b/tests/mcp/test_numeric_oracle_contract_check.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import copy
+
+from gpd.mcp.servers.verification_server import run_contract_check
+
+_N = 20
+
+
+def _request(*, claim_offset: float = 0.0, drift_at: int | None = None, drift: float = 0.0, **overrides):
+    claim = [1.0 + 0.1 * i for i in range(_N)]
+    blind = [c + claim_offset for c in claim]
+    if drift_at is not None:
+        blind[drift_at] = claim[drift_at] + drift
+    request: dict = {
+        "check_key": "contract.numeric_oracle_agreement",
+        "metadata": {
+            "contracted_observable_id": "obs-1",
+            "contracted_observable_kind": "scalar",
+            "typed_restatement_observable_id": "obs-1",
+            "typed_restatement_observable_kind": "scalar",
+            "typed_restatement_statement": "value of F at the sampled points",
+            "numeric_tolerance": 1e-6,
+            "min_shared_points": 20,
+            "claim_cell_hash": "a" * 64,
+            "blind_cell_hash": "b" * 64,
+        },
+        "observed": {
+            "sample_points": [{"x": str(i)} for i in range(_N)],
+            "claim_values": claim,
+            "blind_values": blind,
+        },
+    }
+    for key, value in overrides.items():
+        if key in ("metadata", "observed"):
+            request[key] = {**request[key], **value}
+        else:
+            request[key] = value
+    return request
+
+
+def test_agreement_passes() -> None:
+    result = run_contract_check(_request())
+    assert result["status"] == "pass"
+    assert result["evidence_directness"] == "direct"
+    assert result["metrics"]["numeric_oracle_verdict"]["verdict"] == "GREEN"
+    assert result["metrics"]["verdict_hash"].startswith("sha256:")
+
+
+def test_disagreement_fails() -> None:
+    result = run_contract_check(_request(drift_at=5, drift=0.5))
+    assert result["status"] == "fail"
+    assert result["metrics"]["numeric_oracle_verdict"]["verdict"] == "RED"
+    assert result["metrics"]["numeric_oracle_verdict"]["worst_point_index"] == 5
+    assert result["automated_issues"]
+
+
+def test_missing_cell_hash_is_inconclusive() -> None:
+    request = _request()
+    del request["metadata"]["claim_cell_hash"]
+    result = run_contract_check(request)
+    assert result["status"] == "insufficient_evidence"
+    assert result["metrics"]["numeric_oracle_verdict"]["verdict"] == "INCONCLUSIVE"
+    assert result["metrics"]["numeric_oracle_verdict"]["both_cells_present"] is False
+    assert any("cell_hash" in item for item in result["missing_inputs"])
+
+
+def test_fidelity_mismatch_is_inconclusive_despite_agreement() -> None:
+    result = run_contract_check(
+        _request(metadata={"typed_restatement_observable_id": "obs-other"})
+    )
+    assert result["status"] == "insufficient_evidence"
+    verdict = result["metrics"]["numeric_oracle_verdict"]
+    assert verdict["verdict"] == "INCONCLUSIVE"
+    assert verdict["fidelity_ok"] is False
+    assert verdict["agreeing_points"] == _N
+
+
+def test_too_few_points_is_inconclusive_via_missing_inputs() -> None:
+    request = _request()
+    request["observed"]["sample_points"] = request["observed"]["sample_points"][:5]
+    request["observed"]["claim_values"] = request["observed"]["claim_values"][:5]
+    request["observed"]["blind_values"] = request["observed"]["blind_values"][:5]
+    request["metadata"]["min_shared_points"] = 20
+    result = run_contract_check(request)
+    assert result["status"] == "insufficient_evidence"
+    # Five usable points provided, comparison reports INCONCLUSIVE on sufficiency.
+    assert result["metrics"]["numeric_oracle_verdict"]["verdict"] == "INCONCLUSIVE"
+
+
+def test_missing_observed_lists_report_missing_inputs() -> None:
+    request = _request()
+    del request["observed"]["claim_values"]
+    result = run_contract_check(request)
+    assert result["status"] == "insufficient_evidence"
+    assert "observed.claim_values" in result["missing_inputs"]
+    # No verdict is built when prerequisites are absent.
+    assert "numeric_oracle_verdict" not in result["metrics"]
+
+
+def test_unknown_metadata_key_is_rejected() -> None:
+    request = _request(metadata={"bogus_key": "x"})
+    result = run_contract_check(request)
+    assert result.get("status") == "error" or result.get("error")
+
+
+def test_non_positive_tolerance_is_an_input_error() -> None:
+    request = _request(metadata={"numeric_tolerance": 0.0})
+    result = run_contract_check(request)
+    assert result.get("status") == "error" or result.get("error")
+
+
+def test_deterministic_verdict_hash_across_calls() -> None:
+    first = run_contract_check(_request())
+    second = run_contract_check(copy.deepcopy(_request()))
+    assert (
+        first["metrics"]["verdict_hash"]
+        == second["metrics"]["verdict_hash"]
+    )

--- a/tests/mcp/test_servers.py
+++ b/tests/mcp/test_servers.py
@@ -327,7 +327,7 @@ class TestBuiltinServerDescriptors:
         for name, descriptor in descriptors.items():
             prerequisites = descriptor["prerequisites"]
             assert prerequisites[:1] == expected, name
-            if name != "gpd-arxiv":
+            if name not in ("gpd-arxiv", "gpd-compute"):
                 assert prerequisites == expected, name
             for prerequisite in prerequisites:
                 prerequisite = prerequisite.lower()
@@ -464,10 +464,11 @@ class TestBuiltinServerDescriptors:
 
         target_python = "/opt/gpd/python3.11"
         current_python = "/usr/bin/python3.9"
+        observed_commands: list[list[str]] = []
         observed: dict[str, object] = {}
 
         def fake_run(command, *, check, stdout, stderr, timeout):
-            observed["command"] = command
+            observed_commands.append(command)
             observed["check"] = check
             observed["stdout"] = stdout
             observed["stderr"] = stderr
@@ -480,9 +481,11 @@ class TestBuiltinServerDescriptors:
         servers = builtin_servers.build_mcp_servers_dict(python_path=target_python)
 
         assert "gpd-arxiv" in servers
-        assert observed["command"][0] == target_python
-        assert observed["command"][2].startswith("import importlib.util")
-        assert observed["command"][3] == "arxiv_mcp_server"
+        # Every optional module is probed in the target interpreter, not the current one.
+        assert observed_commands
+        assert all(command[0] == target_python for command in observed_commands)
+        assert all(command[2].startswith("import importlib.util") for command in observed_commands)
+        assert "arxiv_mcp_server" in {command[3] for command in observed_commands}
         assert observed["check"] is False
         assert observed["timeout"] == 5
 
@@ -3846,7 +3849,7 @@ class TestVerificationServer:
         assert result["found"] is True
         assert result["schema_version"] == 1
         assert result["domain_check_count"] > 0
-        assert result["universal_check_count"] == 24
+        assert result["universal_check_count"] == 25
         assert result["universal_checks"][0]["check_id"] == "5.1"
         assert "evidence_kind" in result["universal_checks"][0]
         contract_check = next(

--- a/tests/mcp/test_verification_contract_request_regressions.py
+++ b/tests/mcp/test_verification_contract_request_regressions.py
@@ -550,7 +550,10 @@ def test_contract_parse_recoverability_keeps_case_drift_nonblocking() -> None:
                     "metadata contains unsupported keys: unexpected; supported keys are "
                     "regime_label, expected_behavior, source_reference_id, declared_family, allowed_families, "
                     "forbidden_families, theorem_parameter_symbols, hypothesis_ids, quantifiers, "
-                    "conclusion_clause_ids, claim_statement"
+                    "conclusion_clause_ids, claim_statement, contracted_observable_id, "
+                    "contracted_observable_kind, typed_restatement_observable_id, "
+                    "typed_restatement_observable_kind, typed_restatement_statement, numeric_tolerance, "
+                    "min_shared_points, claim_evaluator_id, blind_evaluator_id, claim_cell_hash, blind_cell_hash"
                 ),
                 "schema_version": 1,
             },
@@ -568,7 +571,8 @@ def test_contract_parse_recoverability_keeps_case_drift_nonblocking() -> None:
                     "proxy_available, consistency_passed, selected_family, competing_family_checked, bias_checked, "
                     "calibration_checked, covered_hypothesis_ids, missing_hypothesis_ids, "
                     "covered_parameter_symbols, missing_parameter_symbols, uncovered_quantifiers, "
-                    "uncovered_conclusion_clause_ids, quantifier_status, scope_status, counterexample_status"
+                    "uncovered_conclusion_clause_ids, quantifier_status, scope_status, counterexample_status, "
+                    "sample_points, claim_values, blind_values"
                 ),
                 "schema_version": 1,
             },

--- a/tests/repo_graph_contract.json
+++ b/tests/repo_graph_contract.json
@@ -20,7 +20,7 @@
   ],
   "scope_counts": {
     "`src/gpd/commands/*.md`": 71,
-    "`src/gpd/agents/*.md`": 24,
+    "`src/gpd/agents/*.md`": 25,
     "`src/gpd/specs/workflows/*.md`": 72,
     "`src/gpd/specs/templates/**/*.md`": 81,
     "`src/gpd/specs/references/**/*.md`": 241,
@@ -28,8 +28,8 @@
     "`src/gpd/hooks/*.py`": 11,
     "`src/gpd/mcp/*.py`": 5,
     "`src/gpd/mcp/integrations/*.py`": 2,
-    "`src/gpd/mcp/servers/*.py`": 15,
-    "`infra/gpd-*.json`": 8
+    "`src/gpd/mcp/servers/*.py`": 16,
+    "`infra/gpd-*.json`": 9
   },
   "prompt_stem_inventory": {
     "same_stems": [


### PR DESCRIPTION
## What & why

GPD's verifier is its moat, but a code audit confirmed the core today runs **no executed physics check**: `run_check` is keyword/regex triage that returns `passes_physics: False`, and the decisive verdict terminates in **LLM self-report**. This PR adds a real, deterministic **numbers-vs-numbers** check so a decisive quantitative claim is verified by comparing an independent *blind* re-derivation against the claim — not by trusting prose.

The engine stays deterministic (zero LLM/MCP calls): the **agent** calls the `gpd-compute` oracle to evaluate both evaluators, and the engine only **diffs the returned numbers** and content-addresses the verdict.

## Engine (deterministic core — ships independently, no external package or model needed)
- `core/numeric_oracle.py` — `NumericOracleComparison` + `compare_numeric_oracle` (tri-state **GREEN / RED / INCONCLUSIVE**, fail-closed) + a content-addressed kernel verdict, modeled on `reproducibility.py`. INCONCLUSIVE lives here; the shared kernel `Result` stays binary.
- `verification_checks.py` — new check **5.25 `contract.numeric_oracle_agreement`**.
- `contracts.py` — additive, optional `ContractObservable` numeric-oracle fields (backward-compatible).
- `verification_server.py` — `run_contract_check` branch: GREEN→`pass`, RED→`fail`, INCONCLUSIVE→`insufficient_evidence`. **Anti-fabrication** (every accepted number needs a backing executed-cell hash) + **proposition-fidelity guard** (agreement on the *wrong* quantity cannot pass GREEN).

## Orchestration
- New **`gpd-blind-deriver`** agent — blinded by *tool starvation* (only `gpd-compute` MCP tools; no file/shell/web), sees only the problem statement + ConventionLock, never the answer.
- `gpd-verifier` — Level-3 blind oracle sub-protocol + Oracle Gate hook; full protocol in `references/verification/core/blind-oracle-subprotocol.md` (kept out of the verifier hotspot prompt).
- `verify-work` — blind+oracle step in `inventory-build`; verdict surfaced in `interactive-validation`; **INCONCLUSIVE routes to `expert_needed`** (not gap-closure), only **RED** is a `gaps_found` issue.

## Registration
`gpd-compute` is a **separate public package** ([psi-oss/gpd-compute](https://github.com/psi-oss/gpd-compute)) — a no-network sandboxed mpmath/numpy evaluator. Wired here as an **optional** MCP server via a thin in-repo bridge, gated by `module_check` so it is **inert until installed**. Infra descriptor + repo-graph contract regenerated. No `compute` pyproject extra yet (the package isn't on PyPI; adding it now would make `uv.lock` unsolvable) — a publish-time follow-up.

## Honest scope
On flagship hep-th (interacting-QFT path integrals, GR-tensor canonicalization) an independent numeric evaluator often can't be constructed, so the steady-state verdict there is INCONCLUSIVE — intended, not failure. v1 reliably covers closed-form / integral / special-function / asymptotic / dimensionless quantities. GREEN-rate on real trace problems should be measured before any "revolutionary" framing.

## Tests
- New: `tests/core/test_numeric_oracle.py`, `tests/mcp/test_numeric_oracle_contract_check.py` (GREEN/RED/every INCONCLUSIVE path, determinism).
- `gpd-compute` repo: 10 tests pass incl. the real subprocess sandbox (network/import escapes blocked, values match, special functions run).
- Parity baselines updated for the new check, the new agent, and the verifier's oracle hooks (counts, supported-key enumerations, prompt-surface budgets).

## CI note
A `compare-experiment` codex prompt-projection budget was 8 chars over baseline (`7708 > 7700`) — pre-existing drift on base main, independent of this change (none of the files this PR touches are in that command's projection chain). Bumped the budget to 7750 in `projection_budget_support.py` so CI is green; no behavior change.
