### PR TITLE
fix(mcp): rewrite draft-only const keywords in published tool schemas

### DIFF
--- a/src/gpd/mcp/servers/__init__.py
+++ b/src/gpd/mcp/servers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import copy
 import importlib
+import json
 import logging
 import os
 import re
@@ -208,13 +209,60 @@ def _set_tool_attribute(tool: object, attribute: str, value: object) -> None:
         object.__setattr__(tool, attribute, value)
 
 
+def _rewrite_const_constraint(fragment: dict[str, object], value: object) -> None:
+    """Rewrite one popped ``const`` value into runtime-portable keywords in place."""
+
+    if isinstance(value, str):
+        fragment["enum"] = [value]
+        return
+    if isinstance(value, bool):
+        fragment["enum"] = [value]
+        return
+    if isinstance(value, (int, float)):
+        fragment["minimum"] = value
+        fragment["maximum"] = value
+        return
+    note = f"Must be exactly {json.dumps(value)}."
+    description = fragment.get("description")
+    fragment["description"] = f"{description} {note}" if isinstance(description, str) and description else note
+
+
+def _make_schema_fragment_portable(fragment: object) -> None:
+    if isinstance(fragment, dict):
+        if "const" in fragment:
+            _rewrite_const_constraint(fragment, fragment.pop("const"))
+        for value in fragment.values():
+            _make_schema_fragment_portable(value)
+    elif isinstance(fragment, list):
+        for item in fragment:
+            _make_schema_fragment_portable(item)
+
+
+def portable_published_schema(schema: dict[str, object]) -> dict[str, object]:
+    """Return a deep copy of ``schema`` with draft-only keywords rewritten for cross-runtime portability.
+
+    Published tool schemas are re-encoded by MCP clients for model providers
+    whose restricted schema dialects reject the JSON Schema ``const`` keyword
+    and type ``enum`` members as strings, so a published ``{"const": 1}``
+    surfaces as an ``Invalid value ... (TYPE_STRING), 1`` error at call time
+    (issue #239). Exact string values survive as single-member enums and exact
+    numeric values as ``minimum``/``maximum`` bounds; server-side argument
+    validation remains the enforcement layer.
+    """
+
+    portable = copy.deepcopy(schema)
+    _make_schema_fragment_portable(portable)
+    return portable
+
+
 def set_published_tool_input_schema(tool: object, schema: dict[str, object]) -> None:
     """Write a published input schema onto both public and private FastMCP surfaces."""
 
+    portable = portable_published_schema(schema)
     if hasattr(tool, "inputSchema"):
-        _set_tool_attribute(tool, "inputSchema", copy.deepcopy(schema))
+        _set_tool_attribute(tool, "inputSchema", portable)
     if hasattr(tool, "parameters"):
-        _set_tool_attribute(tool, "parameters", copy.deepcopy(schema))
+        _set_tool_attribute(tool, "parameters", copy.deepcopy(portable))
 
 
 def set_registered_and_published_tool_input_schema(mcp: object, tool: object, schema: dict[str, object]) -> None:
