### PR TITLE
fix(readme): repair the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,11 +637,11 @@ Papers that cite or acknowledge use of GPD. If your paper should be listed here,
 ## Star History
 
 <p align="center">
-  <a href="https://star-history.com/#psi-oss/get-physics-done&Date">
+  <a href="https://star-history.dera.page/#psi-oss/get-physics-done&Date">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=psi-oss/get-physics-done&type=Date&theme=dark" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=psi-oss/get-physics-done&type=Date" />
-      <img alt="Star History Chart" src="https://api.star-history.com/image?repos=psi-oss/get-physics-done&type=Date" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=psi-oss/get-physics-done&type=Date&theme=dark" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=psi-oss/get-physics-done&type=Date" />
+      <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=psi-oss/get-physics-done&type=Date" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
The Star History chart in the README is currently broken because the upstream star-history.com image endpoint no longer works for this repository, a consequence of GitHub's stargazer API restrictions. This change points the chart at the star-history.dera.page service, which serves the SVG chart directly and renders correctly, so the chart displays as intended again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History embeds to use the new `star-history.dera.page` URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->