@@ -336,6 +384,7 @@ __all__ = [
     "parse_frontmatter_safe",
     "parse_frontmatter_with_error",
     "patterns_server",
+    "portable_published_schema",
     "protocols_server",
     "resolve_absolute_project_dir",
     "run_mcp_server",

--- a/src/gpd/mcp/servers/__init__.py
+++ b/src/gpd/mcp/servers/__init__.py
@@ -228,6 +228,12 @@ def _rewrite_const_constraint(fragment: dict[str, object], value: object) -> Non
 
 
 def _make_schema_fragment_portable(fragment: object) -> None:
+    """Recursively rewrite every ``const`` keyword under ``fragment`` in place.
+
+    Walks dicts and lists so nested subtrees (``anyOf`` members, ``items``,
+    conditional ``if``/``then`` branches) are covered, not just the top level.
+    """
+
     if isinstance(fragment, dict):
         if "const" in fragment:
             _rewrite_const_constraint(fragment, fragment.pop("const"))

--- a/tests/mcp/test_portable_published_schemas.py
+++ b/tests/mcp/test_portable_published_schemas.py
@@ -35,6 +35,12 @@ _CONDITIONAL_KEYWORDS = frozenset({"if", "then", "else", "not"})
 
 
 def _collect_violations(fragment: object, path: str, *, in_conditional: bool, violations: list[str]) -> None:
+    """Append a dotted-path complaint for each restricted-dialect violation under ``fragment``.
+
+    Flags any surviving ``const`` keyword, and non-string ``enum`` members
+    outside the conditional subtrees listed in ``_CONDITIONAL_KEYWORDS``.
+    """
+
     if isinstance(fragment, dict):
         if "const" in fragment:
             violations.append(f"{path}: draft-only `const` keyword in published schema")
@@ -56,6 +62,12 @@ def _collect_violations(fragment: object, path: str, *, in_conditional: bool, vi
 
 
 def _published_tool_schemas(module_name: str) -> list[tuple[str, dict[str, object]]]:
+    """Return ``(tool_name, inputSchema)`` pairs as the named server actually publishes them.
+
+    Reads through ``list_tools()`` rather than the in-process registry so the
+    assertion covers the payload a client receives.
+    """
+
     module = importlib.import_module(f"gpd.mcp.servers.{module_name}")
 
     async def _load() -> list[tuple[str, dict[str, object]]]:
@@ -66,6 +78,8 @@ def _published_tool_schemas(module_name: str) -> list[tuple[str, dict[str, objec
 
 
 def test_all_published_tool_schemas_are_runtime_portable() -> None:
+    """Every FastMCP server publishes schemas a restricted-dialect client can encode."""
+
     violations: list[str] = []
     for module_name in _FASTMCP_SERVER_MODULES:
         for tool_name, schema in _published_tool_schemas(module_name):
@@ -79,6 +93,8 @@ def test_all_published_tool_schemas_are_runtime_portable() -> None:
 
 
 def test_portable_schema_rewrites_string_const_to_enum() -> None:
+    """A string ``const`` becomes a single-member ``enum``, leaving the input untouched."""
+
     schema = {"type": "object", "properties": {"mode": {"type": "string", "const": "strict"}}}
     portable = portable_published_schema(schema)
     assert portable["properties"]["mode"] == {"type": "string", "enum": ["strict"]}
@@ -87,12 +103,16 @@ def test_portable_schema_rewrites_string_const_to_enum() -> None:
 
 
 def test_portable_schema_rewrites_integer_const_to_bounds() -> None:
+    """A numeric ``const`` becomes equal ``minimum``/``maximum`` bounds, not a typed enum."""
+
     schema = {"type": "object", "properties": {"schema_version": {"type": "integer", "const": 1}}}
     portable = portable_published_schema(schema)
     assert portable["properties"]["schema_version"] == {"type": "integer", "minimum": 1, "maximum": 1}
 
 
 def test_portable_schema_rewrites_boolean_const_to_single_member_enum() -> None:
+    """A boolean ``const`` inside a conditional subtree becomes a single-member ``enum``."""
+
     schema = {"if": {"properties": {"must_surface": {"const": True}}}, "then": {"required": ["applies_to"]}}
     portable = portable_published_schema(schema)
     assert portable["if"]["properties"]["must_surface"] == {"enum": [True]}
@@ -100,6 +120,8 @@ def test_portable_schema_rewrites_boolean_const_to_single_member_enum() -> None:
 
 
 def test_portable_schema_walks_nested_structures() -> None:
+    """Rewriting reaches ``const`` nested under ``anyOf`` members and ``items``."""
+
     schema = {
         "type": "object",
         "properties": {
@@ -116,6 +138,8 @@ def test_portable_schema_walks_nested_structures() -> None:
 
 
 def test_portable_schema_documents_unrepresentable_const_values() -> None:
+    """Values with no keyword equivalent are dropped and described in prose instead."""
+
     schema = {"properties": {"marker": {"const": None, "description": "Sentinel."}}}
     portable = portable_published_schema(schema)
     marker = portable["properties"]["marker"]

--- a/tests/mcp/test_portable_published_schemas.py
+++ b/tests/mcp/test_portable_published_schemas.py
@@ -1,0 +1,123 @@
+"""Published tool schemas must stay portable across MCP client schema dialects.
+
+Regression guard for issue #239: Gemini's OpenAPI schema subset rejects the
+JSON Schema ``const`` keyword and types ``enum`` values as strings, so a
+``{"const": 1}`` fragment published by any GPD server surfaces as an
+``Invalid value ... (TYPE_STRING), 1`` error in Gemini-backed runtimes.
+
+The ``arxiv_bridge`` server builds a lowlevel ``mcp.Server`` inside its entry
+point rather than a module-level FastMCP instance, so it is exercised by its
+own suite; its hand-written tool schemas contain no draft-only keywords.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import anyio
+
+from gpd.mcp.servers import portable_published_schema
+
+_FASTMCP_SERVER_MODULES = (
+    "conventions_server",
+    "errors_mcp",
+    "patterns_server",
+    "protocols_server",
+    "skills_server",
+    "state_server",
+    "verification_server",
+)
+
+# Subtree keywords whose contents draft-aware validators evaluate conditionally;
+# clients targeting restricted dialects drop these subtrees wholesale, so
+# non-string enum members inside them never reach a provider's schema proto.
+_CONDITIONAL_KEYWORDS = frozenset({"if", "then", "else", "not"})
+
+
+def _collect_violations(fragment: object, path: str, *, in_conditional: bool, violations: list[str]) -> None:
+    if isinstance(fragment, dict):
+        if "const" in fragment:
+            violations.append(f"{path}: draft-only `const` keyword in published schema")
+        enum_values = fragment.get("enum")
+        if isinstance(enum_values, list) and not in_conditional:
+            non_string = [value for value in enum_values if not isinstance(value, str)]
+            if non_string:
+                violations.append(f"{path}: non-string enum members {non_string!r} outside a conditional subtree")
+        for key, value in fragment.items():
+            _collect_violations(
+                value,
+                f"{path}.{key}",
+                in_conditional=in_conditional or key in _CONDITIONAL_KEYWORDS,
+                violations=violations,
+            )
+    elif isinstance(fragment, list):
+        for index, item in enumerate(fragment):
+            _collect_violations(item, f"{path}[{index}]", in_conditional=in_conditional, violations=violations)
+
+
+def _published_tool_schemas(module_name: str) -> list[tuple[str, dict[str, object]]]:
+    module = importlib.import_module(f"gpd.mcp.servers.{module_name}")
+
+    async def _load() -> list[tuple[str, dict[str, object]]]:
+        tools = await module.mcp.list_tools()
+        return [(str(tool.name), tool.inputSchema) for tool in tools]
+
+    return anyio.run(_load)
+
+
+def test_all_published_tool_schemas_are_runtime_portable() -> None:
+    violations: list[str] = []
+    for module_name in _FASTMCP_SERVER_MODULES:
+        for tool_name, schema in _published_tool_schemas(module_name):
+            _collect_violations(
+                schema,
+                f"{module_name}.{tool_name}",
+                in_conditional=False,
+                violations=violations,
+            )
+    assert not violations, "Published schemas contain keywords Gemini-dialect clients reject:\n" + "\n".join(violations)
+
+
+def test_portable_schema_rewrites_string_const_to_enum() -> None:
+    schema = {"type": "object", "properties": {"mode": {"type": "string", "const": "strict"}}}
+    portable = portable_published_schema(schema)
+    assert portable["properties"]["mode"] == {"type": "string", "enum": ["strict"]}
+    # The input schema is never mutated.
+    assert schema["properties"]["mode"]["const"] == "strict"
+
+
+def test_portable_schema_rewrites_integer_const_to_bounds() -> None:
+    schema = {"type": "object", "properties": {"schema_version": {"type": "integer", "const": 1}}}
+    portable = portable_published_schema(schema)
+    assert portable["properties"]["schema_version"] == {"type": "integer", "minimum": 1, "maximum": 1}
+
+
+def test_portable_schema_rewrites_boolean_const_to_single_member_enum() -> None:
+    schema = {"if": {"properties": {"must_surface": {"const": True}}}, "then": {"required": ["applies_to"]}}
+    portable = portable_published_schema(schema)
+    assert portable["if"]["properties"]["must_surface"] == {"enum": [True]}
+    assert portable["then"] == {"required": ["applies_to"]}
+
+
+def test_portable_schema_walks_nested_structures() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "payload": {
+                "anyOf": [
+                    {"type": "array", "items": {"const": "fixed"}},
+                    {"type": "null"},
+                ]
+            }
+        },
+    }
+    portable = portable_published_schema(schema)
+    assert portable["properties"]["payload"]["anyOf"][0]["items"] == {"enum": ["fixed"]}
+
+
+def test_portable_schema_documents_unrepresentable_const_values() -> None:
+    schema = {"properties": {"marker": {"const": None, "description": "Sentinel."}}}
+    portable = portable_published_schema(schema)
+    marker = portable["properties"]["marker"]
+    assert "const" not in marker
+    assert marker["description"] == "Sentinel. Must be exactly null."

--- a/tests/mcp/test_tool_contract_visibility.py
+++ b/tests/mcp/test_tool_contract_visibility.py
@@ -822,7 +822,9 @@ def test_contract_tools_list_tools_expose_structured_request_schemas() -> None:
     assert "Closed reference-anchor object." in reference_item["description"]
     reference_surface_rule = reference_item["allOf"][0]
     assert reference_surface_rule["if"]["required"] == ["must_surface"]
-    assert reference_surface_rule["if"]["properties"]["must_surface"]["const"] is True
+    # Published as a single-member enum: draft-only `const` is rewritten for
+    # runtime portability (see test_portable_published_schemas.py).
+    assert reference_surface_rule["if"]["properties"]["must_surface"]["enum"] == [True]
     assert reference_surface_rule["then"]["required"] == ["applies_to", "required_actions"]
     assert reference_surface_rule["then"]["properties"]["applies_to"]["minItems"] == 1
     assert reference_surface_rule["then"]["properties"]["required_actions"]["minItems"] == 1


### PR DESCRIPTION
Fixes #239.

## Root cause

Published tool input schemas cross MCP clients that re-encode them for model providers with restricted schema dialects. The failing provider's schema proto types `enum` as a repeated **string** field and rejects the JSON Schema `const` keyword outright — so `schema_version: {"type": "integer", "const": 1}` fails registration with `Invalid value ... (TYPE_STRING), 1`, and the commonly suggested `{"type": "integer", "enum": [1]}` fails identically (non-string enum member). Details in [this comment on #239](https://github.com/psi-oss/get-physics-done/issues/239#issuecomment-4995973745). Ten `const` fragments ship in published schemas today, all via the verification server's contract schemas.

## Fix

Sanitize once at the publish chokepoint — `set_published_tool_input_schema` — instead of spot-fixing each literal. New `portable_published_schema()` deep-copies the schema and rewrites draft-only constructs into forms valid in both dialects while keeping exactness machine-checkable:

| Fragment | Rewritten to | Why |
|---|---|---|
| string `const` | single-member `enum` | string enum members are valid in the restricted dialect |
| numeric `const` | equal `minimum`/`maximum` bounds | avoids the string-typed enum proto entirely; exactness stays machine-checkable |
| boolean `const` (occurs only inside `if/then` conditionals) | single-member `enum` | dialect-restricted clients strip conditional subtrees wholesale, so these never reach a provider proto |
| unrepresentable (e.g. `null`) | `"Must be exactly …"` description note | last resort, still self-documenting |

Internal schemas stay draft-expressive; server-side argument validation remains the enforcement layer, unchanged.

## Regression guard

`tests/mcp/test_portable_published_schemas.py` walks every FastMCP server's actually-published tool schemas (`mcp.list_tools()`) and fails on any `const` or non-string enum member outside conditional subtrees — keeping the whole class fixed, not just these instances. At current `main` it red-fails with 10 violations, including the exact `properties.contract.properties.schema_version` path from the issue's error trace. (`arxiv_bridge` builds a lowlevel `mcp.Server` in its entry point and publishes no draft-only keywords; it's exercised by its own suite.)

Plus unit tests for each rewrite rule, and `test_tool_contract_visibility.py` updated for the `must_surface` fragment's published form.

## Validation

- Full suite: 12,953 passed
- `ruff format` / repo meta-tests (test inventory, runtime-name policy) green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved published tool input schemas to be runtime-portable across MCP clients by rewriting strict value constraints into broadly supported JSON Schema constructs.
  * Added clearer schema descriptions for exact values that can’t be represented directly in portable form.
* **Tests**
  * Added validation to ensure all published tool schemas avoid restricted-dialect constructs.
  * Expanded unit coverage for portable schema rewriting, including nested and conditional structures, plus adjusted contract expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->